### PR TITLE
5.1 SRD Update: Monsters - Dragons

### DIFF
--- a/packs/_source/monsters/dragon/adult-black-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-black-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,6 +478,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
   - _id: P47jJ8bjQulsbdUg
     name: Multiattack
@@ -489,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .A3azHlbNcHLRgogu]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .amUUCouL69OK1GZU]]{bite} and two with its [[/item
-          .uXxifk618IakGfYG]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .A3azHlbNcHLRgogu]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .amUUCouL69OK1GZU]]{Bite} and two with its
+          [[/item .uXxifk618IakGfYG]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -506,13 +504,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        vmDwKYjvyQWmj8V5:
           type: utility
           activation:
             type: action
@@ -527,15 +524,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -546,7 +544,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -563,7 +562,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 200000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: vmDwKYjvyQWmj8V5
       enchant: {}
       prerequisites:
         level: null
@@ -577,22 +584,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448748502
+      systemVersion: 6.0.0
+      createdTime: 1781552871673
+      modifiedTime: 1781555001998
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!M4eX4Mu5IHCr3TMf.P47jJ8bjQulsbdUg'
   - _id: amUUCouL69OK1GZU
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Black Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -655,7 +664,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -664,8 +673,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        DqSkjkOiXau92oGx:
           type: attack
           activation:
             type: action
@@ -680,10 +688,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -700,7 +709,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '1'
               type: ''
@@ -713,36 +723,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 8
                 bonus: ''
                 types:
                   - acid
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: DqSkjkOiXau92oGx
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -752,22 +773,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448747768
+      systemVersion: 6.0.0
+      createdTime: 1781552501752
+      modifiedTime: 1781552520716
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!M4eX4Mu5IHCr3TMf.amUUCouL69OK1GZU'
   - _id: uXxifk618IakGfYG
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Black Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -830,7 +853,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -839,8 +862,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        JMAIJu4Yu2FrJS30:
           type: attack
           activation:
             type: action
@@ -855,10 +877,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -875,7 +898,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '1'
               type: ''
@@ -888,24 +912,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: JMAIJu4Yu2FrJS30
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -915,22 +952,24 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448747768
+      systemVersion: 6.0.0
+      createdTime: 1781552534568
+      modifiedTime: 1781552546991
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!M4eX4Mu5IHCr3TMf.uXxifk618IakGfYG'
   - _id: t9FrDQLVCU8x4obw
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Black Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -992,9 +1031,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1003,8 +1041,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1019,10 +1056,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1039,7 +1077,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '1'
               type: ''
@@ -1052,20 +1091,32 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1080,33 +1131,36 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448820431
+      systemVersion: 6.0.0
+      createdTime: 1781552801976
+      modifiedTime: 1781552825669
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!M4eX4Mu5IHCr3TMf.t9FrDQLVCU8x4obw'
   - _id: A3azHlbNcHLRgogu
     name: Frightful Presence
     type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
     system:
       description:
         value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
         chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
       source:
         custom: ''
         book: ''
@@ -1119,13 +1173,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        2VOmvThI0bGdUsMt:
           type: save
           activation:
             type: action
@@ -1140,13 +1193,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '120'
             units: ft
@@ -1161,6 +1220,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1173,20 +1233,77 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
-              calculation: ''
+              calculation: cha
               formula: '16'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
       enchant: {}
       prerequisites:
         level: null
       identifier: frightful-presence
-    effects: []
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781553545050
+          modifiedTime: 1781553639733
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!M4eX4Mu5IHCr3TMf.A3azHlbNcHLRgogu.JG2uXIqEJlTnRHpq
     folder: null
     sort: 500000
     ownership:
@@ -1195,69 +1312,23 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448773444
+      systemVersion: 6.0.0
+      createdTime: 1781552901546
+      modifiedTime: 1781630463823
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!M4eX4Mu5IHCr3TMf.A3azHlbNcHLRgogu'
-  - _id: Xlzm4nSYrmGB03GH
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 200000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1745448735615
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!M4eX4Mu5IHCr3TMf.Xlzm4nSYrmGB03GH'
   - _id: 6gjpG1ezpMNyJDGc
     name: Legendary Resistance
     type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
+    img: icons/equipment/shield/targe-steel-blue.webp
     system:
       description:
         value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
         chat: ''
       source:
         custom: ''
@@ -1271,7 +1342,7 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties:
@@ -1283,16 +1354,14 @@ items:
           activation:
             type: special
             value: null
-            condition: ''
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
             override: false
           consumption:
             targets:
               - type: attribute
-                target: resources.legres.value
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: resources.legres.value
+                scaling: {}
             scaling:
               allowed: false
               max: ''
@@ -1321,7 +1390,7 @@ items:
               units: ''
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1336,6 +1405,13 @@ items:
             prompt: false
             visible: false
           sort: 0
+          name: Persevere
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
       enchant: {}
       prerequisites:
         level: null
@@ -1349,29 +1425,30 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448736261
+      systemVersion: 6.0.0
+      createdTime: 1781554825200
+      modifiedTime: 1781554877554
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!M4eX4Mu5IHCr3TMf.6gjpG1ezpMNyJDGc'
   - _id: 6bromElr0abqNXJL
     name: Acid Breath
     type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
+    img: icons/magic/acid/projectile-faceted-glob.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales acid in a 60-foot line that is 5 feet wide. Each
+          <p>The [[lookup @name lowercase]]{monster} exhales acid in a [[lookup
+          @labels.description.template activity=t3MxfqSALI2iH4b2]]. Each
           creature in that line must make a [[/save]] saving throw, taking
           [[/damage average]] damage on a failed save, or half as much damage on
           a successful one.</p>
         chat: >-
-          <p>The dragon exhales acid in a 60-foot line that is 5 feet wide. Each
-          creature in that line must make a <strong>Dexterity</strong> saving
-          throw.</p>
+          <p>The [[lookup @name]]{monster} exhales acid in a [[lookup
+          @labels.description.template activity=t3MxfqSALI2iH4b2]]. Each
+          creature in that line must make a Dexterity saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1387,13 +1464,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        t3MxfqSALI2iH4b2:
           type: save
           activation:
             type: action
@@ -1412,6 +1488,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1432,6 +1509,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1457,12 +1535,26 @@ items:
                 scaling:
                   number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '18'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Exhale Acid
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: t3MxfqSALI2iH4b2
       enchant: {}
       prerequisites:
         level: null
@@ -1476,18 +1568,18 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.zjcGly9P3Gn9MXt7
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448797835
+      systemVersion: 6.0.0
+      createdTime: 1781553647198
+      modifiedTime: 1781553723160
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!M4eX4Mu5IHCr3TMf.6bromElr0abqNXJL'
   - _id: tWGObm0RZMwSrQLU
     name: Legendary Actions
     type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
@@ -1504,10 +1596,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -1522,184 +1615,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448742011
+      systemVersion: 6.0.0
+      createdTime: 1781554953506
+      modifiedTime: 1781554960193
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!M4eX4Mu5IHCr3TMf.tWGObm0RZMwSrQLU'
-  - _id: LgqLdk3VQOVcO5UI
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
-    system:
-      description:
-        value: <p>The dragon makes a [[/item .t9FrDQLVCU8x4obw]]{tail} attack.</p>
-        chat: |-
-          <section>
-
-          </section>
-          <p>The dragon slams its long tail against its foe!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: simpleM
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448827057
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!M4eX4Mu5IHCr3TMf.LgqLdk3VQOVcO5UI'
-  - _id: kFPbmQZGCKfWRXpq
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
+  - _id: RnqMV5Ur5n9S3wIt
+    name: Detect
+    type: feat
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
     system:
       description:
         value: >-
-          <p>The dragon beats its wings. Each creature within 10 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: <p>The dragon beats its wings!</p>
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
       source:
         custom: ''
         book: ''
@@ -1707,72 +1640,159 @@ items:
         license: CC-BY-4.0
         rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 10
       uses:
         max: ''
         recovery: []
         spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
       type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
+          activation:
+            type: legendary
+            override: false
+            condition: ''
+            value: 1
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+      identifier: detect
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781553739823
+      modifiedTime: 1781555451286
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!M4eX4Mu5IHCr3TMf.RnqMV5Ur5n9S3wIt'
+  - _id: hXswroxnO4Vgg6KJ
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781551996605
+      modifiedTime: 1781551996605
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!M4eX4Mu5IHCr3TMf.hXswroxnO4Vgg6KJ'
+  - name: Wing Attack
+    type: feat
+    _id: iUiQzMwuCHfvZMPB
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
+      activities:
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1787,6 +1807,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1808,6 +1829,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1826,72 +1848,86 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
               formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
       identifier: wing-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
     folder: null
-    sort: 300000
+    sort: 200000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781554346563
+      modifiedTime: 1781554690250
+      lastModifiedBy: dnd5ebuilder0000
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453157767
-      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!M4eX4Mu5IHCr3TMf.kFPbmQZGCKfWRXpq'
-  - _id: RnqMV5Ur5n9S3wIt
-    name: Detect
+    _key: '!actors.items!M4eX4Mu5IHCr3TMf.iUiQzMwuCHfvZMPB'
+  - name: Tail Attack
     type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    _id: iXsGJD1VHeJYYSev
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bH5x9SlFErQaWMuP:
           type: utility
           activation:
             type: legendary
@@ -1906,15 +1942,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1925,10 +1962,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1943,10 +1981,45 @@ items:
             prompt: false
             visible: false
           sort: 0
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .t9FrDQLVCU8x4obw]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
       enchant: {}
       prerequisites:
+        items: []
+        repeatable: false
         level: null
-      identifier: detect
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
     folder: null
     sort: 0
@@ -1954,16 +2027,16 @@ items:
       default: 0
     flags: {}
     _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781554695817
+      modifiedTime: 1781554768136
+      lastModifiedBy: dnd5ebuilder0000
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.2.0
-      createdTime: null
-      modifiedTime: 1745448802389
-      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!M4eX4Mu5IHCr3TMf.RnqMV5Ur5n9S3wIt'
+    _key: '!actors.items!M4eX4Mu5IHCr3TMf.iXsGJD1VHeJYYSev'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1972,7 +2045,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171224647

--- a/packs/_source/monsters/dragon/adult-black-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-black-dragon.yml
@@ -1154,7 +1154,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/adult-black-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-black-dragon.yml
@@ -1149,12 +1149,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1316,7 +1317,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781552901546
-      modifiedTime: 1781630463823
+      modifiedTime: 1781631874409
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!M4eX4Mu5IHCr3TMf.A3azHlbNcHLRgogu'

--- a/packs/_source/monsters/dragon/adult-black-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-black-dragon.yml
@@ -1584,7 +1584,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1620,7 +1622,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781554953506
-      modifiedTime: 1781554960193
+      modifiedTime: 1781897276825
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!M4eX4Mu5IHCr3TMf.tWGObm0RZMwSrQLU'

--- a/packs/_source/monsters/dragon/adult-black-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-black-dragon.yml
@@ -489,8 +489,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .A3azHlbNcHLRgogu]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .amUUCouL69OK1GZU]]{Bite} and two with its
-          [[/item .uXxifk618IakGfYG]]{Claws}.</p>
+          one with its [[/item .amUUCouL69OK1GZU]]{bite} and two with its
+          [[/item .uXxifk618IakGfYG]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -588,7 +588,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781552871673
-      modifiedTime: 1781555001998
+      modifiedTime: 1783370775541
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!M4eX4Mu5IHCr3TMf.P47jJ8bjQulsbdUg'
@@ -2004,7 +2004,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .t9FrDQLVCU8x4obw]]{Tail} attack.</p>
+          .t9FrDQLVCU8x4obw]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -2034,7 +2034,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781554695817
-      modifiedTime: 1781554768136
+      modifiedTime: 1783370784936
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: null
       duplicateSource: null

--- a/packs/_source/monsters/dragon/adult-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-blue-dragon.yml
@@ -1081,7 +1081,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1121,7 +1123,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567773392
-      modifiedTime: 1781567773392
+      modifiedTime: 1781897271015
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!cGM3iVYTtCsYXjzO.6VXyIp8Zt4a94Tb8'

--- a/packs/_source/monsters/dragon/adult-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-blue-dragon.yml
@@ -1142,7 +1142,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/adult-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-blue-dragon.yml
@@ -1135,12 +1135,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1306,7 +1307,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567786525
-      modifiedTime: 1781567839993
+      modifiedTime: 1781631951836
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!cGM3iVYTtCsYXjzO.xWSOEwthNmDecfQ8'

--- a/packs/_source/monsters/dragon/adult-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-blue-dragon.yml
@@ -855,10 +855,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .xWSOEwthNmDecfQ8]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .tz3vYeFf3GLouPGC]]{Bite} and two with its [[/item
-          .kYySllKlNPBsT7Ho]]{Claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .xWSOEwthNmDecfQ8]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .tz3vYeFf3GLouPGC]]{bite} and two with its
+          [[/item .kYySllKlNPBsT7Ho]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -872,7 +872,7 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -947,7 +947,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567928003
-      modifiedTime: 1781567928003
+      modifiedTime: 1783370849425
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!cGM3iVYTtCsYXjzO.kWquVg3QhBwODyz3'
@@ -1499,9 +1499,9 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon exhales lightning in a [[lookup
-          @labels.description.template activity=GSQtl90Opu6WzZk4]]. Each
-          creature in that line must make a [[/save]] saving throw, taking
+          <p>The [[lookup @name lowercase]]{monster} exhales lightning in a
+          [[lookup @labels.description.template activity=GSQtl90Opu6WzZk4]].
+          Each creature in that line must make a [[/save]] saving throw, taking
           [[/damage average]] damage on a failed save, or half as much damage on
           a successful one.</p>
         chat: >-
@@ -1635,7 +1635,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567949643
-      modifiedTime: 1781568153769
+      modifiedTime: 1783370815717
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!cGM3iVYTtCsYXjzO.tU4OoHX9Hwg3qGLM'
@@ -1833,7 +1833,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .tPZA3sUmzXN6euE9]]{Tail} attack.</p>
+          .tPZA3sUmzXN6euE9]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -1863,7 +1863,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567987520
-      modifiedTime: 1781567999586
+      modifiedTime: 1783370828987
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/adult-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-blue-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,15 +478,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
   - _id: tz3vYeFf3GLouPGC
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Blue Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -552,7 +552,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -561,8 +561,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        41FDpL4xge2xPaaT:
           type: attack
           activation:
             type: action
@@ -577,10 +576,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -597,7 +597,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '1'
               type: ''
@@ -610,36 +611,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 10
                 bonus: ''
                 types:
                   - lightning
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: 41FDpL4xge2xPaaT
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -649,22 +661,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449126572
+      systemVersion: 6.0.0
+      createdTime: 1781567891273
+      modifiedTime: 1781567910905
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!cGM3iVYTtCsYXjzO.tz3vYeFf3GLouPGC'
   - _id: kYySllKlNPBsT7Ho
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Blue Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -727,7 +741,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -736,8 +750,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        OHXV7VMZ9jPyp7YE:
           type: attack
           activation:
             type: action
@@ -752,10 +765,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -772,7 +786,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '1'
               type: ''
@@ -785,24 +800,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: OHXV7VMZ9jPyp7YE
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -812,515 +840,14 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449126572
+      systemVersion: 6.0.0
+      createdTime: 1781567872441
+      modifiedTime: 1781567884334
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!cGM3iVYTtCsYXjzO.kYySllKlNPBsT7Ho'
-  - _id: wpVgm5eOdM9j3C3N
-    name: Detect
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: detect
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449176532
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!cGM3iVYTtCsYXjzO.wpVgm5eOdM9j3C3N'
-  - _id: zMT1Uj814On8O1Hg
-    name: Frightful Presence
-    type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
-    system:
-      description:
-        value: >-
-          <p>Each creature of the dragon's choice that is within 120 ft. of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: creature
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '17'
-          sort: 0
-          name: ''
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449154661
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!cGM3iVYTtCsYXjzO.zMT1Uj814On8O1Hg'
-  - _id: 2yqNNNEOupSnZs0p
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449122975
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!cGM3iVYTtCsYXjzO.2yqNNNEOupSnZs0p'
-  - _id: BNmepDhipTFG7kIT
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449116125
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!cGM3iVYTtCsYXjzO.BNmepDhipTFG7kIT'
-  - _id: ZrmS45Tc7RieN0qd
-    name: Lightning Breath
-    type: feat
-    img: icons/magic/lightning/bolt-strike-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon exhales lightning in a 90-foot line that is 5 ft. wide.
-          Each creature in that line must make a [[/save]] saving throw, taking
-          [[/damage average]] damage on a failed save, or half as much damage on
-          a successful one.</p>
-        chat: >-
-          <p>The dragon exhales lightning in a 90-foot line that is 5 ft. wide.
-          Each creature in that line must make a <strong>Dexterity</strong>
-          saving throw.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: line
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - number: 12
-                denomination: 10
-                bonus: ''
-                types: []
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          save:
-            ability: dex
-            dc:
-              calculation: ''
-              formula: '19'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: lightning-breath
-    effects: []
-    folder: null
-    sort: 600000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.LVnd9fq9cQj7rR0Q
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449167819
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!cGM3iVYTtCsYXjzO.ZrmS45Tc7RieN0qd'
   - _id: kWquVg3QhBwODyz3
     name: Multiattack
     type: feat
@@ -1328,10 +855,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .zMT1Uj814On8O1Hg]]{Frightful
+          <p>The dragon can use its [[/item .xWSOEwthNmDecfQ8]]{Frightful
           Presence}. It then makes three attacks: one with its [[/item
-          .tz3vYeFf3GLouPGC]]{bite} and two with its [[/item
-          .kYySllKlNPBsT7Ho]]{claws}.</p>
+          .tz3vYeFf3GLouPGC]]{Bite} and two with its [[/item
+          .kYySllKlNPBsT7Ho]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -1416,22 +943,383 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449127330
+      systemVersion: 6.0.0
+      createdTime: 1781567928003
+      modifiedTime: 1781567928003
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!cGM3iVYTtCsYXjzO.kWquVg3QhBwODyz3'
-  - _id: JRgWoRDlExmKqNVa
+  - _id: xX2G1oW5oG2hw4jE
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567772309
+      modifiedTime: 1781567772309
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!cGM3iVYTtCsYXjzO.xX2G1oW5oG2hw4jE'
+  - _id: 6VXyIp8Zt4a94Tb8
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 600000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567773392
+      modifiedTime: 1781567773392
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!cGM3iVYTtCsYXjzO.6VXyIp8Zt4a94Tb8'
+  - _id: xWSOEwthNmDecfQ8
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        2VOmvThI0bGdUsMt:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '120'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781567786525
+          modifiedTime: 1781567786525
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!cGM3iVYTtCsYXjzO.xWSOEwthNmDecfQ8.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 475000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567786525
+      modifiedTime: 1781567839993
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!cGM3iVYTtCsYXjzO.xWSOEwthNmDecfQ8'
+  - _id: tPZA3sUmzXN6euE9
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Blue Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1447,7 +1335,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1494,17 +1381,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1519,10 +1404,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1539,7 +1425,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '1'
               type: ''
@@ -1552,54 +1439,72 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
       mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
     folder: null
-    sort: 400000
+    sort: 450000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449197039
+      systemVersion: 6.0.0
+      createdTime: 1781567801740
+      modifiedTime: 1781567802876
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!cGM3iVYTtCsYXjzO.JRgWoRDlExmKqNVa'
-  - _id: ANMZzr2n2EpU41eg
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!cGM3iVYTtCsYXjzO.tPZA3sUmzXN6euE9'
+  - _id: tU4OoHX9Hwg3qGLM
+    name: Lightning Breath
+    type: feat
+    img: icons/magic/lightning/bolt-beam-strike-blue.webp
     system:
       description:
-        value: <p>The dragon makes a [[/item .JRgWoRDlExmKqNVa]]{tail} attack.</p>
-        chat: |-
-          <section>
-
-          </section>
-          <p>The dragon slams its long tail against its foe!</p>
+        value: >-
+          <p>The dragon exhales lightning in a [[lookup
+          @labels.description.template activity=GSQtl90Opu6WzZk4]]. Each
+          creature in that line must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} exhales lightning in a [[lookup
+          @labels.description.template activity=GSQtl90Opu6WzZk4]]. Each
+          creature in that line must make a Dexterity saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1607,68 +1512,251 @@ items:
         license: CC-BY-4.0
         rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        GSQtl90Opu6WzZk4:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: line
+              size: '90'
+              width: '5'
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 12
+                denomination: 10
+                bonus: ''
+                types:
+                  - lightning
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '12'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: GSQtl90Opu6WzZk4
+          name: Exhale Lightning
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: lightning-breath
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.LVnd9fq9cQj7rR0Q
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567949643
+      modifiedTime: 1781568153769
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!cGM3iVYTtCsYXjzO.tU4OoHX9Hwg3qGLM'
+  - _id: mkWSsQbEzK9uK5OI
+    name: Detect
+    type: feat
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
       uses:
         max: ''
         recovery: []
         spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
       type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
+          activation:
+            type: legendary
+            override: false
+            value: 1
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567981834
+      modifiedTime: 1781567981834
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!cGM3iVYTtCsYXjzO.mkWSsQbEzK9uK5OI'
+  - name: Tail Attack
+    type: feat
+    _id: Bt6Lf5wZJLxdShut
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
+    system:
+      activities:
+        bH5x9SlFErQaWMuP:
           type: utility
           activation:
             type: legendary
@@ -1676,28 +1764,23 @@ items:
             condition: ''
             override: false
           consumption:
-            targets:
-              - type: attribute
-                target: resources.legact.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+            targets: []
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1708,10 +1791,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1726,113 +1810,69 @@ items:
             prompt: false
             visible: false
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .tPZA3sUmzXN6euE9]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
       identifier: tail-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 100000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449200210
+      systemVersion: 6.0.0
+      createdTime: 1781567987520
+      modifiedTime: 1781567999586
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
       exportSource: null
-    _key: '!actors.items!cGM3iVYTtCsYXjzO.ANMZzr2n2EpU41eg'
-  - _id: GcUNB4m0NAPgP0Nx
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
+    _key: '!actors.items!cGM3iVYTtCsYXjzO.Bt6Lf5wZJLxdShut'
+  - name: Wing Attack
+    type: feat
+    _id: BVm93fESzDI3ALm0
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
     system:
-      description:
-        value: >-
-          <p>The dragon beats its wings. Each creature within 10 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: <p>The dragon beats its wings!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 10
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1840,16 +1880,14 @@ items:
             condition: ''
             override: false
           consumption:
-            targets:
-              - type: attribute
-                value: '2'
-                target: resources.legact.value
+            targets: []
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1871,6 +1909,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1889,45 +1928,79 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '20'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      mastery: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
       identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 300000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453147815
+      systemVersion: 6.0.0
+      createdTime: 1781568002354
+      modifiedTime: 1781568004434
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!cGM3iVYTtCsYXjzO.GcUNB4m0NAPgP0Nx'
+    _key: '!actors.items!cGM3iVYTtCsYXjzO.BVm93fESzDI3ALm0'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1936,7 +2009,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171243035

--- a/packs/_source/monsters/dragon/adult-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-brass-dragon.yml
@@ -847,8 +847,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .XyhdTtNxXj219dlP]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .Rr34cx78OgioMSHH]]{Bite} and two with its
-          [[/item .Gx6DVWF7D9lzZjse]]{Claws}.</p>
+          one with its [[/item .Rr34cx78OgioMSHH]]{bite} and two with its
+          [[/item .Gx6DVWF7D9lzZjse]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -946,7 +946,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620904151
-      modifiedTime: 1781620909524
+      modifiedTime: 1783370871372
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!7vswgicsiMfS4ZTS.MUTDiPrzhDqLYlKU'
@@ -1975,7 +1975,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .wpjVwZ9oJcl07bYG]]{Tail} attack.</p>
+          .wpjVwZ9oJcl07bYG]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -2005,7 +2005,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620853178
-      modifiedTime: 1781620878428
+      modifiedTime: 1783370840577
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/adult-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-brass-dragon.yml
@@ -1313,12 +1313,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1484,7 +1485,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620771093
-      modifiedTime: 1781620772277
+      modifiedTime: 1781631945275
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!7vswgicsiMfS4ZTS.XyhdTtNxXj219dlP'
@@ -1507,9 +1508,9 @@ items:
           @labels.description.template activity=O02zuaLvAqtmgutQ]]. Each
           creature in that area must succeed on a [[/save
           activity=O02zuaLvAqtmgutQ]] saving throw or fall
-          &amp;Reference[unconscious] for 10 minutes. This effect ends for a
-          creature if the creature takes damage or someone uses an action to
-          wake it.</p>
+          &amp;Reference[unconscious] for [[lookup @labels.duration
+          activity=O02zuaLvAqtmgutQ]]. This effect ends for a creature if the
+          creature takes damage or someone uses an action to wake it.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -1647,9 +1648,10 @@ items:
               [[lookup @labels.description.template activity=O02zuaLvAqtmgutQ]].
               Each creature in that area must succeed on a [[/save
               activity=O02zuaLvAqtmgutQ]] saving throw or fall
-              &amp;Reference[unconscious] for 10 minutes. This effect ends for a
-              creature if the creature takes damage or someone uses an action to
-              wake it.</p>
+              &amp;Reference[unconscious] for [[lookup @labels.duration
+              activity=O02zuaLvAqtmgutQ]]. This effect ends for a creature if
+              the creature takes damage or someone uses an action to wake
+              it.</p>
           duration:
             concentration: false
             value: '10'
@@ -1773,7 +1775,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620775166
-      modifiedTime: 1781622834419
+      modifiedTime: 1781631812013
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!7vswgicsiMfS4ZTS.bylvyjev8yh0oVj6'

--- a/packs/_source/monsters/dragon/adult-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-brass-dragon.yml
@@ -957,7 +957,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -997,7 +999,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620671011
-      modifiedTime: 1781620671011
+      modifiedTime: 1781897266393
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!7vswgicsiMfS4ZTS.fZxjrr4ag5ahtBxv'

--- a/packs/_source/monsters/dragon/adult-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-brass-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,15 +478,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
   - _id: Rr34cx78OgioMSHH
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Brass Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -513,7 +513,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -551,9 +551,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -562,8 +561,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        6LLAhYHofQDuBBMz:
           type: attack
           activation:
             type: action
@@ -578,10 +576,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -598,7 +597,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -611,20 +611,32 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 6LLAhYHofQDuBBMz
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -639,22 +651,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450846430
+      systemVersion: 6.0.0
+      createdTime: 1781620685882
+      modifiedTime: 1781620704393
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!7vswgicsiMfS4ZTS.Rr34cx78OgioMSHH'
   - _id: Gx6DVWF7D9lzZjse
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Brass Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -717,7 +731,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -726,8 +740,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        SBkWRvg4VheuyzmL:
           type: attack
           activation:
             type: action
@@ -742,10 +755,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -762,7 +776,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -775,24 +790,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: SBkWRvg4VheuyzmL
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -802,22 +830,26 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450846430
+      systemVersion: 6.0.0
+      createdTime: 1781620720631
+      modifiedTime: 1781620760035
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!7vswgicsiMfS4ZTS.Gx6DVWF7D9lzZjse'
-  - _id: jM7XLTjt7QeJ8B7U
-    name: Detect
+  - _id: MUTDiPrzhDqLYlKU
+    name: Multiattack
     type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    img: icons/skills/melee/blade-tips-triple-steel.webp
     system:
       description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .XyhdTtNxXj219dlP]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .Rr34cx78OgioMSHH]]{Bite} and two with its
+          [[/item .Gx6DVWF7D9lzZjse]]{Claws}.</p>
+        chat: ''
       source:
         custom: ''
         book: ''
@@ -830,16 +862,15 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        tUSrxZU11ay5xOos:
           type: utility
           activation:
-            type: legendary
+            type: action
             value: 1
             condition: ''
             override: false
@@ -851,15 +882,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -870,7 +902,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -887,157 +920,40 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: tUSrxZU11ay5xOos
       enchant: {}
       prerequisites:
         level: null
-      identifier: detect
+      identifier: multiattack
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450956373
+      systemVersion: 6.0.0
+      createdTime: 1781620904151
+      modifiedTime: 1781620909524
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!7vswgicsiMfS4ZTS.jM7XLTjt7QeJ8B7U'
-  - _id: cVkEgorVxYQJkS8M
-    name: Frightful Presence
-    type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
-    system:
-      description:
-        value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: creature
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '16'
-          sort: 0
-          name: ''
-          img: ''
-          appliedEffects: []
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 450000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450869654
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!7vswgicsiMfS4ZTS.cVkEgorVxYQJkS8M'
-  - _id: Mmn2SNmzahxtikN3
+    _key: '!actors.items!7vswgicsiMfS4ZTS.MUTDiPrzhDqLYlKU'
+  - _id: fZxjrr4ag5ahtBxv
     name: Legendary Actions
     type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
@@ -1054,41 +970,46 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: legendary-actions
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
-    sort: 0
+    folder: 5cwqjeuI64dkrUa8
+    sort: 137500
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450814744
+      systemVersion: 6.0.0
+      createdTime: 1781620671011
+      modifiedTime: 1781620671011
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!7vswgicsiMfS4ZTS.Mmn2SNmzahxtikN3'
-  - _id: 86DJipzmvkhxDoKr
+    _key: '!actors.items!7vswgicsiMfS4ZTS.fZxjrr4ag5ahtBxv'
+  - _id: 8aBI5knFgJjHMTBr
     name: Legendary Resistance
     type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
+    img: icons/equipment/shield/targe-steel-blue.webp
     system:
       description:
         value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
         chat: ''
       source:
         custom: ''
@@ -1102,7 +1023,7 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties:
@@ -1113,32 +1034,31 @@ items:
           type: utility
           activation:
             type: special
-            value: 1
-            condition: ''
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
             override: false
           consumption:
             targets:
               - type: attribute
-                target: resources.legres.value
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: resources.legres.value
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1149,10 +1069,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1167,138 +1088,52 @@ items:
             prompt: false
             visible: false
           sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: legendary-resistance
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
-    sort: 0
+    folder: 5cwqjeuI64dkrUa8
+    sort: 125000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450822633
+      systemVersion: 6.0.0
+      createdTime: 1781620671847
+      modifiedTime: 1781620671847
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!7vswgicsiMfS4ZTS.86DJipzmvkhxDoKr'
-  - _id: MUTDiPrzhDqLYlKU
-    name: Multiattack
-    type: feat
-    img: icons/skills/melee/blade-tips-triple-steel.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon can use its [[/item .cVkEgorVxYQJkS8M]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .Rr34cx78OgioMSHH]]{bite} and two with its [[/item
-          .Gx6DVWF7D9lzZjse]]{claws}.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: multiattack
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450847115
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!7vswgicsiMfS4ZTS.MUTDiPrzhDqLYlKU'
-  - _id: rR1dMvZqWVQTgCVw
+    _key: '!actors.items!7vswgicsiMfS4ZTS.8aBI5knFgJjHMTBr'
+  - _id: wpjVwZ9oJcl07bYG
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Brass Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1314,7 +1149,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1361,17 +1195,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1386,10 +1218,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1406,9 +1239,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1419,49 +1253,78 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
-    folder: null
-    sort: 400000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 350000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450846430
+      systemVersion: 6.0.0
+      createdTime: 1781620764932
+      modifiedTime: 1781620765977
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!7vswgicsiMfS4ZTS.rR1dMvZqWVQTgCVw'
-  - _id: StCQbn2czecQteRM
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!7vswgicsiMfS4ZTS.wpjVwZ9oJcl07bYG'
+  - _id: XyhdTtNxXj219dlP
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
     system:
       description:
-        value: <p>The dragon makes a [[/item .rR1dMvZqWVQTgCVw]]{tail} attack.</p>
-        chat: <p>The dragon slams its long tail against its foe!</p>
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
       source:
         custom: ''
         book: ''
@@ -1469,74 +1332,20 @@ items:
         license: CC-BY-4.0
         rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
       uses:
         max: ''
         recovery: []
         spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 8
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
       type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: attack
+        2VOmvThI0bGdUsMt:
+          type: save
           activation:
-            type: legendary
+            type: action
             value: 1
             condition: ''
             override: false
@@ -1548,15 +1357,22 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
-            value: ''
-            units: ''
+            value: '1'
+            units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
-            units: ''
+            value: '120'
+            units: ft
             special: ''
             override: false
           target:
@@ -1567,10 +1383,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: any
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1579,246 +1396,121 @@ items:
             spent: 0
             max: ''
             recovery: []
-          attack:
-            ability: str
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
           damage:
-            critical:
-              bonus: ''
-            includeBase: true
+            onSave: none
             parts: []
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450974418
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!7vswgicsiMfS4ZTS.StCQbn2czecQteRM'
-  - _id: Ge1y4jlE3zGCsy6K
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
-    system:
-      description:
-        value: "<p>The dragon beats its wings. Each creature within\_10 feet of the dragon must succeed on a\_[[/save]] saving throw\_or take\_[[/damage average]]\_damage and be knocked &amp;Reference[prone]. The dragon can then fly up to half its flying speed.</p>"
-        chat: |-
-          <section>
-
-          </section>
-          <p>The dragon beats its wings!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: legendary
-            value: 2
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                value: '2'
-                target: resources.legact.value
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: radius
-              size: '10'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 2
-                denomination: '6'
-                bonus: '@mod'
-                types:
-                  - bludgeoning
           save:
-            ability: dex
+            ability:
+              - wis
             dc:
-              calculation: str
-              formula: '19'
-          sort: 0
-          name: ''
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: wing-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 300000
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781620771093
+          modifiedTime: 1781620771093
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!7vswgicsiMfS4ZTS.XyhdTtNxXj219dlP.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 400000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453136989
+      systemVersion: 6.0.0
+      createdTime: 1781620771093
+      modifiedTime: 1781620772277
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!7vswgicsiMfS4ZTS.Ge1y4jlE3zGCsy6K'
-  - _id: asAmhLPOTnfZhb5I
+    _key: '!actors.items!7vswgicsiMfS4ZTS.XyhdTtNxXj219dlP'
+  - _id: bylvyjev8yh0oVj6
     name: Breath Weapons
     type: feat
     img: icons/creatures/abilities/dragon-fire-breath-orange.webp
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Fire Breath.</strong> The dragon exhales fire
-          in an 60-foot line that is 5 feet wide. Each creature in that line
-          must make a [[/save activity=1sMTs1dMXloeFhPm]] saving throw, taking
-          [[/damage average activity=1sMTs1dMXloeFhPm]] damage on a failed save,
-          or half as much damage on a successful one.</p><p><strong>Sleep
-          Breath.</strong> The dragon exhales sleep gas in a 60-foot cone. Each
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Fire Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales fire in an [[lookup
+          @labels.description.template activity=NBdXGRF1vahbq4p8]]. Each
+          creature in that line must make a [[/save activity=NBdXGRF1vahbq4p8]]
+          saving throw, taking [[/damage average activity=NBdXGRF1vahbq4p8]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Sleep Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales sleep gas in a [[lookup
+          @labels.description.template activity=O02zuaLvAqtmgutQ]]. Each
           creature in that area must succeed on a [[/save
-          activity=FogutuTRCMsfoCAT]] saving throw or fall
+          activity=O02zuaLvAqtmgutQ]] saving throw or fall
           &amp;Reference[unconscious] for 10 minutes. This effect ends for a
           creature if the creature takes damage or someone uses an action to
           wake it.</p>
-        chat: <p>The dragon breathes in!</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -1834,12 +1526,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        1sMTs1dMXloeFhPm:
+        NBdXGRF1vahbq4p8:
           type: save
           activation:
             type: action
@@ -1851,12 +1543,20 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales fire in an
+              [[lookup @labels.description.template activity=NBdXGRF1vahbq4p8]].
+              Each creature in that line must make a [[/save
+              activity=NBdXGRF1vahbq4p8]] saving throw, taking [[/damage average
+              activity=NBdXGRF1vahbq4p8]] damage on a failed save, or half as
+              much damage on a successful one.</p>
           duration:
             concentration: false
             value: ''
@@ -1874,12 +1574,13 @@ items:
               contiguous: false
               type: line
               size: '60'
-              width: ''
+              width: '5'
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1895,22 +1596,34 @@ items:
                   enabled: false
                   formula: ''
                 number: 13
-                denomination: '6'
+                denomination: 6
                 bonus: ''
                 types:
                   - fire
+                scaling:
+                  number: 1
           save:
             ability:
               - dex
             dc:
-              calculation: ''
-              formula: '18'
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
           sort: 0
-          _id: 1sMTs1dMXloeFhPm
+          _id: NBdXGRF1vahbq4p8
           name: Fire Breath
           img: ''
-          appliedEffects: []
-        FogutuTRCMsfoCAT:
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+        O02zuaLvAqtmgutQ:
           type: save
           activation:
             type: action
@@ -1922,19 +1635,33 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales sleep gas in a
+              [[lookup @labels.description.template activity=O02zuaLvAqtmgutQ]].
+              Each creature in that area must succeed on a [[/save
+              activity=O02zuaLvAqtmgutQ]] saving throw or fall
+              &amp;Reference[unconscious] for 10 minutes. This effect ends for a
+              creature if the creature takes damage or someone uses an action to
+              wake it.</p>
           duration:
             concentration: false
             value: '10'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: P1rGrKiV7x2OMiN0
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             units: self
             special: ''
@@ -1948,9 +1675,385 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - con
+            dc:
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: O02zuaLvAqtmgutQ
+          name: Sleep Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: breath-weapons
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Sleep Breath
+        img: icons/magic/control/sleep-bubble-purple.webp
+        origin: Compendium.dnd5e.monsters.Actor.azCbLQt5LAYwTI7U.Item.JmVLjWM4G6OOQxl4
+        transfer: false
+        _id: P1rGrKiV7x2OMiN0
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 10
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[unconcious apply=false] for 10 minutes. This
+          effect ends for you when you take damage or when someone uses and
+          action to wake you.</p>
+        tint: '#ffffff'
+        statuses:
+          - unconscious
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781620775166
+          modifiedTime: 1781621233594
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!7vswgicsiMfS4ZTS.bylvyjev8yh0oVj6.P1rGrKiV7x2OMiN0
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620775166
+      modifiedTime: 1781622834419
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!7vswgicsiMfS4ZTS.bylvyjev8yh0oVj6'
+  - _id: U9WqW9QBVAUjz5ii
+    name: Detect
+    type: feat
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
+          activation:
+            type: legendary
+            override: false
+            value: 1
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
               type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620852169
+      modifiedTime: 1781620852169
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!7vswgicsiMfS4ZTS.U9WqW9QBVAUjz5ii'
+  - name: Tail Attack
+    type: feat
+    _id: 6HbC9df2Q4N6U2Ev
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
+    system:
+      activities:
+        bH5x9SlFErQaWMuP:
+          type: utility
+          activation:
+            type: legendary
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .wpjVwZ9oJcl07bYG]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620853178
+      modifiedTime: 1781620878428
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!7vswgicsiMfS4ZTS.6HbC9df2Q4N6U2Ev'
+  - name: Wing Attack
+    type: feat
+    _id: oKHKm9QeOQCdWI8x
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
+      activities:
+        4U3711rd7WmlJIhy:
+          type: save
+          activation:
+            type: legendary
+            value: 2
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '10'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1961,43 +2064,84 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts: []
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
+                denomination: 6
+                bonus: '@mod'
+                types:
+                  - bludgeoning
+                scaling:
+                  number: 1
           save:
             ability:
-              - con
+              - dex
             dc:
-              calculation: ''
+              calculation: str
               formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          _id: FogutuTRCMsfoCAT
-          name: Sleep Breath
+          name: Flap Wings
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
+      identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
       enchant: {}
       prerequisites:
+        items: []
+        repeatable: false
         level: null
-      identifier: breath-weapons
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 475000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451222754
+      systemVersion: 6.0.0
+      createdTime: 1781620854729
+      modifiedTime: 1781620855660
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!7vswgicsiMfS4ZTS.asAmhLPOTnfZhb5I'
+    _key: '!actors.items!7vswgicsiMfS4ZTS.oKHKm9QeOQCdWI8x'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -2006,7 +2150,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171206347

--- a/packs/_source/monsters/dragon/adult-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-brass-dragon.yml
@@ -1320,7 +1320,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/adult-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-bronze-dragon.yml
@@ -980,9 +980,8 @@ items:
       activities: {}
       enchant: {}
       prerequisites:
-        level: 3
-        items:
-          - reptile-bloodline
+        level: null
+        items: []
         repeatable: false
       identifier: amphibious
       advancement: {}

--- a/packs/_source/monsters/dragon/adult-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-bronze-dragon.yml
@@ -1188,12 +1188,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1359,7 +1360,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781626354164
-      modifiedTime: 1781626371025
+      modifiedTime: 1781631938483
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VCuG0Z3MrO8kfDU0.P4bK8qQ7SlmtJi6F'

--- a/packs/_source/monsters/dragon/adult-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-bronze-dragon.yml
@@ -1011,7 +1011,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1051,7 +1053,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781626352313
-      modifiedTime: 1781626352313
+      modifiedTime: 1781897260644
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VCuG0Z3MrO8kfDU0.Hwxcic6acJolHw9u'

--- a/packs/_source/monsters/dragon/adult-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-bronze-dragon.yml
@@ -668,8 +668,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .P4bK8qQ7SlmtJi6F]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .zMFGBLVpXSZC1Vjm]]{Bite} and two with its
-          [[/item .P0ycd36lowML3rTc]]{Claws}.</p>
+          one with its [[/item .zMFGBLVpXSZC1Vjm]]{bite} and two with its
+          [[/item .P0ycd36lowML3rTc]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -767,7 +767,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781626459192
-      modifiedTime: 1781626466846
+      modifiedTime: 1783370889270
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VCuG0Z3MrO8kfDU0.Sn1RpgmvWb3DPz66'
@@ -2130,7 +2130,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .pwUlwu2kJ7ed1Tij]]{Tail} attack.</p>
+          .pwUlwu2kJ7ed1Tij]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -2160,7 +2160,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781626621298
-      modifiedTime: 1781626651224
+      modifiedTime: 1783370897108
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/adult-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-bronze-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,61 +478,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
-  - _id: KVwqxZJAuhE9M5kP
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1745451317099
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!VCuG0Z3MrO8kfDU0.KVwqxZJAuhE9M5kP'
   - _id: zMFGBLVpXSZC1Vjm
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Bronze Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -598,7 +552,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -607,8 +561,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        guDbUP7UYOBJApzo:
           type: attack
           activation:
             type: action
@@ -623,10 +576,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -643,7 +597,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -656,24 +611,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: guDbUP7UYOBJApzo
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -683,122 +651,14 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451320043
+      systemVersion: 6.0.0
+      createdTime: 1781626421275
+      modifiedTime: 1781626432163
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VCuG0Z3MrO8kfDU0.zMFGBLVpXSZC1Vjm'
-  - _id: ZEeiaB4lQMzRas3i
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451316143
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!VCuG0Z3MrO8kfDU0.ZEeiaB4lQMzRas3i'
   - _id: Sn1RpgmvWb3DPz66
     name: Multiattack
     type: feat
@@ -806,10 +666,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .m7dF0hheApwoJLpp]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .zMFGBLVpXSZC1Vjm]]{bite} and two with its [[/item
-          .P0ycd36lowML3rTc]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .P4bK8qQ7SlmtJi6F]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .zMFGBLVpXSZC1Vjm]]{Bite} and two with its
+          [[/item .P0ycd36lowML3rTc]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -823,13 +683,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        cOKcv5QJEmms2Hfe:
           type: utility
           activation:
             type: action
@@ -844,15 +703,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -863,7 +723,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -880,7 +741,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: cOKcv5QJEmms2Hfe
       enchant: {}
       prerequisites:
         level: null
@@ -894,22 +763,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451320701
+      systemVersion: 6.0.0
+      createdTime: 1781626459192
+      modifiedTime: 1781626466846
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VCuG0Z3MrO8kfDU0.Sn1RpgmvWb3DPz66'
   - _id: P0ycd36lowML3rTc
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Bronze Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -972,7 +843,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -981,8 +852,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        MZQ5IElXCyYA3ftP:
           type: attack
           activation:
             type: action
@@ -997,10 +867,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1017,7 +888,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1030,24 +902,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: MZQ5IElXCyYA3ftP
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1057,22 +942,828 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451320043
+      systemVersion: 6.0.0
+      createdTime: 1781626400833
+      modifiedTime: 1781626414101
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VCuG0Z3MrO8kfDU0.P0ycd36lowML3rTc'
-  - _id: irNLCfkryOmVWf25
+  - _id: Wp5Zbgfex3XmySkq
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: class
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: 3
+        items:
+          - reptile-bloodline
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 62500
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781626350948
+      modifiedTime: 1781626360468
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!VCuG0Z3MrO8kfDU0.Wp5Zbgfex3XmySkq'
+  - _id: Hwxcic6acJolHw9u
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 137500
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781626352313
+      modifiedTime: 1781626352313
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!VCuG0Z3MrO8kfDU0.Hwxcic6acJolHw9u'
+  - _id: gsSS3zrWpnHkPOJO
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781626353207
+      modifiedTime: 1781626353207
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!VCuG0Z3MrO8kfDU0.gsSS3zrWpnHkPOJO'
+  - _id: P4bK8qQ7SlmtJi6F
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        2VOmvThI0bGdUsMt:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '120'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781626354164
+          modifiedTime: 1781626354164
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!VCuG0Z3MrO8kfDU0.P4bK8qQ7SlmtJi6F.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 450000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781626354164
+      modifiedTime: 1781626371025
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!VCuG0Z3MrO8kfDU0.P4bK8qQ7SlmtJi6F'
+  - _id: BG4wxIFUTkVBlc7s
+    name: Change Shape
+    type: feat
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} magically polymorphs into a
+          humanoid or beast that has a challenge rating no higher than its own,
+          or back into its true form. It reverts to its true form if it dies.
+          Any equipment it is wearing or carrying is absorbed or borne by the
+          new form (the [[lookup @name lowercase]]{monster}'s choice).</p><p>In
+          a new form, the [[lookup @name lowercase]]{monster} retains its
+          alignment, hit points, Hit Dice, ability to speak, proficiencies,
+          Legendary Resistance, lair actions, and Intelligence, Wisdom, and
+          Charisma scores, as well as this action. Its statistics and
+          capabilities are otherwise replaced by those of the new form, except
+          any class features or legendary actions of that form.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} changes its form into a humanoid or
+          beast!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - mgc
+      activities:
+        WgVVVBedNPAgXuDm:
+          type: transform
+          name: Change Shape into Humanoid or Beast
+          _id: WgVVVBedNPAgXuDm
+          img: ''
+          sort: 100000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: false
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: '@details.cr'
+              name: ''
+              _id: hAZbWYsA1wVyGXVn
+              uuid: null
+              sizes: []
+              types:
+                - beast
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings:
+            effects:
+              - all
+            keep:
+              - mental
+              - skills
+              - languages
+              - items
+              - spells
+              - bio
+            preset: polymorph
+            merge: []
+            other: []
+            spellLists: []
+            transformTokens: true
+            minimumAC: ''
+            tempFormula: ''
+          transform:
+            customize: true
+            mode: cr
+            preset: polymorph
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: change-shape
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 900000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.MO382D2sxtAIuUC5.Item.Fyvg74zRJWn05uhK
+      duplicateSource: Item.gfURBnJDJatlzDXj
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781626375181
+      modifiedTime: 1781630703367
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!VCuG0Z3MrO8kfDU0.BG4wxIFUTkVBlc7s'
+  - _id: 2a60l0GqXGN8lx4R
+    name: Breath Weapons
+    type: feat
+    img: icons/creatures/abilities/dragon-ice-breath-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Lightning Breath.</strong> The [[lookup
+          @name lowercase]]{monster} exhales lightning in a [[lookup
+          @labels.description.template activity=w2CftR6CLr5PZ7zY]]. Each
+          creature in that line must make a [[/save activity=w2CftR6CLr5PZ7zY]]
+          saving throw, taking [[/damage average activity=w2CftR6CLr5PZ7zY]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Repulsion Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales repulsion energy in a [[lookup
+          @labels.description.template activity=YElWYv6C5UfhAu48]]. Each
+          creature in that area must succeed on a [[/save
+          activity=YElWYv6C5UfhAu48]] saving throw. On a failed save, the
+          creature is pushed 60 feet away from the [[lookup @name
+          lowercase]]{monster}.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        w2CftR6CLr5PZ7zY:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales lightning in a
+              [[lookup @labels.description.template activity=w2CftR6CLr5PZ7zY]].
+              Each creature in that line must make a [[/save
+              activity=w2CftR6CLr5PZ7zY]] saving throw, taking [[/damage average
+              activity=w2CftR6CLr5PZ7zY]] damage on a failed save, or half as
+              much damage on a successful one.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: line
+              size: '90'
+              width: '5'
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 12
+                denomination: 10
+                bonus: ''
+                types:
+                  - lightning
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '12'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: w2CftR6CLr5PZ7zY
+          name: Lightning Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+        YElWYv6C5UfhAu48:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales repulsion
+              energy in a [[lookup @labels.description.template
+              activity=YElWYv6C5UfhAu48]]. Each creature in that area must
+              succeed on a [[/save activity=YElWYv6C5UfhAu48]] saving throw. On
+              a failed save, the creature is pushed 60 feet away from the
+              [[lookup @name lowercase]]{monster}.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '30'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - str
+            dc:
+              calculation: con
+              formula: '12'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: YElWYv6C5UfhAu48
+          name: Repulsion Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        repeatable: false
+        items: []
+      identifier: breath-weapons
+      advancement: {}
+      cover: null
+      crewed: false
+    effects: []
+    folder: null
+    sort: 600000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781626381625
+      modifiedTime: 1781626526932
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!VCuG0Z3MrO8kfDU0.2a60l0GqXGN8lx4R'
+  - _id: pwUlwu2kJ7ed1Tij
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Bronze Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1088,7 +1779,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1135,17 +1825,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1160,10 +1848,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1180,9 +1869,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1193,318 +1883,66 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
-    folder: null
-    sort: 400000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 425000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451320043
+      systemVersion: 6.0.0
+      createdTime: 1781626390806
+      modifiedTime: 1781626392738
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!VCuG0Z3MrO8kfDU0.irNLCfkryOmVWf25'
-  - _id: m7dF0hheApwoJLpp
-    name: Frightful Presence
-    type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
-    system:
-      description:
-        value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: creature
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '17'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451555335
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!VCuG0Z3MrO8kfDU0.m7dF0hheApwoJLpp'
-  - _id: ZDVExJaMLcCwOcyq
-    name: Change Shape
-    type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon magically polymorphs into a humanoid or beast that has a
-          challenge rating no higher than its own, or back into its true form.
-          It reverts to its true form if it dies. Any equipment it is wearing or
-          carrying is absorbed or borne by the new form (the dragon's
-          choice).</p><p>In a new form, the dragon retains its alignment, hit
-          points, Hit Dice, ability to speak, proficiencies, Legendary
-          Resistance, lair actions, and Intelligence, Wisdom, and Charisma
-          scores, as well as this action. Its statistics and capabilities are
-          otherwise replaced by those of the new form, except any class features
-          or legendary actions of that form.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: change-shape
-    effects: []
-    folder: null
-    sort: 800000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.JsAys4RSGi4lN5Jy
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451638333
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!VCuG0Z3MrO8kfDU0.ZDVExJaMLcCwOcyq'
-  - _id: jwbM0YJCiaOuH9fv
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451316143
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!VCuG0Z3MrO8kfDU0.jwbM0YJCiaOuH9fv'
-  - _id: 7UhgJ951z7hjLmBu
+    _key: '!actors.items!VCuG0Z3MrO8kfDU0.pwUlwu2kJ7ed1Tij'
+  - _id: nl3TSPaAwBq3HY7J
     name: Detect
     type: feat
     img: icons/creatures/eyes/lizard-single-slit-blue.webp
     system:
       description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
       source:
         custom: ''
         book: ''
@@ -1517,166 +1955,105 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
           activation:
             type: legendary
+            override: false
             value: 1
             condition: ''
-            override: false
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
+              type: self
               special: ''
-            prompt: true
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: detect
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
-    sort: 0
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451643850
+      systemVersion: 6.0.0
+      createdTime: 1781626618923
+      modifiedTime: 1781626618923
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!VCuG0Z3MrO8kfDU0.7UhgJ951z7hjLmBu'
-  - _id: JOKHSoiYvCINS119
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!VCuG0Z3MrO8kfDU0.nl3TSPaAwBq3HY7J'
+  - name: Tail Attack
+    type: feat
+    _id: c6O0wQM6Ad7tDiKv
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
-      description:
-        value: <p>The dragon makes a [[/item .irNLCfkryOmVWf25]]{tail} attack.</p>
-        chat: <p>The dragon slams its long tail against its foe!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bH5x9SlFErQaWMuP:
           type: utility
           activation:
             type: legendary
@@ -1691,15 +2068,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1710,10 +2088,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1728,113 +2107,69 @@ items:
             prompt: false
             visible: false
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .pwUlwu2kJ7ed1Tij]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
       identifier: tail-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 100000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451659536
+      systemVersion: 6.0.0
+      createdTime: 1781626621298
+      modifiedTime: 1781626651224
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
       exportSource: null
-    _key: '!actors.items!VCuG0Z3MrO8kfDU0.JOKHSoiYvCINS119'
-  - _id: Ls6rBLfLiVx1xTaD
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
+    _key: '!actors.items!VCuG0Z3MrO8kfDU0.c6O0wQM6Ad7tDiKv'
+  - name: Wing Attack
+    type: feat
+    _id: EZt1TGEK0zFWLKn8
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
     system:
-      description:
-        value: "<p>The dragon beats its wings. Each creature within\_10 feet of the dragon must succeed on a\_[[/save]] saving throw\_or take\_[[/damage average]]\_damage and be knocked &amp;Reference[prone]. The dragon can then fly up to half its flying speed.</p>"
-        chat: <p>The dragon beats its wings!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1849,6 +2184,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1857,7 +2193,8 @@ items:
             override: false
           effects: []
           range:
-            units: ''
+            value: '10'
+            units: ft
             special: ''
             override: false
           target:
@@ -1868,10 +2205,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: any
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1887,246 +2225,79 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
-          save:
-            ability: dex
-            dc:
-              calculation: str
-              formula: '20'
-          sort: 0
-          name: ''
-          img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: wing-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453127990
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!VCuG0Z3MrO8kfDU0.Ls6rBLfLiVx1xTaD'
-  - _id: kwsQiZZFKo5ZOGB9
-    name: Breath Weapons
-    type: feat
-    img: icons/creatures/abilities/dragon-ice-breath-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Lightning Breath.</strong> The dragon exhales
-          lightning in a 120-foot line that is 10 feet wide. Each creature in
-          that line must make a [[/save activity=w2CftR6CLr5PZ7zY]] saving
-          throw, taking [[/damage average activity=w2CftR6CLr5PZ7zY]] damage on
-          a failed save, or half as much damage on a successful
-          one.</p><p><strong>Repulsion Breath.</strong> The dragon exhales
-          repulsion energy in a 30-foot cone. Each creature in that area must
-          succeed on a [[/save activity=YElWYv6C5UfhAu48]] saving throw. On a
-          failed save, the creature is pushed 60 feet away from the dragon.</p>
-        chat: <p>The dragon breathes in!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        w2CftR6CLr5PZ7zY:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: line
-              size: '120'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 12
-                denomination: '10'
-                bonus: ''
-                types:
-                  - lightning
+                scaling:
+                  number: 1
           save:
             ability:
               - dex
             dc:
-              calculation: ''
-              formula: '19'
+              calculation: str
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          _id: w2CftR6CLr5PZ7zY
-          name: Lightning Breath
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-        YElWYv6C5UfhAu48:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '30'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability:
-              - str
-            dc:
-              calculation: ''
-              formula: '19'
-          sort: 0
-          _id: YElWYv6C5UfhAu48
-          name: Repulsion Breath
-          img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
+      identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
       enchant: {}
       prerequisites:
-        level: null
+        items: []
         repeatable: false
-      identifier: breath-weapons
-      advancement: []
-      cover: null
-      crewed: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 700000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 350000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: 1745451452388
-      modifiedTime: 1745451637681
+      systemVersion: 6.0.0
+      createdTime: 1781626622238
+      modifiedTime: 1781626631466
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!VCuG0Z3MrO8kfDU0.kwsQiZZFKo5ZOGB9'
+    _key: '!actors.items!VCuG0Z3MrO8kfDU0.EZt1TGEK0zFWLKn8'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -2135,7 +2306,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171235892

--- a/packs/_source/monsters/dragon/adult-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-copper-dragon.yml
@@ -1647,7 +1647,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1687,7 +1689,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625510965
-      modifiedTime: 1781625510965
+      modifiedTime: 1781897254504
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!irz834sqAxRihtSG.R4O5JcEVUa2e4Ccg'

--- a/packs/_source/monsters/dragon/adult-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-copper-dragon.yml
@@ -489,8 +489,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{mosnter} can use its [[/item
           .kBBFeaEBaGACIQ1b]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .jLzmwSFLsR0jhWHF]]{Bite} and two with its
-          [[/item .rIzRUQvEexZL1wZx]]{Claws}.</p>
+          one with its [[/item .jLzmwSFLsR0jhWHF]]{bite} and two with its
+          [[/item .rIzRUQvEexZL1wZx]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -588,7 +588,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625559259
-      modifiedTime: 1781625573499
+      modifiedTime: 1783370908834
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!irz834sqAxRihtSG.qfV8YlDhXHfI9Uin'
@@ -2010,7 +2010,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .psMedm7VzByFIBBF]]{Tail} attack.</p>
+          .psMedm7VzByFIBBF]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -2040,7 +2040,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625523630
-      modifiedTime: 1781625546924
+      modifiedTime: 1783370914525
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/adult-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-copper-dragon.yml
@@ -960,12 +960,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1131,7 +1132,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625395488
-      modifiedTime: 1781625397570
+      modifiedTime: 1781631932408
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!irz834sqAxRihtSG.kBBFeaEBaGACIQ1b'
@@ -1157,8 +1158,9 @@ items:
           creature can't use reactions, its speed is halved, and it can't make
           more than one attack on its turn. In addition, the creature can use
           either an action or a bonus action on its turn, but not both. These
-          effects last for 1 minute. The creature can repeat the saving throw at
-          the end of each of its turns, ending the effect on itself with a
+          effects last for [[lookup @labels.duration
+          activity=CkPMajPOZWWj3gl0]]. The creature can repeat the saving throw
+          at the end of each of its turns, ending the effect on itself with a
           successful save.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
@@ -1300,9 +1302,10 @@ items:
               creature can't use reactions, its speed is halved, and it can't
               make more than one attack on its turn. In addition, the creature
               can use either an action or a bonus action on its turn, but not
-              both. These effects last for 1 minute. The creature can repeat the
-              saving throw at the end of each of its turns, ending the effect on
-              itself with a successful save.</p>
+              both. These effects last for [[lookup @labels.duration
+              activity=CkPMajPOZWWj3gl0]]. The creature can repeat the saving
+              throw at the end of each of its turns, ending the effect on itself
+              with a successful save.</p>
           duration:
             concentration: false
             value: '1'
@@ -1454,7 +1457,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625401646
-      modifiedTime: 1781625450502
+      modifiedTime: 1781631747662
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!irz834sqAxRihtSG.HsJrAS1hqUisyq9J'

--- a/packs/_source/monsters/dragon/adult-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-copper-dragon.yml
@@ -487,7 +487,7 @@ items:
     system:
       description:
         value: >-
-          <p>The [[lookup @name lowercase]]{mosnter} can use its [[/item
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .kBBFeaEBaGACIQ1b]]{Frightful Presence}. It then makes three attacks:
           one with its [[/item .jLzmwSFLsR0jhWHF]]{bite} and two with its
           [[/item .rIzRUQvEexZL1wZx]]{claws}.</p>
@@ -965,7 +965,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/adult-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-copper-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,115 +478,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
-  - _id: 2WoNMpj7w91Dt4fY
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451762721
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!irz834sqAxRihtSG.2WoNMpj7w91Dt4fY'
   - _id: qfV8YlDhXHfI9Uin
     name: Multiattack
     type: feat
@@ -597,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .3ovBwWW2b9S8LYId]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .jLzmwSFLsR0jhWHF]]{bite} and two with its [[/item
-          .rIzRUQvEexZL1wZx]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{mosnter} can use its [[/item
+          .kBBFeaEBaGACIQ1b]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .jLzmwSFLsR0jhWHF]]{Bite} and two with its
+          [[/item .rIzRUQvEexZL1wZx]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -614,13 +504,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        GxZ2KG0fxbOLbLTG:
           type: utility
           activation:
             type: action
@@ -635,15 +524,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -654,7 +544,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -671,7 +562,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: GxZ2KG0fxbOLbLTG
       enchant: {}
       prerequisites:
         level: null
@@ -685,22 +584,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451771954
+      systemVersion: 6.0.0
+      createdTime: 1781625559259
+      modifiedTime: 1781625573499
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!irz834sqAxRihtSG.qfV8YlDhXHfI9Uin'
   - _id: jLzmwSFLsR0jhWHF
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Copper Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -763,7 +664,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -772,8 +673,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        32rE7dA5tg1Lvuel:
           type: attack
           activation:
             type: action
@@ -788,10 +688,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -808,7 +709,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -821,24 +723,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 32rE7dA5tg1Lvuel
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -848,22 +763,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451771270
+      systemVersion: 6.0.0
+      createdTime: 1781625490552
+      modifiedTime: 1781625504212
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!irz834sqAxRihtSG.jLzmwSFLsR0jhWHF'
   - _id: rIzRUQvEexZL1wZx
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Copper Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -926,7 +843,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -935,8 +852,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        0MEgk8ilop0E7LVg:
           type: attack
           activation:
             type: action
@@ -951,10 +867,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -971,7 +888,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -984,24 +902,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: 0MEgk8ilop0E7LVg
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1011,22 +942,532 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451771270
+      systemVersion: 6.0.0
+      createdTime: 1781625464719
+      modifiedTime: 1781625485638
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!irz834sqAxRihtSG.rIzRUQvEexZL1wZx'
-  - _id: S1RmDd4fOJffOxAy
+  - _id: kBBFeaEBaGACIQ1b
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        2VOmvThI0bGdUsMt:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '120'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781625395488
+          modifiedTime: 1781625395488
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!irz834sqAxRihtSG.kBBFeaEBaGACIQ1b.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 450000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625395488
+      modifiedTime: 1781625397570
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!irz834sqAxRihtSG.kBBFeaEBaGACIQ1b'
+  - _id: HsJrAS1hqUisyq9J
+    name: Breath Weapons
+    type: feat
+    img: icons/magic/acid/projectile-faceted-glob.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Acid Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales acid in an [[lookup
+          @labels.description.template activity=zTWpuajI6meBb52D]]. Each
+          creature in that line must make a [[/save activity=zTWpuajI6meBb52D]]
+          saving throw, taking [[/damage average activity=zTWpuajI6meBb52D]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Slowing Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales gas in a [[lookup
+          @labels.description.template activity=zTWpuajI6meBb52D]]. Each
+          creature in that area must succeed on a [[/save
+          activity=CkPMajPOZWWj3gl0]] saving throw. On a failed save, the
+          creature can't use reactions, its speed is halved, and it can't make
+          more than one attack on its turn. In addition, the creature can use
+          either an action or a bonus action on its turn, but not both. These
+          effects last for 1 minute. The creature can repeat the saving throw at
+          the end of each of its turns, ending the effect on itself with a
+          successful save.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        zTWpuajI6meBb52D:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales acid in an
+              [[lookup @labels.description.template activity=zTWpuajI6meBb52D]].
+              Each creature in that line must make a [[/save
+              activity=zTWpuajI6meBb52D]] saving throw, taking [[/damage average
+              activity=zTWpuajI6meBb52D]] damage on a failed save, or half as
+              much damage on a successful one.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: line
+              size: '60'
+              width: '5'
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 12
+                denomination: 8
+                bonus: ''
+                types:
+                  - acid
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: zTWpuajI6meBb52D
+          name: Acid Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+        CkPMajPOZWWj3gl0:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=zTWpuajI6meBb52D]].
+              Each creature in that area must succeed on a [[/save
+              activity=CkPMajPOZWWj3gl0]] saving throw. On a failed save, the
+              creature can't use reactions, its speed is halved, and it can't
+              make more than one attack on its turn. In addition, the creature
+              can use either an action or a bonus action on its turn, but not
+              both. These effects last for 1 minute. The creature can repeat the
+              saving throw at the end of each of its turns, ending the effect on
+              itself with a successful save.</p>
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: 5E6iveIba4rYeUbc
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '60'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - con
+            dc:
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: CkPMajPOZWWj3gl0
+          name: Slowing Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        repeatable: false
+        items: []
+      identifier: breath-weapons
+      advancement: {}
+      cover: null
+      crewed: false
+    effects:
+      - name: Slowed
+        img: icons/skills/movement/arrow-down-pink.webp
+        origin: Compendium.dnd5e.monsters.Actor.AyvniEKtyroOe83p.Item.XuuhDCc4RQcZOXUL
+        transfer: false
+        _id: 5E6iveIba4rYeUbc
+        type: base
+        system:
+          changes:
+            - key: system.attributes.movement.burrow
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.climb
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.fly
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.swim
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.walk
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are slowed. While slowed, you can't use reactions, your speed
+          is halved, and you can't make more than one attack on your turn. In
+          addition, you can use either an action or a bonus action on your turn,
+          but not both.</p><p>These effects last for 1 minute. You can repeat
+          the saving throw at the end of each of your turns, ending the effect
+          on yourself with a succesful save.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781625401646
+          modifiedTime: 1781625401646
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!irz834sqAxRihtSG.HsJrAS1hqUisyq9J.5E6iveIba4rYeUbc
+    folder: null
+    sort: 550000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625401646
+      modifiedTime: 1781625450502
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!irz834sqAxRihtSG.HsJrAS1hqUisyq9J'
+  - _id: psMedm7VzByFIBBF
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Copper Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1042,7 +1483,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1089,17 +1529,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1114,10 +1552,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1134,9 +1573,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1147,159 +1587,60 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
-    folder: null
-    sort: 400000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 375000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451771270
+      systemVersion: 6.0.0
+      createdTime: 1781625457902
+      modifiedTime: 1781625461313
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!irz834sqAxRihtSG.S1RmDd4fOJffOxAy'
-  - _id: 3ovBwWW2b9S8LYId
-    name: Frightful Presence
-    type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
-    system:
-      description:
-        value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: creature
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '16'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451993106
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!irz834sqAxRihtSG.3ovBwWW2b9S8LYId'
-  - _id: EuIDfrjxsngqBcnD
+    _key: '!actors.items!irz834sqAxRihtSG.psMedm7VzByFIBBF'
+  - _id: R4O5JcEVUa2e4Ccg
     name: Legendary Actions
     type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
@@ -1316,40 +1657,170 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: legendary-actions
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
-    sort: 0
+    folder: 5cwqjeuI64dkrUa8
+    sort: 137500
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451755198
+      systemVersion: 6.0.0
+      createdTime: 1781625510965
+      modifiedTime: 1781625510965
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!irz834sqAxRihtSG.EuIDfrjxsngqBcnD'
-  - _id: WpLmLtkW78JzpUOu
+    _key: '!actors.items!irz834sqAxRihtSG.R4O5JcEVUa2e4Ccg'
+  - _id: ZTiDsxMhrruvvKQ6
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625511657
+      modifiedTime: 1781625511657
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!irz834sqAxRihtSG.ZTiDsxMhrruvvKQ6'
+  - _id: pqagd5goSTbjBWsm
     name: Detect
     type: feat
     img: icons/creatures/eyes/lizard-single-slit-blue.webp
     system:
       description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
       source:
         custom: ''
         book: ''
@@ -1362,166 +1833,105 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
           activation:
             type: legendary
+            override: false
             value: 1
             condition: ''
-            override: false
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
+              type: self
               special: ''
-            prompt: true
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: detect
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
-    sort: 0
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452078710
+      systemVersion: 6.0.0
+      createdTime: 1781625519914
+      modifiedTime: 1781625519914
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!irz834sqAxRihtSG.WpLmLtkW78JzpUOu'
-  - _id: 56yxRgRdOJvr3Hi3
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!irz834sqAxRihtSG.pqagd5goSTbjBWsm'
+  - name: Tail Attack
+    type: feat
+    _id: hh4W4ZNwtCD90kGH
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
-      description:
-        value: <p>The dragon makes a [[/item .S1RmDd4fOJffOxAy]]{tail} attack.</p>
-        chat: <p>The dragon slams its long tail against its foe!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bH5x9SlFErQaWMuP:
           type: utility
           activation:
             type: legendary
@@ -1536,15 +1946,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1555,10 +1966,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1573,117 +1985,69 @@ items:
             prompt: false
             visible: false
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452098276
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!irz834sqAxRihtSG.56yxRgRdOJvr3Hi3'
-  - _id: 4Cf4U7JMFMCyjw7N
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
-    system:
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
       description:
         value: >-
-          <p>The dragon beats its wings. Each creature within 10 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: <p>The dragon beats its wings!</p>
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .psMedm7VzByFIBBF]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
       source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 10
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: simpleM
-        baseItem: ''
-      container: null
+        rules: '2014'
       crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625523630
+      modifiedTime: 1781625546924
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!irz834sqAxRihtSG.hh4W4ZNwtCD90kGH'
+  - name: Wing Attack
+    type: feat
+    _id: HphVvv2raYm2FmQJ
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1698,6 +2062,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1719,6 +2084,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1737,251 +2103,79 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
-          save:
-            ability: dex
-            dc:
-              calculation: str
-              formula: '19'
-          sort: 0
-          name: ''
-          img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: wing-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453116328
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!irz834sqAxRihtSG.4Cf4U7JMFMCyjw7N'
-  - _id: KutCl5ajieFbNaYF
-    name: Breath Weapons
-    type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Acid Breath.</strong> The dragon exhales acid
-          in an 90-foot line that is 10 feet wide. Each creature in that line
-          must make a [[/save activity=zTWpuajI6meBb52D]] saving throw, taking
-          [[/damage average activity=zTWpuajI6meBb52D]] damage on a failed save,
-          or half as much damage on a successful one.</p><p><strong>Slowing
-          Breath.</strong> The dragon exhales gas in a 90-foot cone. Each
-          creature in that area must succeed on a [[/save
-          activity=CkPMajPOZWWj3gl0]] saving throw. On a failed save, the
-          creature can't use reactions, its speed is halved, and it can't make
-          more than one attack on its turn. In addition, the creature can use
-          either an action or a bonus action on its turn, but not both. These
-          effects last for 1 minute. The creature can repeat the saving throw at
-          the end of each of its turns, ending the effect on itself with a
-          successful save.</p>
-        chat: <p>The dragon breathes in!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        zTWpuajI6meBb52D:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: line
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 12
-                denomination: '8'
-                bonus: ''
-                types:
-                  - acid
+                scaling:
+                  number: 1
           save:
             ability:
               - dex
             dc:
-              calculation: ''
+              calculation: str
               formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          _id: zTWpuajI6meBb52D
-          name: Acid Breath
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-        CkPMajPOZWWj3gl0:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability:
-              - con
-            dc:
-              calculation: ''
-              formula: '18'
-          sort: 0
-          _id: CkPMajPOZWWj3gl0
-          name: Slowing Breath
-          img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
+      identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
       enchant: {}
       prerequisites:
-        level: null
+        items: []
         repeatable: false
-      identifier: breath-weapons
-      advancement: []
-      cover: null
-      crewed: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 550000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: 1745451889099
-      modifiedTime: 1745451900816
+      systemVersion: 6.0.0
+      createdTime: 1781625524391
+      modifiedTime: 1781625528012
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!irz834sqAxRihtSG.KutCl5ajieFbNaYF'
+    _key: '!actors.items!irz834sqAxRihtSG.HphVvv2raYm2FmQJ'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1990,7 +2184,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171251400

--- a/packs/_source/monsters/dragon/adult-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-gold-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,161 +478,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
-  - _id: EDuUEVF5kjzG5YQZ
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1745452171993
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!MO382D2sxtAIuUC5.EDuUEVF5kjzG5YQZ'
-  - _id: OFL5IcvfcWfE3Vmp
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 200000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452171993
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!MO382D2sxtAIuUC5.OFL5IcvfcWfE3Vmp'
   - _id: TUvgGNvTgO6MlepM
     name: Multiattack
     type: feat
@@ -643,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .v92F1DGzRWSEMPxH]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .tx5M41t7JlSuVQ9R]]{bite} and two with its [[/item
-          .ORrcO13EbgjVvNjA]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .W6aNcnRIymq6cl2M]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .tx5M41t7JlSuVQ9R]]{Bite} and two with its
+          [[/item .ORrcO13EbgjVvNjA]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -660,13 +504,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        VC4UO1Msee3sYqG4:
           type: utility
           activation:
             type: action
@@ -681,15 +524,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -700,7 +544,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -717,7 +562,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: VC4UO1Msee3sYqG4
       enchant: {}
       prerequisites:
         level: null
@@ -731,22 +584,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452188695
+      systemVersion: 6.0.0
+      createdTime: 1781620431787
+      modifiedTime: 1781620437789
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MO382D2sxtAIuUC5.TUvgGNvTgO6MlepM'
   - _id: tx5M41t7JlSuVQ9R
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Gold Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -809,7 +664,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -818,8 +673,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        CYCyKd3yiMmYWXyh:
           type: attack
           activation:
             type: action
@@ -834,10 +688,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -854,7 +709,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -867,24 +723,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: CYCyKd3yiMmYWXyh
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -894,22 +763,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452188045
+      systemVersion: 6.0.0
+      createdTime: 1781605883251
+      modifiedTime: 1781605893849
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MO382D2sxtAIuUC5.tx5M41t7JlSuVQ9R'
   - _id: ORrcO13EbgjVvNjA
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Gold Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -972,7 +843,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -981,8 +852,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        pDLU2g4oFV2W6xac:
           type: attack
           activation:
             type: action
@@ -997,10 +867,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1017,7 +888,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1030,24 +902,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: pDLU2g4oFV2W6xac
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1057,22 +942,691 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452188045
+      systemVersion: 6.0.0
+      createdTime: 1781605902052
+      modifiedTime: 1781605916375
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MO382D2sxtAIuUC5.ORrcO13EbgjVvNjA'
-  - _id: FXYoii0YU2Y7CqBa
+  - _id: Fyvg74zRJWn05uhK
+    name: Change Shape
+    type: feat
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} magically polymorphs into a
+          humanoid or beast that has a challenge rating no higher than its own,
+          or back into its true form. It reverts to its true form if it dies.
+          Any equipment it is wearing or carrying is absorbed or borne by the
+          new form (the [[lookup @name lowercase]]{monster}'s choice).</p><p>In
+          a new form, the [[lookup @name lowercase]]{monster} retains its
+          alignment, hit points, Hit Dice, ability to speak, proficiencies,
+          Legendary Resistance, lair actions, and Intelligence, Wisdom, and
+          Charisma scores, as well as this action. Its statistics and
+          capabilities are otherwise replaced by those of the new form, except
+          any class features or legendary actions of that form.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} changes its form into a humanoid or
+          beast!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - mgc
+      activities:
+        WgVVVBedNPAgXuDm:
+          type: transform
+          name: Change Shape into Humanoid or Beast
+          _id: WgVVVBedNPAgXuDm
+          img: ''
+          sort: 100000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: false
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: '@details.cr'
+              name: ''
+              _id: hAZbWYsA1wVyGXVn
+              uuid: null
+              sizes: []
+              types:
+                - beast
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings:
+            effects:
+              - all
+            keep:
+              - mental
+              - skills
+              - languages
+              - items
+              - spells
+              - bio
+            preset: polymorph
+            merge: []
+            other: []
+            spellLists: []
+            transformTokens: true
+            minimumAC: ''
+            tempFormula: ''
+          transform:
+            customize: true
+            mode: cr
+            preset: polymorph
+      enchant: {}
+      prerequisites:
+        level: null
+      identifier: change-shape
+    effects: []
+    folder: null
+    sort: 900000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.JsAys4RSGi4lN5Jy
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781619698463
+      modifiedTime: 1781630623442
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!MO382D2sxtAIuUC5.Fyvg74zRJWn05uhK'
+  - _id: tcMcU8C97qfoFwNJ
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 25000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605846981
+      modifiedTime: 1781605859006
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!MO382D2sxtAIuUC5.tcMcU8C97qfoFwNJ'
+  - _id: sK2BoWjS3OuYVHTl
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605853411
+      modifiedTime: 1781605853411
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!MO382D2sxtAIuUC5.sK2BoWjS3OuYVHTl'
+  - _id: r3GJm2ZQCAEk5ODf
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 137500
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605854551
+      modifiedTime: 1781605854551
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!MO382D2sxtAIuUC5.r3GJm2ZQCAEk5ODf'
+  - _id: yAA3vcH0THsoKJfy
+    name: Breath Weapons
+    type: feat
+    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Fire Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=o8fOmWWIqCYwGu3C]]. Each
+          creature in that area must make a [[/save activity=o8fOmWWIqCYwGu3C]]
+          saving throw, taking [[/damage average activity=o8fOmWWIqCYwGu3C]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Weakening Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales gas in a [[lookup
+          @labels.description.template activity=J4QhEMZOdsyIy2D6]]. Each
+          creature in that area must succeed on a [[/save
+          activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+          Strength-based attack rolls, Strength checks, and Strength saving
+          throws for 1 minute. A creature can repeat the saving throw at the end
+          of each of its turns, ending the effect on itself on a success.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        o8fOmWWIqCYwGu3C:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=J4QhEMZOdsyIy2D6]].
+              Each creature in that area must succeed on a [[/save
+              activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+              Strength-based attack rolls, Strength checks, and Strength saving
+              throws for 1 minute. A creature can repeat the saving throw at the
+              end of each of its turns, ending the effect on itself on a
+              success.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '60'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 12
+                denomination: 10
+                bonus: ''
+                types:
+                  - fire
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: o8fOmWWIqCYwGu3C
+          name: Fire Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+        J4QhEMZOdsyIy2D6:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: a5q0M5lHMSOhKxFi
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '60'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - str
+            dc:
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: J4QhEMZOdsyIy2D6
+          name: Weakening Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        repeatable: false
+        items: []
+      identifier: breath-weapons
+      advancement: {}
+      cover: null
+      crewed: false
+    effects:
+      - name: Weakened
+        img: icons/magic/death/hand-withered-gray.webp
+        origin: Compendium.dnd5e.monsters.Actor.naSoHU9KbkgeNIwB.Item.5vCVx0zwz1FKIvTX
+        transfer: false
+        _id: a5q0M5lHMSOhKxFi
+        type: base
+        system:
+          changes:
+            - key: system.abilities.str.save.roll.mode
+              type: add
+              value: -1
+              phase: initial
+              priority: null
+            - key: system.abilities.str.check.roll.mode
+              type: add
+              value: -1
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are weakened. While weakened, you have disadavntage on
+          Strength-based attack rolls, Strength checks, and Strength saving
+          throws for 1 minute. You can repeat the saving throw at the end of
+          each of your turns, ending the effect on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781605871370
+          modifiedTime: 1781605871370
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!MO382D2sxtAIuUC5.yAA3vcH0THsoKJfy.a5q0M5lHMSOhKxFi
+    folder: null
+    sort: 600000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605871370
+      modifiedTime: 1781630329825
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!MO382D2sxtAIuUC5.yAA3vcH0THsoKJfy'
+  - _id: yC56dUP8RQ94wa5t
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Gold Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1088,7 +1642,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1135,17 +1688,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1160,10 +1711,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1180,9 +1732,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1193,60 +1746,78 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
-    folder: null
-    sort: 400000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 350000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452188045
+      systemVersion: 6.0.0
+      createdTime: 1781605878692
+      modifiedTime: 1781605897106
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!MO382D2sxtAIuUC5.FXYoii0YU2Y7CqBa'
-  - _id: v92F1DGzRWSEMPxH
+    _key: '!actors.items!MO382D2sxtAIuUC5.yC56dUP8RQ94wa5t'
+  - _id: W6aNcnRIymq6cl2M
     name: Frightful Presence
     type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
     system:
       description:
         value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
         chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
       source:
         custom: ''
         book: ''
@@ -1259,13 +1830,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        2VOmvThI0bGdUsMt:
           type: save
           activation:
             type: action
@@ -1280,13 +1850,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '120'
             units: ft
@@ -1300,10 +1876,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: any
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1313,198 +1890,107 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
-              calculation: ''
-              formula: '21'
-          sort: 0
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781605923621
+          modifiedTime: 1781605923621
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!MO382D2sxtAIuUC5.W6aNcnRIymq6cl2M.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 425000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452412041
+      systemVersion: 6.0.0
+      createdTime: 1781605923621
+      modifiedTime: 1781605924786
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!MO382D2sxtAIuUC5.v92F1DGzRWSEMPxH'
-  - _id: Fyvg74zRJWn05uhK
-    name: Change Shape
-    type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon magically polymorphs into a humanoid or beast that has a
-          challenge rating no higher than its own, or back into its true form.
-          It reverts to its true form if it dies. Any equipment it is wearing or
-          carrying is absorbed or borne by the new form (the dragon's
-          choice).</p><p>In a new form, the dragon retains its alignment, hit
-          points, Hit Dice, ability to speak, proficiencies, Legendary
-          Resistance, lair actions, and Intelligence, Wisdom, and Charisma
-          scores, as well as this action. Its statistics and capabilities are
-          otherwise replaced by those of the new form, except any class features
-          or legendary actions of that form.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: change-shape
-    effects: []
-    folder: null
-    sort: 900000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.JsAys4RSGi4lN5Jy
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452425569
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!MO382D2sxtAIuUC5.Fyvg74zRJWn05uhK'
-  - _id: RNFCtDcWoF0NAvl2
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452183746
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!MO382D2sxtAIuUC5.RNFCtDcWoF0NAvl2'
-  - _id: QtK9Z8y5x78hUIxF
+    _key: '!actors.items!MO382D2sxtAIuUC5.W6aNcnRIymq6cl2M'
+  - _id: DyLYgvIioxP7vk3a
     name: Detect
     type: feat
     img: icons/creatures/eyes/lizard-single-slit-blue.webp
     system:
       description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
       source:
         custom: ''
         book: ''
@@ -1517,166 +2003,105 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
           activation:
             type: legendary
+            override: false
             value: 1
             condition: ''
-            override: false
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
+              type: self
               special: ''
-            prompt: true
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: detect
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
-    sort: 0
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452451587
+      systemVersion: 6.0.0
+      createdTime: 1781605931976
+      modifiedTime: 1781605931976
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!MO382D2sxtAIuUC5.QtK9Z8y5x78hUIxF'
-  - _id: FehkcXNr3EsmJMif
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!MO382D2sxtAIuUC5.DyLYgvIioxP7vk3a'
+  - name: Tail Attack
+    type: feat
+    _id: jzJmvFRU5XvaTiSc
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
-      description:
-        value: <p>The dragon makes a [[/item .FXYoii0YU2Y7CqBa]]{tail} attack.</p>
-        chat: <p>The dragon slams its long tail against its foe!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: simpleM
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bH5x9SlFErQaWMuP:
           type: utility
           activation:
             type: legendary
@@ -1691,15 +2116,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1710,10 +2136,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1728,116 +2155,69 @@ items:
             prompt: false
             visible: false
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452473373
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!MO382D2sxtAIuUC5.FehkcXNr3EsmJMif'
-  - _id: G0aqIC7Haxea184o
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
-    system:
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
       description:
         value: >-
-          <p>The dragon beats its wings. Each creature within 10 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: <p>The dragon beats its wings!</p>
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .yC56dUP8RQ94wa5t]] attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
       source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 10
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
+        rules: '2014'
       crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605933219
+      modifiedTime: 1781605961360
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!MO382D2sxtAIuUC5.jzJmvFRU5XvaTiSc'
+  - name: Wing Attack
+    type: feat
+    _id: dnubJctJh9euCpmD
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1845,16 +2225,14 @@ items:
             condition: ''
             override: false
           consumption:
-            targets:
-              - type: attribute
-                value: '2'
-                target: resources.legact.value
+            targets: []
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1871,14 +2249,15 @@ items:
             template:
               count: ''
               contiguous: false
-              type: cone
+              type: ''
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: any
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1894,244 +2273,79 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
-                types: []
-          save:
-            ability: dex
-            dc:
-              calculation: str
-              formula: '22'
-          sort: 0
-          name: ''
-          img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: wing-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452539886
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!MO382D2sxtAIuUC5.G0aqIC7Haxea184o'
-  - _id: I0vQvWjLHqwlo6X2
-    name: Breath Weapons
-    type: feat
-    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Fire Breath.</strong> The dragon exhales fire
-          in a 90-foot cone. Each creature in that area must make a [[/save
-          activity=o8fOmWWIqCYwGu3C]] saving throw, taking [[/damage average
-          activity=o8fOmWWIqCYwGu3C]] damage on a failed save, or half as much
-          damage on a successful one.</p><p><strong>Weakening Breath.</strong>
-          The dragon exhales gas in a 90-foot cone. Each creature in that area
-          must succeed on a [[/save activity=J4QhEMZOdsyIy2D6]] saving throw or
-          have disadvantage on Strength-based attack rolls, Strength checks, and
-          Strength saving throws for 1 minute. A creature can repeat the saving
-          throw at the end of each of its turns, ending the effect on itself on
-          a success.</p>
-        chat: <p>The dragon breathes in!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        o8fOmWWIqCYwGu3C:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 12
-                denomination: '10'
-                bonus: ''
                 types:
-                  - fire
+                  - bludgeoning
+                scaling:
+                  number: 1
           save:
             ability:
               - dex
             dc:
-              calculation: ''
-              formula: '21'
+              calculation: str
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          _id: o8fOmWWIqCYwGu3C
-          name: Fire Breath
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-        J4QhEMZOdsyIy2D6:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability:
-              - str
-            dc:
-              calculation: ''
-              formula: '21'
-          sort: 0
-          _id: J4QhEMZOdsyIy2D6
-          name: Weakening Breath
-          img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
+      identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
       enchant: {}
       prerequisites:
-        level: null
+        items: []
         repeatable: false
-      identifier: breath-weapons
-      advancement: []
-      cover: null
-      crewed: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 600000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 350000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: 1745452318160
-      modifiedTime: 1745452331753
+      systemVersion: 6.0.0
+      createdTime: 1781605934304
+      modifiedTime: 1781605950651
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!MO382D2sxtAIuUC5.I0vQvWjLHqwlo6X2'
+    _key: '!actors.items!MO382D2sxtAIuUC5.dnubJctJh9euCpmD'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -2140,7 +2354,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171225451

--- a/packs/_source/monsters/dragon/adult-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-gold-dragon.yml
@@ -1278,7 +1278,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1318,7 +1320,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605854551
-      modifiedTime: 1781605854551
+      modifiedTime: 1781897250023
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MO382D2sxtAIuUC5.r3GJm2ZQCAEk5ODf'

--- a/packs/_source/monsters/dragon/adult-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-gold-dragon.yml
@@ -1822,7 +1822,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/adult-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-gold-dragon.yml
@@ -489,8 +489,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .W6aNcnRIymq6cl2M]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .tx5M41t7JlSuVQ9R]]{Bite} and two with its
-          [[/item .ORrcO13EbgjVvNjA]]{Claws}.</p>
+          one with its [[/item .tx5M41t7JlSuVQ9R]]{bite} and two with its
+          [[/item .ORrcO13EbgjVvNjA]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -588,7 +588,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620431787
-      modifiedTime: 1781620437789
+      modifiedTime: 1783370924487
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MO382D2sxtAIuUC5.TUvgGNvTgO6MlepM'
@@ -2187,7 +2187,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .yC56dUP8RQ94wa5t]] attack.</p>
+          .yC56dUP8RQ94wa5t]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -2217,7 +2217,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605933219
-      modifiedTime: 1781605961360
+      modifiedTime: 1783370934275
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/adult-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-gold-dragon.yml
@@ -1342,8 +1342,9 @@ items:
           creature in that area must succeed on a [[/save
           activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
           Strength-based attack rolls, Strength checks, and Strength saving
-          throws for 1 minute. A creature can repeat the saving throw at the end
-          of each of its turns, ending the effect on itself on a success.</p>
+          throws for [[lookup @labels.duration activity=J4QhEMZOdsyIy2D6]]. A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -1478,7 +1479,15 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-            value: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=J4QhEMZOdsyIy2D6]].
+              Each creature in that area must succeed on a [[/save
+              activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+              Strength-based attack rolls, Strength checks, and Strength saving
+              throws for [[lookup @labels.duration activity=J4QhEMZOdsyIy2D6]].
+              A creature can repeat the saving throw at the end of each of its
+              turns, ending the effect on itself on a success.</p>
           duration:
             concentration: false
             value: '1'
@@ -1613,7 +1622,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605871370
-      modifiedTime: 1781630329825
+      modifiedTime: 1781631495962
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MO382D2sxtAIuUC5.yAA3vcH0THsoKJfy'
@@ -1806,12 +1815,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1977,7 +1987,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605923621
-      modifiedTime: 1781605924786
+      modifiedTime: 1781631923726
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MO382D2sxtAIuUC5.W6aNcnRIymq6cl2M'

--- a/packs/_source/monsters/dragon/adult-green-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-green-dragon.yml
@@ -1150,12 +1150,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1321,7 +1322,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605169516
-      modifiedTime: 1781605170571
+      modifiedTime: 1781631915703
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!GP8JMSDugRxuLOD2.ebLmzTCe2tSvj7KR'

--- a/packs/_source/monsters/dragon/adult-green-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-green-dragon.yml
@@ -490,8 +490,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .ebLmzTCe2tSvj7KR]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .ZJR61a1mg2JHdHE0]]{Bite} and two with its
-          [[/item .I4ycwNCADZj1bun0]]{Claws}.</p>
+          one with its [[/item .ZJR61a1mg2JHdHE0]]{bite} and two with its
+          [[/item .I4ycwNCADZj1bun0]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -589,7 +589,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605259196
-      modifiedTime: 1781605266032
+      modifiedTime: 1783370945333
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!GP8JMSDugRxuLOD2.dhanHpeimPZOKFTP'
@@ -1667,7 +1667,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .1D08FAjBuD5BOnol]]{Tail} attack.</p>
+          .1D08FAjBuD5BOnol]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -1697,7 +1697,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605279424
-      modifiedTime: 1781605306468
+      modifiedTime: 1783370952306
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/adult-green-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-green-dragon.yml
@@ -1155,7 +1155,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/adult-green-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-green-dragon.yml
@@ -2021,7 +2021,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -2061,7 +2063,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605366321
-      modifiedTime: 1781605366321
+      modifiedTime: 1781897245105
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!GP8JMSDugRxuLOD2.UtMWS1CAYJSIPS3n'

--- a/packs/_source/monsters/dragon/adult-green-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-green-dragon.yml
@@ -445,9 +445,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -462,7 +459,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -482,161 +479,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
-  - _id: iSMssiqxkZFEt2ch
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1745449560162
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!GP8JMSDugRxuLOD2.iSMssiqxkZFEt2ch'
-  - _id: dOplnQbE1lIu7Rt8
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 200000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449560162
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!GP8JMSDugRxuLOD2.dOplnQbE1lIu7Rt8'
   - _id: dhanHpeimPZOKFTP
     name: Multiattack
     type: feat
@@ -644,10 +488,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .k9uTT39kBp2sDDUE]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .ZJR61a1mg2JHdHE0]]{bite} and two with its [[/item
-          .I4ycwNCADZj1bun0]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .ebLmzTCe2tSvj7KR]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .ZJR61a1mg2JHdHE0]]{Bite} and two with its
+          [[/item .I4ycwNCADZj1bun0]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -661,13 +505,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        mIf9xHBdVc62IXUH:
           type: utility
           activation:
             type: action
@@ -682,15 +525,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -701,7 +545,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -718,7 +563,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 200000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: mIf9xHBdVc62IXUH
       enchant: {}
       prerequisites:
         level: null
@@ -732,22 +585,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449565860
+      systemVersion: 6.0.0
+      createdTime: 1781605259196
+      modifiedTime: 1781605266032
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!GP8JMSDugRxuLOD2.dhanHpeimPZOKFTP'
   - _id: ZJR61a1mg2JHdHE0
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Green Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -810,7 +665,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -819,8 +674,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        1E0iN6MV1lPPLeBe:
           type: attack
           activation:
             type: action
@@ -835,10 +689,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -855,7 +710,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -868,36 +724,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 6
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 300000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: 1E0iN6MV1lPPLeBe
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -907,22 +774,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449565159
+      systemVersion: 6.0.0
+      createdTime: 1781605095194
+      modifiedTime: 1781605115623
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!GP8JMSDugRxuLOD2.ZJR61a1mg2JHdHE0'
   - _id: I4ycwNCADZj1bun0
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Green Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -985,7 +854,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -994,8 +863,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        LUDSWNEXKz26naBu:
           type: attack
           activation:
             type: action
@@ -1010,10 +878,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1030,7 +899,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1043,24 +913,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: LUDSWNEXKz26naBu
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1070,22 +953,24 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449565159
+      systemVersion: 6.0.0
+      createdTime: 1781605132927
+      modifiedTime: 1781605440755
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!GP8JMSDugRxuLOD2.I4ycwNCADZj1bun0'
-  - _id: HwjAaKkl4iBsFB24
+  - _id: 1D08FAjBuD5BOnol
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Green Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1101,7 +986,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1148,17 +1032,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1173,10 +1055,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1193,9 +1076,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1206,61 +1090,78 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
       mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
     folder: null
-    sort: 400000
+    sort: 450000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449624048
+      systemVersion: 6.0.0
+      createdTime: 1781605151763
+      modifiedTime: 1781605153296
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!GP8JMSDugRxuLOD2.HwjAaKkl4iBsFB24'
-  - _id: k9uTT39kBp2sDDUE
+    _key: '!actors.items!GP8JMSDugRxuLOD2.1D08FAjBuD5BOnol'
+  - _id: ebLmzTCe2tSvj7KR
     name: Frightful Presence
     type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
     system:
       description:
         value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours .</p>
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
         chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
       source:
         custom: ''
         book: ''
@@ -1273,13 +1174,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        2VOmvThI0bGdUsMt:
           type: save
           activation:
             type: action
@@ -1294,16 +1194,22 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '120'
-            units: ''
+            units: ft
             special: ''
             override: false
           target:
@@ -1315,6 +1221,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1327,50 +1234,113 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
-              calculation: ''
+              calculation: cha
               formula: '16'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781605169516
+          modifiedTime: 1781605169516
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!GP8JMSDugRxuLOD2.ebLmzTCe2tSvj7KR.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 550000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449588006
+      systemVersion: 6.0.0
+      createdTime: 1781605169516
+      modifiedTime: 1781605170571
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!GP8JMSDugRxuLOD2.k9uTT39kBp2sDDUE'
-  - _id: WAglSb6wsm8V1iCd
+    _key: '!actors.items!GP8JMSDugRxuLOD2.ebLmzTCe2tSvj7KR'
+  - _id: a3xDshs0j4FSNSo8
     name: Poison Breath
     type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
+    img: icons/skills/toxins/cauldron-bubbles-overflow-green.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales poisonous gas in a 60-foot cone. Each creature
-          in that area must make a [[/save]] saving throw, taking [[/damage
-          average]] damage on a failed save, or half as much damage on a
-          successful one.</p>
+          <p>The [[lookup @name lowercase]]{monster} exhales poisonous gas in a
+          [[lookup @labels.description.template activity=MiNhGAqISi8NVtZa]].
+          Each creature in that area must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
         chat: >-
-          <p>The dragon exhales poisonous gas in a 60-foot cone. Each creature
-          in that area must make a <strong>Constitution</strong> saving
-          throw.</p>
+          <p>The [[lookup @name]]{monster} exhales poisonous gas in a [[lookup
+          @labels.description.template activity=MiNhGAqISi8NVtZa]]. Each
+          creature in that area must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1386,13 +1356,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        MiNhGAqISi8NVtZa:
           type: save
           activation:
             type: action
@@ -1402,17 +1371,16 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1433,9 +1401,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1447,99 +1416,72 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 16
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 16
                 denomination: 6
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
-              calculation: ''
-              formula: '18'
-          sort: 0
+              calculation: con
+              formula: '11'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: MiNhGAqISi8NVtZa
+          name: Exhale Poison
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: poison-breath
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
-    sort: 600000
+    sort: 700000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.JAEclghgOT24pQD9
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449603574
+      systemVersion: 6.0.0
+      createdTime: 1781605195177
+      modifiedTime: 1781605213865
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!GP8JMSDugRxuLOD2.WAglSb6wsm8V1iCd'
-  - _id: jls6tBzceKBhLIJ9
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449560162
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!GP8JMSDugRxuLOD2.jls6tBzceKBhLIJ9'
-  - _id: hj8x2cAmsCz65VMp
+    _key: '!actors.items!GP8JMSDugRxuLOD2.a3xDshs0j4FSNSo8'
+  - _id: 9ot6ZkIpu8tbxeOW
     name: Detect
     type: feat
     img: icons/creatures/eyes/lizard-single-slit-blue.webp
     system:
       description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
       source:
         custom: ''
         book: ''
@@ -1552,166 +1494,105 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
           activation:
             type: legendary
+            override: false
             value: 1
             condition: ''
-            override: false
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
+              type: self
               special: ''
-            prompt: true
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: detect
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
-    sort: 0
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449614908
+      systemVersion: 6.0.0
+      createdTime: 1781605278398
+      modifiedTime: 1781605278398
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!GP8JMSDugRxuLOD2.hj8x2cAmsCz65VMp'
-  - _id: jp6U9gVAnEqYxjal
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!GP8JMSDugRxuLOD2.9ot6ZkIpu8tbxeOW'
+  - name: Tail Attack
+    type: feat
+    _id: KaEnVBhnIhVarfHb
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
-      description:
-        value: <p>The dragon makes a [[/item .HwjAaKkl4iBsFB24]]{tail} attack.</p>
-        chat: <p>The dragon slams its long tail against its foe!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bH5x9SlFErQaWMuP:
           type: utility
           activation:
             type: legendary
@@ -1726,15 +1607,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1745,10 +1627,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1763,117 +1646,69 @@ items:
             prompt: false
             visible: false
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449641756
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!GP8JMSDugRxuLOD2.jp6U9gVAnEqYxjal'
-  - _id: mjuHphDtsXPuLymt
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
-    system:
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
       description:
         value: >-
-          <p>The dragon beats its wings. Each creature within 10 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: <p>The dragon beats its wings!</p>
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .1D08FAjBuD5BOnol]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
       source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 10
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: simpleM
-        baseItem: ''
-      container: null
+        rules: '2014'
       crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605279424
+      modifiedTime: 1781605306468
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!GP8JMSDugRxuLOD2.KaEnVBhnIhVarfHb'
+  - name: Wing Attack
+    type: feat
+    _id: JIdJJzhbgwbd235E
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1888,6 +1723,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1909,6 +1745,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1923,50 +1760,310 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '19'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          name: Flap Wings
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
       identifier: wing-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 300000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453103538
+      systemVersion: 6.0.0
+      createdTime: 1781605280422
+      modifiedTime: 1781605288554
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
+      exportSource: null
+    _key: '!actors.items!GP8JMSDugRxuLOD2.JIdJJzhbgwbd235E'
+  - _id: GulXNndFdgIGNF5f
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605360713
+      modifiedTime: 1781605360713
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!GP8JMSDugRxuLOD2.mjuHphDtsXPuLymt'
+    _key: '!actors.items!GP8JMSDugRxuLOD2.GulXNndFdgIGNF5f'
+  - _id: zsGdaiUrr69pvYWf
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605365224
+      modifiedTime: 1781605365224
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!GP8JMSDugRxuLOD2.zsGdaiUrr69pvYWf'
+  - _id: UtMWS1CAYJSIPS3n
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 600000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605366321
+      modifiedTime: 1781605366321
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!GP8JMSDugRxuLOD2.UtMWS1CAYJSIPS3n'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1975,7 +2072,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171217653

--- a/packs/_source/monsters/dragon/adult-red-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-red-dragon.yml
@@ -1289,12 +1289,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1460,7 +1461,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781604437116
-      modifiedTime: 1781604440280
+      modifiedTime: 1781631908097
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZyIBOoZZD0nDaO2s.ySrfqC410pMPhqpH'

--- a/packs/_source/monsters/dragon/adult-red-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-red-dragon.yml
@@ -1142,7 +1142,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/adult-red-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-red-dragon.yml
@@ -489,8 +489,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .ySrfqC410pMPhqpH]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .060hAjIEDdMDfVoE]]{Bite} and two with its
-          [[/item .pzDFBmC7wfQsMJzw]]{Claws}.</p>
+          one with its [[/item .060hAjIEDdMDfVoE]]{bite} and two with its
+          [[/item .pzDFBmC7wfQsMJzw]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -504,7 +504,7 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -579,7 +579,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781604660441
-      modifiedTime: 1781604660441
+      modifiedTime: 1783370965429
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZyIBOoZZD0nDaO2s.nF4ZHYj37UstHCUT'
@@ -951,160 +951,6 @@ items:
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZyIBOoZZD0nDaO2s.pzDFBmC7wfQsMJzw'
-  - _id: ut9yaZWaSkU7bT1h
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
-    system:
-      description:
-        value: <p>The dragon makes a [[/item .DF0doZR8pYSjsrme]]{tail} attack.</p>
-        chat: <p>The dragon slams its long tail against its foe!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '14.361'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450115842
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ZyIBOoZZD0nDaO2s.ut9yaZWaSkU7bT1h'
   - _id: 6BPWT2E4DlgYUv4m
     name: Legendary Resistance
     type: feat
@@ -1987,7 +1833,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .3AymdEL9N4S8M06R]]{Tail} attack.</p>
+          .3AymdEL9N4S8M06R]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -2017,7 +1863,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781604590346
-      modifiedTime: 1781604613826
+      modifiedTime: 1783370973949
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/adult-red-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-red-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,115 +478,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
-  - _id: MN60UTO1pjltasYN
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450037233
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ZyIBOoZZD0nDaO2s.MN60UTO1pjltasYN'
   - _id: nF4ZHYj37UstHCUT
     name: Multiattack
     type: feat
@@ -597,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .ftqEpCKoioTST72K]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .060hAjIEDdMDfVoE]]{bite} and two with its [[/item
-          .pzDFBmC7wfQsMJzw]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .ySrfqC410pMPhqpH]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .060hAjIEDdMDfVoE]]{Bite} and two with its
+          [[/item .pzDFBmC7wfQsMJzw]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -685,265 +575,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450047796
+      systemVersion: 6.0.0
+      createdTime: 1781604660441
+      modifiedTime: 1781604660441
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZyIBOoZZD0nDaO2s.nF4ZHYj37UstHCUT'
-  - _id: ftqEpCKoioTST72K
-    name: Frightful Presence
-    type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
-    system:
-      description:
-        value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours .</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: creature
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '16'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450067339
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ZyIBOoZZD0nDaO2s.ftqEpCKoioTST72K'
-  - _id: tD8Vmsb4B5eqTOJA
-    name: Fire Breath
-    type: feat
-    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon exhales fire in a 60-foot cone. Each creature in that
-          area must make a [[/save]] saving throw, taking [[/damage average]]
-          damage on a failed save, or half as much damage on a successful
-          one.</p>
-        chat: >-
-          <p>The dragon exhales fire in a 60-foot cone. Each creature in that
-          area must make a <strong>Dexterity</strong> saving throw.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '60'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - number: 18
-                denomination: 6
-                bonus: ''
-                types:
-                  - fire
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          save:
-            ability: dex
-            dc:
-              calculation: ''
-              formula: '21'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: fire-breath
-    effects: []
-    folder: null
-    sort: 600000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.bGSW8IuWURWiWtxr
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450084365
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ZyIBOoZZD0nDaO2s.tD8Vmsb4B5eqTOJA'
   - _id: 060hAjIEDdMDfVoE
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Red Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1006,7 +655,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1015,8 +664,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        gy2zyxW3KtliG5Lr:
           type: attack
           activation:
             type: action
@@ -1031,10 +679,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1051,7 +700,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1064,36 +714,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: gy2zyxW3KtliG5Lr
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -1103,22 +764,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450047031
+      systemVersion: 6.0.0
+      createdTime: 1781604384353
+      modifiedTime: 1781604404488
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZyIBOoZZD0nDaO2s.060hAjIEDdMDfVoE'
   - _id: pzDFBmC7wfQsMJzw
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Red Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1181,7 +844,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1190,8 +853,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        g9BaIe0jiu4SOdkI:
           type: attack
           activation:
             type: action
@@ -1206,10 +868,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1226,7 +889,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1239,24 +903,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: g9BaIe0jiu4SOdkI
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1266,326 +943,14 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450047031
+      systemVersion: 6.0.0
+      createdTime: 1781604411750
+      modifiedTime: 1781604428424
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZyIBOoZZD0nDaO2s.pzDFBmC7wfQsMJzw'
-  - _id: DF0doZR8pYSjsrme
-    name: Tail
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
-    system:
-      description:
-        value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Red Dragon attacks with its Tail.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 15
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 8
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: attack
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '15'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: str
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts: []
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail
-    effects: []
-    folder: null
-    sort: 400000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450047031
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ZyIBOoZZD0nDaO2s.DF0doZR8pYSjsrme'
-  - _id: LESSs8CLEr1DEuLM
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450043265
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ZyIBOoZZD0nDaO2s.LESSs8CLEr1DEuLM'
-  - _id: 1PppVLNAsjADU0Za
-    name: Detect
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: detect
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450095029
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ZyIBOoZZD0nDaO2s.1PppVLNAsjADU0Za'
   - _id: ut9yaZWaSkU7bT1h
     name: Tail Attack
     type: weapon
@@ -1732,7 +1097,7 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -1740,18 +1105,522 @@ items:
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZyIBOoZZD0nDaO2s.ut9yaZWaSkU7bT1h'
-  - _id: Q5JDbGOejqXyeaCj
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
+  - _id: 6BPWT2E4DlgYUv4m
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
     system:
       description:
         value: >-
-          <p>The dragon beats its wings. Each creature within 10 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: <p>The dragon beats its wings!</p>
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604370116
+      modifiedTime: 1781604370116
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ZyIBOoZZD0nDaO2s.6BPWT2E4DlgYUv4m'
+  - _id: WURUdX44H05bcwj8
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 600000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604371006
+      modifiedTime: 1781604371006
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ZyIBOoZZD0nDaO2s.WURUdX44H05bcwj8'
+  - _id: ySrfqC410pMPhqpH
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        2VOmvThI0bGdUsMt:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '120'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781604437116
+          modifiedTime: 1781604437116
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!ZyIBOoZZD0nDaO2s.ySrfqC410pMPhqpH.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 450000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604437116
+      modifiedTime: 1781604440280
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ZyIBOoZZD0nDaO2s.ySrfqC410pMPhqpH'
+  - _id: Ux5JGRZ4jABEO0K9
+    name: Fire Breath
+    type: feat
+    img: icons/magic/fire/flame-burning-earth-orange.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=dN04D22jj4eo1ERu]]. Each
+          creature in that area must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=dN04D22jj4eo1ERu]]. Each
+          creature in that area must make a Dexterity saving throw.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        dN04D22jj4eo1ERu:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '60'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 18
+                denomination: 6
+                bonus: ''
+                types:
+                  - fire
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '13'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: dN04D22jj4eo1ERu
+          name: Exhale Fire
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: fire-breath
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.bGSW8IuWURWiWtxr
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604513870
+      modifiedTime: 1781604530748
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ZyIBOoZZD0nDaO2s.Ux5JGRZ4jABEO0K9'
+  - _id: 3AymdEL9N4S8M06R
+    name: Tail
+    type: weapon
+    img: icons/creatures/abilities/tail-swipe-green.webp
+    system:
+      description:
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1767,7 +1636,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1775,7 +1643,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: 10
+        reach: 15
       uses:
         max: ''
         recovery: []
@@ -1795,7 +1663,7 @@ items:
             formula: ''
         base:
           number: 2
-          denomination: 6
+          denomination: 8
           bonus: ''
           types:
             - bludgeoning
@@ -1814,17 +1682,351 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
+          type: attack
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '15'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: '1'
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          attack:
+            ability: ''
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: ''
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
+      ammunition: {}
+      identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
+    effects: []
+    folder: null
+    sort: 425000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604546496
+      modifiedTime: 1781604548673
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ZyIBOoZZD0nDaO2s.3AymdEL9N4S8M06R'
+  - _id: YDvB5ipqtHrFiCgc
+    name: Detect
+    type: feat
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
+          activation:
+            type: legendary
+            override: false
+            value: 1
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604585161
+      modifiedTime: 1781604585161
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ZyIBOoZZD0nDaO2s.YDvB5ipqtHrFiCgc'
+  - name: Tail Attack
+    type: feat
+    _id: soaNifUtSSuuW6wQ
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
+    system:
+      activities:
+        bH5x9SlFErQaWMuP:
+          type: utility
+          activation:
+            type: legendary
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .3AymdEL9N4S8M06R]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604590346
+      modifiedTime: 1781604613826
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!ZyIBOoZZD0nDaO2s.soaNifUtSSuuW6wQ'
+  - name: Wing Attack
+    type: feat
+    _id: hjyotO2wbcLOvhxW
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
+      activities:
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1839,6 +2041,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1860,6 +2063,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1874,50 +2078,83 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '22'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          name: Flap Wings
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
       identifier: wing-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 300000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453094853
+      systemVersion: 6.0.0
+      createdTime: 1781604591942
+      modifiedTime: 1781604593603
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!ZyIBOoZZD0nDaO2s.Q5JDbGOejqXyeaCj'
+    _key: '!actors.items!ZyIBOoZZD0nDaO2s.hjyotO2wbcLOvhxW'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1926,7 +2163,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171240147

--- a/packs/_source/monsters/dragon/adult-red-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-red-dragon.yml
@@ -1235,7 +1235,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1275,7 +1277,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781604371006
-      modifiedTime: 1781604371006
+      modifiedTime: 1781897240232
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZyIBOoZZD0nDaO2s.WURUdX44H05bcwj8'

--- a/packs/_source/monsters/dragon/adult-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-silver-dragon.yml
@@ -1080,7 +1080,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1120,7 +1122,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781624616310
-      modifiedTime: 1781624616310
+      modifiedTime: 1781897235084
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!geM2F7HvVGhtk3h4.0p695bMn6hbqPcdR'

--- a/packs/_source/monsters/dragon/adult-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-silver-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,115 +478,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
-  - _id: PHDGDBP8gGjp1XRs
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452615620
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!geM2F7HvVGhtk3h4.PHDGDBP8gGjp1XRs'
   - _id: ajPmtUy0amdphs7D
     name: Multiattack
     type: feat
@@ -597,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .F8gfPJkHrrlTwVUs]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .3WM5UpCTIb6fQaWA]]{bite} and two with its [[/item
-          .nO1hKkZifzX3UJ2y]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .6CFNRWnWv0IY4aJC]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .3WM5UpCTIb6fQaWA]]{Bite} and two with its
+          [[/item .nO1hKkZifzX3UJ2y]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -614,13 +504,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        93GHwDNFlQJenoLi:
           type: utility
           activation:
             type: action
@@ -635,15 +524,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -654,7 +544,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -671,7 +562,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 93GHwDNFlQJenoLi
       enchant: {}
       prerequisites:
         level: null
@@ -685,22 +584,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452624565
+      systemVersion: 6.0.0
+      createdTime: 1781624660880
+      modifiedTime: 1781624666037
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!geM2F7HvVGhtk3h4.ajPmtUy0amdphs7D'
   - _id: 3WM5UpCTIb6fQaWA
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Silver Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -724,7 +625,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -762,9 +663,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -773,8 +673,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        oEtxRtj1P38sv7Wl:
           type: attack
           activation:
             type: action
@@ -789,10 +688,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -809,7 +709,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -822,20 +723,32 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: oEtxRtj1P38sv7Wl
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -850,22 +763,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452623801
+      systemVersion: 6.0.0
+      createdTime: 1781624680658
+      modifiedTime: 1781624696851
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!geM2F7HvVGhtk3h4.3WM5UpCTIb6fQaWA'
   - _id: nO1hKkZifzX3UJ2y
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Silver Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -928,7 +843,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -937,8 +852,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        UFkJMHOD2eGruoN4:
           type: attack
           activation:
             type: action
@@ -953,10 +867,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -973,7 +888,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -986,24 +902,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: UFkJMHOD2eGruoN4
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1013,22 +942,198 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452623801
+      systemVersion: 6.0.0
+      createdTime: 1781624712311
+      modifiedTime: 1781624911795
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!geM2F7HvVGhtk3h4.nO1hKkZifzX3UJ2y'
-  - _id: v5TMyixZTtiw13d7
+  - _id: V72vh5ksH4SKfgcd
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781624615239
+      modifiedTime: 1781624615239
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!geM2F7HvVGhtk3h4.V72vh5ksH4SKfgcd'
+  - _id: 0p695bMn6hbqPcdR
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 137500
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781624616310
+      modifiedTime: 1781624616310
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!geM2F7HvVGhtk3h4.0p695bMn6hbqPcdR'
+  - _id: ftKGptLQwbS0SJC3
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult Silver Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1044,7 +1149,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1091,17 +1195,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1116,10 +1218,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1136,9 +1239,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1149,60 +1253,78 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
-    folder: null
-    sort: 400000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 350000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452623801
+      systemVersion: 6.0.0
+      createdTime: 1781624617442
+      modifiedTime: 1781624706557
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!geM2F7HvVGhtk3h4.v5TMyixZTtiw13d7'
-  - _id: F8gfPJkHrrlTwVUs
+    _key: '!actors.items!geM2F7HvVGhtk3h4.ftKGptLQwbS0SJC3'
+  - _id: 6CFNRWnWv0IY4aJC
     name: Frightful Presence
     type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
     system:
       description:
         value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
         chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
       source:
         custom: ''
         book: ''
@@ -1215,13 +1337,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        2VOmvThI0bGdUsMt:
           type: save
           activation:
             type: action
@@ -1236,13 +1357,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '120'
             units: ft
@@ -1257,6 +1384,348 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781624618579
+          modifiedTime: 1781624618579
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!geM2F7HvVGhtk3h4.6CFNRWnWv0IY4aJC.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 550000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781624618579
+      modifiedTime: 1781624619961
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!geM2F7HvVGhtk3h4.6CFNRWnWv0IY4aJC'
+  - _id: XXb4suGM31oicyau
+    name: Change Shape
+    type: feat
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} magically polymorphs into a
+          humanoid or beast that has a challenge rating no higher than its own,
+          or back into its true form. It reverts to its true form if it dies.
+          Any equipment it is wearing or carrying is absorbed or borne by the
+          new form (the [[lookup @name lowercase]]{monster}'s choice).</p><p>In
+          a new form, the [[lookup @name lowercase]]{monster} retains its
+          alignment, hit points, Hit Dice, ability to speak, proficiencies,
+          Legendary Resistance, lair actions, and Intelligence, Wisdom, and
+          Charisma scores, as well as this action. Its statistics and
+          capabilities are otherwise replaced by those of the new form, except
+          any class features or legendary actions of that form.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} changes its form into a humanoid or
+          beast!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - mgc
+      activities:
+        WgVVVBedNPAgXuDm:
+          type: transform
+          name: Change Shape into Humanoid or Beast
+          _id: WgVVVBedNPAgXuDm
+          img: ''
+          sort: 100000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: false
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: '@details.cr'
+              name: ''
+              _id: hAZbWYsA1wVyGXVn
+              uuid: null
+              sizes: []
+              types:
+                - beast
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings:
+            effects:
+              - all
+            keep:
+              - mental
+              - skills
+              - languages
+              - items
+              - spells
+              - bio
+            preset: polymorph
+            merge: []
+            other: []
+            spellLists: []
+            transformTokens: true
+            minimumAC: ''
+            tempFormula: ''
+          transform:
+            customize: true
+            mode: cr
+            preset: polymorph
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: change-shape
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 750000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.MO382D2sxtAIuUC5.Item.Fyvg74zRJWn05uhK
+      duplicateSource: Item.gfURBnJDJatlzDXj
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781624625818
+      modifiedTime: 1781630648655
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!geM2F7HvVGhtk3h4.XXb4suGM31oicyau'
+  - _id: zyGeyMoiSCtULHw6
+    name: Breath Weapons
+    type: feat
+    img: icons/creatures/abilities/dragon-ice-breath-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Cold Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales an icy blast in a [[lookup
+          @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
+          creature in that area must make a [[/save activity=U5F5qe2Hu0r0yHmk]]
+          saving throw, taking [[/damage average activity=U5F5qe2Hu0r0yHmk]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Paralyzing Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales paralyzing gas in a [[lookup
+          @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
+          creature in that area must succeed on a [[/save
+          activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for 1 minute.
+          A creature can repeat the saving throw at the end of each of its
+          turns, ending the effect on itself on a success.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        U5F5qe2Hu0r0yHmk:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales an icy blast in
+              a [[lookup @labels.description.labels activity=9gMvqjbgKK42uyzr]].
+              Each creature in that area must make a [[/save
+              activity=U5F5qe2Hu0r0yHmk]] saving throw, taking [[/damage average
+              activity=U5F5qe2Hu0r0yHmk]] damage on a failed save, or half as
+              much damage on a successful one.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '60'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1270,109 +1739,94 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts: []
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 13
+                denomination: 8
+                bonus: ''
+                types:
+                  - cold
+                scaling:
+                  number: 1
           save:
-            ability: wis
+            ability:
+              - con
             dc:
-              calculation: ''
-              formula: '18'
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
           sort: 0
-          name: ''
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452817424
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!geM2F7HvVGhtk3h4.F8gfPJkHrrlTwVUs'
-  - _id: 4NQZ8XlRj6sbjbOs
-    name: Change Shape
-    type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon magically polymorphs into a humanoid or beast that has a
-          challenge rating no higher than its own, or back into its true form.
-          It reverts to its true form if it dies. Any equipment it is wearing or
-          carrying is absorbed or borne by the new form (the dragon's
-          choice).</p><p>In a new form, the dragon retains its alignment, hit
-          points, Hit Dice, ability to speak, proficiencies, Legendary
-          Resistance, lair actions, and Intelligence, Wisdom, and Charisma
-          scores, as well as this action. Its statistics and capabilities are
-          otherwise replaced by those of the new form, except any class features
-          or legendary actions of that form.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+          _id: U5F5qe2Hu0r0yHmk
+          name: Cold Breath
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+        9gMvqjbgKK42uyzr:
+          type: save
           activation:
             type: action
             value: 1
             condition: ''
             override: false
           consumption:
-            targets: []
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales paralyzing gas
+              in a [[lookup @labels.description.template
+              activity=9gMvqjbgKK42uyzr]]. Each creature in that area must
+              succeed on a [[/save activity=9gMvqjbgKK42uyzr]] saving throw or
+              be paralyzed for 1 minute. A creature can repeat the saving throw
+              at the end of each of its turns, ending the effect on itself on a
+              success.</p>
           duration:
             concentration: false
-            value: ''
-            units: ''
+            value: '1'
+            units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: yYbmtst3L1jGwwbF
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
             template:
               count: ''
               contiguous: false
-              type: ''
-              size: ''
+              type: cone
+              size: '60'
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1381,91 +1835,107 @@ items:
             spent: 0
             max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - con
+            dc:
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
           sort: 0
+          _id: 9gMvqjbgKK42uyzr
+          name: Paralyzing Breath
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
       enchant: {}
       prerequisites:
         level: null
-      identifier: change-shape
-    effects: []
+        repeatable: false
+        items: []
+      identifier: breath-weapons
+      advancement: {}
+      cover: null
+      crewed: false
+    effects:
+      - name: Paralyzing Breath
+        img: icons/magic/control/debuff-chains-shackles-movement-purple.webp
+        origin: Compendium.dnd5e.monsters.Actor.J1QVPd8POvcPaqx4.Item.ENcwNUKxDAqH6V9l
+        transfer: false
+        _id: yYbmtst3L1jGwwbF
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[paralyzed apply=false] for 1 minute. You can
+          repeat the saving throw at the end of each of your turns, ending the
+          effect on yourself.</p>
+        tint: '#ffffff'
+        statuses:
+          - paralyzed
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781624933720
+          modifiedTime: 1781624933720
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!geM2F7HvVGhtk3h4.zyGeyMoiSCtULHw6.yYbmtst3L1jGwwbF
     folder: null
-    sort: 900000
+    sort: 600000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.JsAys4RSGi4lN5Jy
+      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452834439
+      systemVersion: 6.0.0
+      createdTime: 1781624933720
+      modifiedTime: 1781624963165
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!geM2F7HvVGhtk3h4.4NQZ8XlRj6sbjbOs'
-  - _id: lslg4XVihVKQhwte
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon can take 3 legendary actions. Only one legendary action
-          option can be used at a time and only at the end of another creature's
-          turn. The dragon regains spent legendary actions at the start of its
-          turn.</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.2.0
-      createdTime: null
-      modifiedTime: 1736804677027
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!geM2F7HvVGhtk3h4.lslg4XVihVKQhwte'
-  - _id: uqanvb4CeQp0bdn3
+    _key: '!actors.items!geM2F7HvVGhtk3h4.zyGeyMoiSCtULHw6'
+  - _id: rIVKpPu8DgBY0UND
     name: Detect
     type: feat
     img: icons/creatures/eyes/lizard-single-slit-blue.webp
     system:
       description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
       source:
         custom: ''
         book: ''
@@ -1478,162 +1948,105 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
           activation:
             type: legendary
+            override: false
             value: 1
             condition: ''
-            override: false
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
+              type: self
               special: ''
-            prompt: true
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: detect
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
-    sort: 0
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.2.0
-      createdTime: null
-      modifiedTime: 1745452780935
+      systemVersion: 6.0.0
+      createdTime: 1781625012212
+      modifiedTime: 1781625012212
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!geM2F7HvVGhtk3h4.uqanvb4CeQp0bdn3'
-  - _id: 1OojtcMLidFnfuTi
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!geM2F7HvVGhtk3h4.rIVKpPu8DgBY0UND'
+  - name: Tail Attack
+    type: feat
+    _id: w953qJLkouOiob82
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
-      description:
-        value: <p>The dragon makes a [[/item .v5TMyixZTtiw13d7]]{tail} attack.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bH5x9SlFErQaWMuP:
           type: utility
           activation:
             type: legendary
@@ -1648,15 +2061,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1667,10 +2081,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1685,115 +2100,69 @@ items:
             prompt: false
             visible: false
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .ftKGptLQwbS0SJC3]] attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
       identifier: tail-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 100000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 150000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452871657
+      systemVersion: 6.0.0
+      createdTime: 1781625013543
+      modifiedTime: 1781625035838
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
       exportSource: null
-    _key: '!actors.items!geM2F7HvVGhtk3h4.1OojtcMLidFnfuTi'
-  - _id: CdSoAS13rAlkBKI7
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
+    _key: '!actors.items!geM2F7HvVGhtk3h4.w953qJLkouOiob82'
+  - name: Wing Attack
+    type: feat
+    _id: owMrPj4m3vzs55yN
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
     system:
-      description:
-        value: "<p>The dragon beats its wings. Each creature within\_10 feet of the dragon must succeed on a\_[[/save]] saving throw\_or take\_[[/damage average]]\_damage and be knocked &amp;Reference[prone]. The dragon can then fly up to half its flying speed.</p>"
-        chat: >-
-          <p>The dragon beats its wings! Each creature within 10 feet of the
-          dragon must make a <strong>Dexterity</strong> saving throw.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 10
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: simpleM
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1801,16 +2170,14 @@ items:
             condition: ''
             override: false
           consumption:
-            targets:
-              - type: attribute
-                value: '2'
-                target: resources.legact.value
+            targets: []
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1832,6 +2199,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1850,247 +2218,79 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '21'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: wing-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452946170
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!geM2F7HvVGhtk3h4.CdSoAS13rAlkBKI7'
-  - _id: q62u3dzMO1jzW24i
-    name: Breath Weapons
-    type: feat
-    img: icons/creatures/abilities/dragon-ice-breath-blue.webp
-    system:
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Cold Breath.</strong> The dragon exhales an icy
-          blast in a 90-foot cone. Each creature in that area must make a
-          [[/save activity=U5F5qe2Hu0r0yHmk]] saving throw, taking [[/damage
-          average activity=U5F5qe2Hu0r0yHmk]] damage on a failed save, or half
-          as much damage on a successful one.</p><p><strong>Paralyzing
-          Breath.</strong> The dragon exhales paralyzing gas in a 90- foot cone.
-          Each creature in that area must succeed on a [[/save
-          activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for 1 minute.
-          A creature can repeat the saving throw at the end of each of its
-          turns, ending the effect on itself on a success.</p>
-        chat: <p>The dragon breathes in!</p>
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
+      identifier: wing-attack
       source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
         revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        U5F5qe2Hu0r0yHmk:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 13
-                denomination: '8'
-                bonus: ''
-                types:
-                  - cold
-          save:
-            ability:
-              - con
-            dc:
-              calculation: ''
-              formula: '20'
-          sort: 0
-          _id: U5F5qe2Hu0r0yHmk
-          name: Cold Breath
-          img: ''
-          appliedEffects: []
-        9gMvqjbgKK42uyzr:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability:
-              - con
-            dc:
-              calculation: ''
-              formula: '20'
-          sort: 0
-          _id: 9gMvqjbgKK42uyzr
-          name: Paralyzing Breath
-          img: ''
-          appliedEffects: []
+        rules: '2014'
+      crewed: false
       enchant: {}
       prerequisites:
-        level: null
+        items: []
         repeatable: false
-      identifier: breath-weapons
-      advancement: []
-      cover: null
-      crewed: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 600000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 200000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: 1745452710032
-      modifiedTime: 1745452727596
+      systemVersion: 6.0.0
+      createdTime: 1781625015041
+      modifiedTime: 1781625015041
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!geM2F7HvVGhtk3h4.q62u3dzMO1jzW24i'
+    _key: '!actors.items!geM2F7HvVGhtk3h4.owMrPj4m3vzs55yN'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -2099,7 +2299,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171248116

--- a/packs/_source/monsters/dragon/adult-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-silver-dragon.yml
@@ -1870,7 +1870,7 @@ items:
       crewed: false
     effects:
       - name: Paralyzing Breath
-        img: icons/magic/control/debuff-chains-shackles-movement-purple.webp
+        img: icons/magic/unholy/energy-smoke-pink.webp
         origin: Compendium.dnd5e.monsters.Actor.J1QVPd8POvcPaqx4.Item.ENcwNUKxDAqH6V9l
         transfer: false
         _id: yYbmtst3L1jGwwbF
@@ -1903,7 +1903,7 @@ items:
           systemId: dnd5e
           systemVersion: 6.0.0
           createdTime: 1781624933720
-          modifiedTime: 1781624933720
+          modifiedTime: 1781631006428
           lastModifiedBy: dnd5ebuilder0000
           compendiumSource: null
           duplicateSource: null

--- a/packs/_source/monsters/dragon/adult-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-silver-dragon.yml
@@ -1320,7 +1320,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/adult-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-silver-dragon.yml
@@ -489,8 +489,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .6CFNRWnWv0IY4aJC]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .3WM5UpCTIb6fQaWA]]{Bite} and two with its
-          [[/item .nO1hKkZifzX3UJ2y]]{Claws}.</p>
+          one with its [[/item .3WM5UpCTIb6fQaWA]]{bite} and two with its
+          [[/item .nO1hKkZifzX3UJ2y]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -588,7 +588,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781624660880
-      modifiedTime: 1781624666037
+      modifiedTime: 1783370991003
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!geM2F7HvVGhtk3h4.ajPmtUy0amdphs7D'
@@ -2125,7 +2125,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .ftKGptLQwbS0SJC3]] attack.</p>
+          .ftKGptLQwbS0SJC3]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -2155,7 +2155,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625013543
-      modifiedTime: 1781625035838
+      modifiedTime: 1783371002239
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/adult-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-silver-dragon.yml
@@ -1313,12 +1313,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1484,7 +1485,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781624618579
-      modifiedTime: 1781624619961
+      modifiedTime: 1781631898558
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!geM2F7HvVGhtk3h4.6CFNRWnWv0IY4aJC'
@@ -1655,9 +1656,10 @@ items:
           lowercase]]{monster} exhales paralyzing gas in a [[lookup
           @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
           creature in that area must succeed on a [[/save
-          activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for 1 minute.
-          A creature can repeat the saving throw at the end of each of its
-          turns, ending the effect on itself on a success.</p>
+          activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for [[lookup
+          @labels.duration activity=9gMvqjbgKK42uyzr]]. A creature can repeat
+          the saving throw at the end of each of its turns, ending the effect on
+          itself on a success.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -1795,9 +1797,10 @@ items:
               in a [[lookup @labels.description.template
               activity=9gMvqjbgKK42uyzr]]. Each creature in that area must
               succeed on a [[/save activity=9gMvqjbgKK42uyzr]] saving throw or
-              be paralyzed for 1 minute. A creature can repeat the saving throw
-              at the end of each of its turns, ending the effect on itself on a
-              success.</p>
+              be paralyzed for [[lookup @labels.duration
+              activity=9gMvqjbgKK42uyzr]]. A creature can repeat the saving
+              throw at the end of each of its turns, ending the effect on itself
+              on a success.</p>
           duration:
             concentration: false
             value: '1'
@@ -1922,7 +1925,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781624933720
-      modifiedTime: 1781624963165
+      modifiedTime: 1781631660468
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!geM2F7HvVGhtk3h4.zyGeyMoiSCtULHw6'

--- a/packs/_source/monsters/dragon/adult-white-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-white-dragon.yml
@@ -1356,12 +1356,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1527,7 +1528,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567037862
-      modifiedTime: 1781567699043
+      modifiedTime: 1781631889473
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!3uIursokd3KdZrW3.vln3DAK5YQJNWMty'

--- a/packs/_source/monsters/dragon/adult-white-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-white-dragon.yml
@@ -862,8 +862,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .vln3DAK5YQJNWMty]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .542eNLhAx7XYJErk]]{Bite} and two with its
-          [[/item .FhUOX8awKhQrGBV0]]{Claws}.</p>
+          one with its [[/item .542eNLhAx7XYJErk]]{bite} and two with its
+          [[/item .FhUOX8awKhQrGBV0]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -961,7 +961,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567169769
-      modifiedTime: 1781567338459
+      modifiedTime: 1783371015964
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!3uIursokd3KdZrW3.QAzUtpWvNd9ptDjZ'
@@ -1902,7 +1902,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .IeP7mvMvXOk8NIEP]]{Tail} attack.</p>
+          .IeP7mvMvXOk8NIEP]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -1932,7 +1932,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567084274
-      modifiedTime: 1781567107374
+      modifiedTime: 1783371023569
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/adult-white-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-white-dragon.yml
@@ -1662,7 +1662,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1702,7 +1704,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567048390
-      modifiedTime: 1781567048390
+      modifiedTime: 1781897228391
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!3uIursokd3KdZrW3.0S3XhpXG7dTpH3gQ'

--- a/packs/_source/monsters/dragon/adult-white-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-white-dragon.yml
@@ -72,6 +72,11 @@ system:
       walk: 40
       units: ft
       hover: false
+      bonus: ''
+      ignoredDifficultTerrain:
+        - ice
+        - snow
+      special: ''
     attunement:
       max: 3
     senses:
@@ -444,9 +449,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +463,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,15 +483,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
   - _id: 542eNLhAx7XYJErk
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult White Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -552,7 +557,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -561,8 +566,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        9nwGbnNd9m6Tii4H:
           type: attack
           activation:
             type: action
@@ -577,10 +581,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -597,7 +602,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -610,36 +616,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 8
                 bonus: ''
                 types:
                   - cold
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 9nwGbnNd9m6Tii4H
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -649,22 +666,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450373179
+      systemVersion: 6.0.0
+      createdTime: 1781567010549
+      modifiedTime: 1781567024900
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!3uIursokd3KdZrW3.542eNLhAx7XYJErk'
   - _id: FhUOX8awKhQrGBV0
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult White Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -727,7 +746,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -736,8 +755,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        WWvJGNtFT8ptAa4p:
           type: attack
           activation:
             type: action
@@ -752,10 +770,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -772,7 +791,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -785,24 +805,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: WWvJGNtFT8ptAa4p
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -812,28 +845,197 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450373179
+      systemVersion: 6.0.0
+      createdTime: 1781566974558
+      modifiedTime: 1781567006215
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!3uIursokd3KdZrW3.FhUOX8awKhQrGBV0'
-  - _id: lQ57BVbUiVe2tJcL
-    name: Cold Breath
+  - _id: QAzUtpWvNd9ptDjZ
+    name: Multiattack
     type: feat
-    img: icons/creatures/abilities/dragon-ice-breath-blue.webp
+    img: icons/skills/melee/blade-tips-triple-steel.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales an icy blast in a 60-foot cone. Each creature in
-          that area must make a [[/save]] saving throw, taking [[/damage
-          average]] damage on a failed save, or half as much damage on a
-          successful one.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .vln3DAK5YQJNWMty]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .542eNLhAx7XYJErk]]{Bite} and two with its
+          [[/item .FhUOX8awKhQrGBV0]]{Claws}.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        4uVdT50I0B5iSUOI:
+          type: utility
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 200000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 4uVdT50I0B5iSUOI
+      enchant: {}
+      prerequisites:
+        level: null
+      identifier: multiattack
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567169769
+      modifiedTime: 1781567338459
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!3uIursokd3KdZrW3.QAzUtpWvNd9ptDjZ'
+  - _id: xlZuzbYZtDVFGyVz
+    name: Ice Walk
+    type: feat
+    img: icons/magic/water/water-iceberg-bubbles.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can move across and climb
+          icy surfaces without needing to make an ability check. Additionally,
+          &amp;reference[difficult terrain] composed of ice or snow doesn't cost
+          it extra movement.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: ice-walk
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.YKC7pwYkJSKn1vuw
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781566899982
+      modifiedTime: 1781566899983
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!3uIursokd3KdZrW3.xlZuzbYZtDVFGyVz'
+  - _id: BvB2dSi53xjWSnaF
+    name: Cold Breath
+    type: feat
+    img: icons/magic/water/projectile-ice-orb-white.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} exhales an icy blast of
+          hail in a [[lookup @labels.description.template
+          activity=UF4fJlhyYiLM7XeM]]. Each creature in that area must make a
+          [[/save]] saving throw, taking [[/damage average]] damage on a failed
+          save, or half as much damage on a successful one.</p>
         chat: >-
-          <p>The dragon exhales an icy blast in a 60-foot cone. Each creature in
-          that area must make a <strong>Constitution</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} exhales an icy blast of hail in a
+          [[lookup @labels.description.template activity=UF4fJlhyYiLM7XeM]].
+          Each creature in that area must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -854,8 +1056,7 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        UF4fJlhyYiLM7XeM:
           type: save
           activation:
             type: action
@@ -865,17 +1066,16 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -896,234 +1096,7 @@ items:
               width: ''
               height: ''
               units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - number: 12
-                denomination: 8
-                bonus: ''
-                types: []
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          save:
-            ability: con
-            dc:
-              calculation: ''
-              formula: '19'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: cold-breath
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.iHOaiOqwUWIfCljJ
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450407026
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!3uIursokd3KdZrW3.lQ57BVbUiVe2tJcL'
-  - _id: CwDVyMam0aPSvRyx
-    name: Detect
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: detect
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450418300
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!3uIursokd3KdZrW3.CwDVyMam0aPSvRyx'
-  - _id: nKX7IFrwLJsAsWXU
-    name: Frightful Presence
-    type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
-    system:
-      description:
-        value: >-
-          <p>Each creature of the dragon's choice that is within 120 ft. of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1137,349 +1110,73 @@ items:
             recovery: []
           damage:
             onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '14'
-          sort: 0
-          name: ''
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 450000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450391081
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!3uIursokd3KdZrW3.nKX7IFrwLJsAsWXU'
-  - _id: FeXPnKNku7x5oGMv
-    name: Ice Walk
-    type: feat
-    img: icons/magic/water/water-iceberg-bubbles.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon can move across and climb icy surfaces without needing
-          to make an ability check. Additionally, difficult terrain composed of
-          ice or snow doesn't cost it extra movement.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: ice-walk
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.YKC7pwYkJSKn1vuw
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1745450364519
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!3uIursokd3KdZrW3.FeXPnKNku7x5oGMv'
-  - _id: 7JtKHjp4ib2tL3Qu
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450369833
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!3uIursokd3KdZrW3.7JtKHjp4ib2tL3Qu'
-  - _id: 2TDIeRNe4vEJPgi6
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
+            parts:
+              - custom:
+                  enabled: false
                   formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+                number: 12
+                denomination: 8
+                bonus: ''
+                types:
+                  - cold
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - con
+            dc:
+              calculation: con
+              formula: '12'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: UF4fJlhyYiLM7XeM
+          name: Exhale Ice
       enchant: {}
       prerequisites:
         level: null
-      identifier: legendary-resistance
+        items: []
+        repeatable: false
+      identifier: cold-breath
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
-    sort: 200000
+    sort: 500000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
+      compendiumSource: Compendium.dnd5e.monsterfeatures.iHOaiOqwUWIfCljJ
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450364519
+      systemVersion: 6.0.0
+      createdTime: 1781566907511
+      modifiedTime: 1781566936044
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!3uIursokd3KdZrW3.2TDIeRNe4vEJPgi6'
-  - _id: QAzUtpWvNd9ptDjZ
-    name: Multiattack
-    type: feat
-    img: icons/skills/melee/blade-tips-triple-steel.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon can use its [[/item .nKX7IFrwLJsAsWXU]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .542eNLhAx7XYJErk]]{bite} and two with its [[/item
-          .FhUOX8awKhQrGBV0]]{claws}.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: multiattack
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450373973
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!3uIursokd3KdZrW3.QAzUtpWvNd9ptDjZ'
-  - _id: pwOLYvuj5c9fEQAH
+    _key: '!actors.items!3uIursokd3KdZrW3.BvB2dSi53xjWSnaF'
+  - _id: IeP7mvMvXOk8NIEP
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Adult White Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1495,7 +1192,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1542,17 +1238,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1567,10 +1261,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1587,9 +1282,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1600,50 +1296,78 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
       mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
     folder: null
-    sort: 400000
+    sort: 425000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450425978
+      systemVersion: 6.0.0
+      createdTime: 1781566960502
+      modifiedTime: 1781566962008
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!3uIursokd3KdZrW3.pwOLYvuj5c9fEQAH'
-  - _id: 6HVXfjsMra3fHVLb
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!3uIursokd3KdZrW3.IeP7mvMvXOk8NIEP'
+  - _id: vln3DAK5YQJNWMty
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
     system:
       description:
-        value: <p>The dragon makes a [[/item .pwOLYvuj5c9fEQAH]]{tail} attack.</p>
-        chat: ''
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
       source:
         custom: ''
         book: ''
@@ -1651,71 +1375,20 @@ items:
         license: CC-BY-4.0
         rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
       uses:
         max: ''
         recovery: []
         spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
       type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        2VOmvThI0bGdUsMt:
+          type: save
           activation:
-            type: legendary
+            type: action
             value: 1
             condition: ''
             override: false
@@ -1727,15 +1400,22 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
-            value: ''
-            units: ''
+            value: '1'
+            units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
-            units: ''
+            value: '120'
+            units: ft
             special: ''
             override: false
           target:
@@ -1746,10 +1426,184 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: any
+              stationary: false
             affects:
               count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781567037862
+          modifiedTime: 1781567037862
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!3uIursokd3KdZrW3.vln3DAK5YQJNWMty.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 475000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567037862
+      modifiedTime: 1781567699043
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!3uIursokd3KdZrW3.vln3DAK5YQJNWMty'
+  - _id: loP59tfIHunnBXVU
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
               type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1764,44 +1618,50 @@ items:
             prompt: false
             visible: false
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
-    sort: 100000
+    sort: 500000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450439805
+      systemVersion: 6.0.0
+      createdTime: 1781567047349
+      modifiedTime: 1781567047349
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!3uIursokd3KdZrW3.6HVXfjsMra3fHVLb'
-  - _id: dEBTjqEC02PwvqOV
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
+    _key: '!actors.items!3uIursokd3KdZrW3.loP59tfIHunnBXVU'
+  - _id: 0S3XhpXG7dTpH3gQ
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
     system:
       description:
-        value: >-
-          <p>The dragon beats its wings. Each creature within 10 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: <p>The dragon beats its wings!</p>
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
       source:
         custom: ''
         book: ''
@@ -1809,72 +1669,279 @@ items:
         license: CC-BY-4.0
         rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 10
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 600000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567048390
+      modifiedTime: 1781567048390
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!3uIursokd3KdZrW3.0S3XhpXG7dTpH3gQ'
+  - _id: YCXSWL2hnjYZ1MQP
+    name: Detect
+    type: feat
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
       uses:
         max: ''
         recovery: []
         spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
       type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
+          activation:
+            type: legendary
+            override: false
+            value: 1
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567077294
+      modifiedTime: 1781567077294
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!3uIursokd3KdZrW3.YCXSWL2hnjYZ1MQP'
+  - name: Tail Attack
+    type: feat
+    _id: HMzzjybHZXGMQ4FJ
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
+    system:
+      activities:
+        bH5x9SlFErQaWMuP:
+          type: utility
+          activation:
+            type: legendary
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .IeP7mvMvXOk8NIEP]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567084274
+      modifiedTime: 1781567107374
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!3uIursokd3KdZrW3.HMzzjybHZXGMQ4FJ'
+  - name: Wing Attack
+    type: feat
+    _id: wrwCK6PkwJMQ6e1g
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
+      activities:
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1882,16 +1949,14 @@ items:
             condition: ''
             override: false
           consumption:
-            targets:
-              - type: attribute
-                value: '2'
-                target: resources.legact.value
+            targets: []
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1913,6 +1978,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1931,45 +1997,79 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '19'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
       identifier: wing-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 300000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453079175
+      systemVersion: 6.0.0
+      createdTime: 1781567122624
+      modifiedTime: 1781567124712
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!3uIursokd3KdZrW3.dEBTjqEC02PwvqOV'
+    _key: '!actors.items!3uIursokd3KdZrW3.wrwCK6PkwJMQ6e1g'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1978,11 +2078,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 6.0.0
   createdTime: 1726171201211
-  modifiedTime: 1745450466317
+  modifiedTime: 1781567071169
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!3uIursokd3KdZrW3'

--- a/packs/_source/monsters/dragon/adult-white-dragon.yml
+++ b/packs/_source/monsters/dragon/adult-white-dragon.yml
@@ -1361,7 +1361,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/ancient-black-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-black-dragon.yml
@@ -1456,7 +1456,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1496,7 +1498,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781554989014
-      modifiedTime: 1781554989014
+      modifiedTime: 1781897424916
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qNdFhY3JOkCfhG3d.ys3uLiJgfbw9PwGb'

--- a/packs/_source/monsters/dragon/ancient-black-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-black-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,161 +478,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 4
 items:
-  - _id: 5IEyeZf0FqkPrv7R
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 200000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1745448555347
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!qNdFhY3JOkCfhG3d.5IEyeZf0FqkPrv7R'
-  - _id: J86tFiZtAP8BbHzF
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 250000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448556024
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!qNdFhY3JOkCfhG3d.J86tFiZtAP8BbHzF'
   - _id: RKsS1lZwBekMMGMt
     name: Multiattack
     type: feat
@@ -731,7 +575,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -742,11 +586,13 @@ items:
   - _id: YauNxZeIeT4uDcTf
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Black Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -809,7 +655,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -818,8 +664,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        GMQaeBoStSpCgyv9:
           type: attack
           activation:
             type: action
@@ -834,10 +679,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -854,7 +700,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -867,36 +714,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 8
                 bonus: ''
                 types:
                   - acid
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: GMQaeBoStSpCgyv9
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -906,22 +764,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448579258
+      systemVersion: 6.0.0
+      createdTime: 1781555010510
+      modifiedTime: 1781555031630
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qNdFhY3JOkCfhG3d.YauNxZeIeT4uDcTf'
   - _id: GQLQiLBrkoOiNc8q
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Black Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -984,7 +844,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -993,8 +853,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        Iow7Kz6W2quNDUSz:
           type: attack
           activation:
             type: action
@@ -1009,10 +868,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1029,7 +889,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1042,20 +903,32 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: Iow7Kz6W2quNDUSz
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1070,22 +943,24 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448579258
+      systemVersion: 6.0.0
+      createdTime: 1781555042696
+      modifiedTime: 1781555058244
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qNdFhY3JOkCfhG3d.GQLQiLBrkoOiNc8q'
   - _id: A5cRQsDF3Qih94rC
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Black Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1147,9 +1022,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1158,8 +1032,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        8tN7EcRSvSR54U3k:
           type: attack
           activation:
             type: action
@@ -1174,10 +1047,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1194,7 +1068,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1207,20 +1082,32 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 8tN7EcRSvSR54U3k
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1235,144 +1122,30 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448579258
+      systemVersion: 6.0.0
+      createdTime: 1781555067917
+      modifiedTime: 1781555173935
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qNdFhY3JOkCfhG3d.A5cRQsDF3Qih94rC'
-  - _id: M3VJyuM63OKH7JH0
-    name: Frightful Presence
-    type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
-    system:
-      description:
-        value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: creature
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '19'
-          sort: 0
-          name: ''
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448608113
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!qNdFhY3JOkCfhG3d.M3VJyuM63OKH7JH0'
   - _id: zDlCrWQVJgZFMfxY
     name: Acid Breath
     type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
+    img: icons/magic/acid/projectile-faceted-glob.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales acid in a 90-foot line that is 10 feet wide.
-          Each creature in that line must make a [[/save]] saving throw, taking
+          <p>The [[lookup @name lowercase]]{monster} exhales acid in a [[lookup
+          @labels.description.template activity=veyLlk1HbQ6RZxvv]]. Each
+          creature in that line must make a [[/save]] saving throw, taking
           [[/damage average]] damage on a failed save, or half as much damage on
           a successful one.</p>
         chat: >-
-          <p>The dragon exhales acid in a 90-foot line that is 10 feet wide.
-          Each creature in that line must make a <strong>Dexterity</strong>
-          saving throw.</p>
+          <p>The [[lookup @name]]{monster} exhales acid in a [[lookup
+          @labels.description.template activity=veyLlk1HbQ6RZxvv]]. Each
+          creature in that line must make a Dexterity saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1393,8 +1166,7 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        veyLlk1HbQ6RZxvv:
           type: save
           activation:
             type: action
@@ -1404,17 +1176,16 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1435,6 +1206,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1449,24 +1221,37 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 15
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 15
                 denomination: 8
                 bonus: ''
                 types:
                   - acid
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '22'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: veyLlk1HbQ6RZxvv
+          name: Exhale Acid
       enchant: {}
       prerequisites:
         level: null
@@ -1480,18 +1265,194 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.zjcGly9P3Gn9MXt7
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448640858
+      systemVersion: 6.0.0
+      createdTime: 1781555275155
+      modifiedTime: 1781555323728
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qNdFhY3JOkCfhG3d.zDlCrWQVJgZFMfxY'
-  - _id: 3ZEmD9O6eOtAfSzJ
+  - _id: CBwTwMTYrbNXCdPG
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781554980037
+      modifiedTime: 1781554980037
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!qNdFhY3JOkCfhG3d.CBwTwMTYrbNXCdPG'
+  - _id: QR8LYH2jgp7fI0MF
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781554986689
+      modifiedTime: 1781554986689
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!qNdFhY3JOkCfhG3d.QR8LYH2jgp7fI0MF'
+  - _id: ys3uLiJgfbw9PwGb
     name: Legendary Actions
     type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
@@ -1508,40 +1469,232 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: legendary-actions
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
-    sort: 300000
+    sort: 600000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448571705
+      systemVersion: 6.0.0
+      createdTime: 1781554989014
+      modifiedTime: 1781554989014
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!qNdFhY3JOkCfhG3d.3ZEmD9O6eOtAfSzJ'
-  - _id: Ue0XiojtilVvKhH4
+    _key: '!actors.items!qNdFhY3JOkCfhG3d.ys3uLiJgfbw9PwGb'
+  - _id: jlrnZ2xIJO0YxtRP
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        2VOmvThI0bGdUsMt:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '120'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '19'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781555179043
+          modifiedTime: 1781555179043
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!qNdFhY3JOkCfhG3d.jlrnZ2xIJO0YxtRP.JG2uXIqEJlTnRHpq
+    folder: null
+    sort: 550000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.ETUEA1ugrv8npkfT
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781555179043
+      modifiedTime: 1781630477432
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!qNdFhY3JOkCfhG3d.jlrnZ2xIJO0YxtRP'
+  - _id: JXvdKNPRIfGOuCft
     name: Detect
     type: feat
     img: icons/creatures/eyes/lizard-single-slit-blue.webp
     system:
       description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
       source:
         custom: ''
         book: ''
@@ -1554,166 +1707,105 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
           activation:
             type: legendary
+            override: false
             value: 1
             condition: ''
-            override: false
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
+              type: self
               special: ''
-            prompt: true
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: detect
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448683669
+      systemVersion: 6.0.0
+      createdTime: 1781555477341
+      modifiedTime: 1781555478217
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!qNdFhY3JOkCfhG3d.Ue0XiojtilVvKhH4'
-  - _id: UpWaTW9cFf96GmMH
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!qNdFhY3JOkCfhG3d.JXvdKNPRIfGOuCft'
+  - name: Tail Attack
+    type: feat
+    _id: GsOwOLsXgIjnSFSG
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
-      description:
-        value: <p>The dragon makes a [[/item .A5cRQsDF3Qih94rC]]{tail} attack.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bH5x9SlFErQaWMuP:
           type: utility
           activation:
             type: legendary
@@ -1728,15 +1820,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1747,10 +1840,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1765,117 +1859,69 @@ items:
             prompt: false
             visible: false
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448677496
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!qNdFhY3JOkCfhG3d.UpWaTW9cFf96GmMH'
-  - _id: i4ggPCju3QyYJslH
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
-    system:
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
       description:
         value: >-
-          <p>The dragon beats its wings. Each creature within 15 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: ''
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .A5cRQsDF3Qih94rC]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
       source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 15
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
+        rules: '2014'
       crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: null
+    sort: 200000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781555483961
+      modifiedTime: 1781555493329
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.3qD1BjSwCtlGUEF0
+      exportSource: null
+    _key: '!actors.items!qNdFhY3JOkCfhG3d.GsOwOLsXgIjnSFSG'
+  - name: Wing Attack
+    type: feat
+    _id: r1ngkxvY1jbVMhd6
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1890,6 +1936,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1911,6 +1958,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1929,45 +1977,79 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '23'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      mastery: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
       identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
     folder: null
-    sort: 300000
+    sort: 475000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453067990
+      systemVersion: 6.0.0
+      createdTime: 1781555496682
+      modifiedTime: 1781567579123
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!qNdFhY3JOkCfhG3d.i4ggPCju3QyYJslH'
+    _key: '!actors.items!qNdFhY3JOkCfhG3d.r1ngkxvY1jbVMhd6'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1976,7 +2058,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171259411

--- a/packs/_source/monsters/dragon/ancient-black-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-black-dragon.yml
@@ -1510,12 +1510,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1681,7 +1682,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781555179043
-      modifiedTime: 1781630477432
+      modifiedTime: 1781632046893
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qNdFhY3JOkCfhG3d.jlrnZ2xIJO0YxtRP'

--- a/packs/_source/monsters/dragon/ancient-black-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-black-dragon.yml
@@ -1527,7 +1527,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/ancient-black-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-black-dragon.yml
@@ -487,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .M3VJyuM63OKH7JH0]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .YauNxZeIeT4uDcTf]]{bite} and two with its [[/item
-          .GQLQiLBrkoOiNc8q]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .M3VJyuM63OKH7JH0]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .YauNxZeIeT4uDcTf]]{bite} and two with its
+          [[/item .GQLQiLBrkoOiNc8q]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -504,13 +504,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bFxsKzwoVXq5aFFT:
           type: utility
           activation:
             type: action
@@ -525,15 +524,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -544,7 +544,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -561,7 +562,16 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          behaviors: []
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: bFxsKzwoVXq5aFFT
       enchant: {}
       prerequisites:
         level: null
@@ -577,9 +587,9 @@ items:
       duplicateSource: null
       coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448580176
+      systemVersion: 6.0.0
+      createdTime: 1783371656009
+      modifiedTime: 1783371665477
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qNdFhY3JOkCfhG3d.RKsS1lZwBekMMGMt'
@@ -1882,7 +1892,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .A5cRQsDF3Qih94rC]]{Tail} attack.</p>
+          .A5cRQsDF3Qih94rC]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -1912,7 +1922,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781555483961
-      modifiedTime: 1781555493329
+      modifiedTime: 1783371671975
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.3qD1BjSwCtlGUEF0

--- a/packs/_source/monsters/dragon/ancient-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-blue-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,115 +478,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 4
 items:
-  - _id: OUkdlIHkMVy9284v
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448989243
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!SNT0JNVSngUTsj4m.OUkdlIHkMVy9284v'
   - _id: gbM7g0hyrF6MMYqR
     name: Multiattack
     type: feat
@@ -597,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .NhYVY7hHFu2YsFpN]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .F29wEcjTlpKWcfO3]]{bite} and two with its [[/item
-          .Hoc6KiovAZiBi5HV]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .HDGLlSq9suLd9DIn]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .F29wEcjTlpKWcfO3]]{Bite} and two with its
+          [[/item .Hoc6KiovAZiBi5HV]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -614,13 +504,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        v3Ba0MC3j0HvaSyF:
           type: utility
           activation:
             type: action
@@ -635,15 +524,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -654,7 +544,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -671,7 +562,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: v3Ba0MC3j0HvaSyF
       enchant: {}
       prerequisites:
         level: null
@@ -685,22 +584,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448994580
+      systemVersion: 6.0.0
+      createdTime: 1781568212020
+      modifiedTime: 1781630422301
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!SNT0JNVSngUTsj4m.gbM7g0hyrF6MMYqR'
   - _id: F29wEcjTlpKWcfO3
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Blue Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -763,7 +664,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -772,8 +673,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        FiR7tdvkjreBzH8o:
           type: attack
           activation:
             type: action
@@ -788,10 +688,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -808,7 +709,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -821,36 +723,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 10
                 bonus: ''
                 types:
                   - lightning
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 300000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: FiR7tdvkjreBzH8o
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -860,171 +773,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448993848
+      systemVersion: 6.0.0
+      createdTime: 1781568125673
+      modifiedTime: 1781568143965
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!SNT0JNVSngUTsj4m.F29wEcjTlpKWcfO3'
-  - _id: uDd2aKkvwMwZfncQ
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448980455
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!SNT0JNVSngUTsj4m.uDd2aKkvwMwZfncQ'
-  - _id: BOsuBiKE1Enpl4xl
-    name: Detect
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: detect
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449054124
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!SNT0JNVSngUTsj4m.BOsuBiKE1Enpl4xl'
   - _id: Hoc6KiovAZiBi5HV
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Blue Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1088,7 +854,7 @@ items:
         conditions: ''
       properties:
         - rch
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1097,8 +863,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        7RUTJb9VWa8DsEyW:
           type: attack
           activation:
             type: action
@@ -1113,10 +878,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1133,7 +899,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1146,20 +913,32 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 7RUTJb9VWa8DsEyW
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1174,33 +953,24 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448993848
+      systemVersion: 6.0.0
+      createdTime: 1781568104843
+      modifiedTime: 1781568118210
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!SNT0JNVSngUTsj4m.Hoc6KiovAZiBi5HV'
-  - _id: NhYVY7hHFu2YsFpN
-    name: Frightful Presence
+  - _id: sjKXyN0wLwqIbKKb
+    name: Legendary Resistance
     type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
+    img: icons/equipment/shield/targe-steel-blue.webp
     system:
       description:
         value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute. A creature can repeat
-          the saving throw at the end of each of its turns, ending the effect on
-          itself on a success. If a creature's saving throw is successful or the
-          effect ends for it, the creature is immune to the dragon's Frightful
-          Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
       source:
         custom: ''
         book: ''
@@ -1213,138 +983,25 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
-          type: save
+          type: utility
           activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: creature
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '20'
-          sort: 0
-          name: ''
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449025607
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!SNT0JNVSngUTsj4m.NhYVY7hHFu2YsFpN'
-  - _id: 834XVlRwHOXkE2rK
-    name: Lightning Breath
-    type: feat
-    img: icons/magic/lightning/bolt-strike-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon exhales lightning in a 120-foot line that is 10 feet
-          wide. Each creature in that line must make a [[/save]] saving throw,
-          taking [[/damage average]] damage on a failed save, or half as much
-          damage on a successful one.</p>
-        chat: >-
-          <p>The dragon exhales lightning in a 120-foot line that is 10 feet
-          wide. Each creature in that line must make a
-          <strong>Dexterity</strong> saving throw.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
             override: false
           consumption:
             targets:
-              - type: itemUses
+              - type: attribute
                 value: '1'
-                target: ''
+                target: resources.legres.value
                 scaling: {}
             scaling:
               allowed: false
@@ -1352,6 +1009,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1367,14 +1025,15 @@ items:
             template:
               count: ''
               contiguous: false
-              type: line
-              size: '120'
+              type: ''
+              size: ''
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1383,30 +1042,82 @@ items:
             spent: 0
             max: ''
             recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 16
-                denomination: 10
-                bonus: ''
-                types:
-                  - lightning
-                scaling:
-                  number: 1
-          save:
-            ability: dex
-            dc:
-              calculation: ''
-              formula: '23'
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
           sort: 0
-          name: ''
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
       enchant: {}
       prerequisites:
         level: null
-      identifier: lightning-breath
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781568029688
+      modifiedTime: 1781568029688
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!SNT0JNVSngUTsj4m.sjKXyN0wLwqIbKKb'
+  - _id: VHYU8qN5MgbPztif
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
     sort: 600000
@@ -1414,24 +1125,26 @@ items:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.LVnd9fq9cQj7rR0Q
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449042480
+      systemVersion: 6.0.0
+      createdTime: 1781568030615
+      modifiedTime: 1781568030615
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!SNT0JNVSngUTsj4m.834XVlRwHOXkE2rK'
-  - _id: rwLwUWCVufdiKDaK
+    _key: '!actors.items!SNT0JNVSngUTsj4m.VHYU8qN5MgbPztif'
+  - _id: GV0gL8StP41vlgL9
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Blue Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1447,7 +1160,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1494,17 +1206,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1519,15 +1229,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            value: '20'
+            value: '15'
             units: ft
             special: ''
             override: false
@@ -1539,9 +1250,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1552,50 +1264,72 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
       mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
     folder: null
-    sort: 400000
+    sort: 500000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449080861
+      systemVersion: 6.0.0
+      createdTime: 1781568055149
+      modifiedTime: 1781568061134
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!SNT0JNVSngUTsj4m.rwLwUWCVufdiKDaK'
-  - _id: qUJb6VyY5ITDA0TL
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!SNT0JNVSngUTsj4m.GV0gL8StP41vlgL9'
+  - _id: 8xjypoENrUXFuApX
+    name: Lightning Breath
+    type: feat
+    img: icons/magic/lightning/bolt-beam-strike-blue.webp
     system:
       description:
-        value: <p>The dragon makes a [[/item .rwLwUWCVufdiKDaK]]{tail} attack.</p>
-        chat: ''
+        value: >-
+          <p>The dragon exhales lightning in a [[lookup
+          @labels.description.template activity=GSQtl90Opu6WzZk4]]. Each
+          creature in that line must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} exhales lightning in a [[lookup
+          @labels.description.template activity=GSQtl90Opu6WzZk4]]. Each
+          creature in that line must make a Dexterity saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1603,68 +1337,251 @@ items:
         license: CC-BY-4.0
         rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        GSQtl90Opu6WzZk4:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: line
+              size: '120'
+              width: '5'
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 16
+                denomination: 10
+                bonus: ''
+                types:
+                  - lightning
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '12'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: GSQtl90Opu6WzZk4
+          name: Exhale Lightning
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: lightning-breath
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.LVnd9fq9cQj7rR0Q
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781568066928
+      modifiedTime: 1781568087902
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!SNT0JNVSngUTsj4m.8xjypoENrUXFuApX'
+  - _id: 3gjBmbGioIalgW1i
+    name: Detect
+    type: feat
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
       uses:
         max: ''
         recovery: []
         spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
       type:
-        value: simpleM
-        baseItem: ''
-      container: null
-      crewed: false
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
+          activation:
+            type: legendary
+            override: false
+            value: 1
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781568158091
+      modifiedTime: 1781568158091
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!SNT0JNVSngUTsj4m.3gjBmbGioIalgW1i'
+  - name: Tail Attack
+    type: feat
+    _id: 6wOtUJpwxfAd7g5X
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
+    system:
+      activities:
+        bH5x9SlFErQaWMuP:
           type: utility
           activation:
             type: legendary
@@ -1672,28 +1589,23 @@ items:
             condition: ''
             override: false
           consumption:
-            targets:
-              - type: attribute
-                target: resources.legact.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+            targets: []
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1704,10 +1616,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1722,113 +1635,69 @@ items:
             prompt: false
             visible: false
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .GV0gL8StP41vlgL9]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
       identifier: tail-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 100000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449083145
+      systemVersion: 6.0.0
+      createdTime: 1781568165507
+      modifiedTime: 1781568193284
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
       exportSource: null
-    _key: '!actors.items!SNT0JNVSngUTsj4m.qUJb6VyY5ITDA0TL'
-  - _id: ZF7ixqLMH0gc0qlL
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
+    _key: '!actors.items!SNT0JNVSngUTsj4m.6wOtUJpwxfAd7g5X'
+  - name: Wing Attack
+    type: feat
+    _id: bvpVmANGxNgRpcKU
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
     system:
-      description:
-        value: >-
-          <p>The dragon beats its wings. Each creature within 15 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 15
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1836,16 +1705,14 @@ items:
             condition: ''
             override: false
           consumption:
-            targets:
-              - type: attribute
-                value: '2'
-                target: resources.legact.value
+            targets: []
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1867,6 +1734,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1885,45 +1753,264 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '24'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      mastery: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
       identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
+    folder: 5cwqjeuI64dkrUa8
+    sort: 400000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781568167474
+      modifiedTime: 1781568175074
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
+      exportSource: null
+    _key: '!actors.items!SNT0JNVSngUTsj4m.bvpVmANGxNgRpcKU'
+  - _id: HDGLlSq9suLd9DIn
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        2VOmvThI0bGdUsMt:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '120'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781630411348
+          modifiedTime: 1781630411348
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!SNT0JNVSngUTsj4m.HDGLlSq9suLd9DIn.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
     sort: 300000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453058320
+      systemVersion: 6.0.0
+      createdTime: 1781630411348
+      modifiedTime: 1781630411348
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!SNT0JNVSngUTsj4m.ZF7ixqLMH0gc0qlL'
+    _key: '!actors.items!SNT0JNVSngUTsj4m.HDGLlSq9suLd9DIn'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1932,7 +2019,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171232180

--- a/packs/_source/monsters/dragon/ancient-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-blue-dragon.yml
@@ -489,8 +489,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .HDGLlSq9suLd9DIn]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .F29wEcjTlpKWcfO3]]{Bite} and two with its
-          [[/item .Hoc6KiovAZiBi5HV]]{Claws}.</p>
+          one with its [[/item .F29wEcjTlpKWcfO3]]{bite} and two with its
+          [[/item .Hoc6KiovAZiBi5HV]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -588,7 +588,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781568212020
-      modifiedTime: 1781630422301
+      modifiedTime: 1783371688168
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!SNT0JNVSngUTsj4m.gbM7g0hyrF6MMYqR'
@@ -1657,7 +1657,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .GV0gL8StP41vlgL9]]{Tail} attack.</p>
+          .GV0gL8StP41vlgL9]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -1687,7 +1687,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781568165507
-      modifiedTime: 1781568193284
+      modifiedTime: 1783371694639
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/ancient-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-blue-dragon.yml
@@ -1836,12 +1836,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -2007,7 +2008,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781630411348
-      modifiedTime: 1781630411348
+      modifiedTime: 1781632038857
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!SNT0JNVSngUTsj4m.HDGLlSq9suLd9DIn'

--- a/packs/_source/monsters/dragon/ancient-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-blue-dragon.yml
@@ -1843,7 +1843,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/ancient-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-blue-dragon.yml
@@ -1091,7 +1091,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1131,7 +1133,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781568030615
-      modifiedTime: 1781568030615
+      modifiedTime: 1781897420620
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!SNT0JNVSngUTsj4m.VHYU8qN5MgbPztif'

--- a/packs/_source/monsters/dragon/ancient-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-brass-dragon.yml
@@ -1279,9 +1279,9 @@ items:
           @labels.description.template activity=O02zuaLvAqtmgutQ]]. Each
           creature in that area must succeed on a [[/save
           activity=O02zuaLvAqtmgutQ]] saving throw or fall
-          &amp;Reference[unconscious] for 10 minutes. This effect ends for a
-          creature if the creature takes damage or someone uses an action to
-          wake it.</p>
+          &amp;Reference[unconscious] for [[lookup @labels.duration
+          activity=O02zuaLvAqtmgutQ]]. This effect ends for a creature if the
+          creature takes damage or someone uses an action to wake it.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -1419,9 +1419,10 @@ items:
               [[lookup @labels.description.template activity=O02zuaLvAqtmgutQ]].
               Each creature in that area must succeed on a [[/save
               activity=O02zuaLvAqtmgutQ]] saving throw or fall
-              &amp;Reference[unconscious] for 10 minutes. This effect ends for a
-              creature if the creature takes damage or someone uses an action to
-              wake it.</p>
+              &amp;Reference[unconscious] for [[lookup @labels.duration
+              activity=O02zuaLvAqtmgutQ]]. This effect ends for a creature if
+              the creature takes damage or someone uses an action to wake
+              it.</p>
           duration:
             concentration: false
             value: '10'
@@ -1545,7 +1546,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781621001210
-      modifiedTime: 1781622862009
+      modifiedTime: 1781631837118
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!pAuiNDr7nvpsW9nG.o8kI0IWURJx3MaqK'
@@ -1559,12 +1560,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1730,7 +1732,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781621006439
-      modifiedTime: 1781621007537
+      modifiedTime: 1781632029623
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!pAuiNDr7nvpsW9nG.aK8gzRFcKnL7yzcH'

--- a/packs/_source/monsters/dragon/ancient-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-brass-dragon.yml
@@ -1567,7 +1567,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/ancient-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-brass-dragon.yml
@@ -1067,7 +1067,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1107,7 +1109,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620939532
-      modifiedTime: 1781620939532
+      modifiedTime: 1781897412793
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!pAuiNDr7nvpsW9nG.r3TxMHJEcubjj65c'

--- a/packs/_source/monsters/dragon/ancient-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-brass-dragon.yml
@@ -489,8 +489,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .aK8gzRFcKnL7yzcH]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .M8QrGIl4ESY4kh6A]]{Bite} and two with its
-          [[/item .Iy1UXphRvuXgybrn]]{Claws}.</p>
+          one with its [[/item .M8QrGIl4ESY4kh6A]]{bite} and two with its
+          [[/item .Iy1UXphRvuXgybrn]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -588,7 +588,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781621089588
-      modifiedTime: 1781621095969
+      modifiedTime: 1783371705139
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!pAuiNDr7nvpsW9nG.IiNKOgZ3djF0mBXR'
@@ -2111,7 +2111,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .ZTkCj3bm1xkpbnkY]]{Tail} attack.</p>
+          .ZTkCj3bm1xkpbnkY]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -2141,7 +2141,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781621101152
-      modifiedTime: 1781621132578
+      modifiedTime: 1783371713684
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/ancient-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-brass-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,115 +478,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 4
 items:
-  - _id: pv497s1HuExllRI0
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450574483
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!pAuiNDr7nvpsW9nG.pv497s1HuExllRI0'
   - _id: IiNKOgZ3djF0mBXR
     name: Multiattack
     type: feat
@@ -597,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .yJGmBczsD2hSQuzI]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .M8QrGIl4ESY4kh6A]]{bite} and two with its [[/item
-          .Iy1UXphRvuXgybrn]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .aK8gzRFcKnL7yzcH]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .M8QrGIl4ESY4kh6A]]{Bite} and two with its
+          [[/item .Iy1UXphRvuXgybrn]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -614,13 +504,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        rWZiKFDO6pp5bLDn:
           type: utility
           activation:
             type: action
@@ -635,15 +524,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -654,7 +544,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -671,7 +562,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: rWZiKFDO6pp5bLDn
       enchant: {}
       prerequisites:
         level: null
@@ -685,22 +584,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450584463
+      systemVersion: 6.0.0
+      createdTime: 1781621089588
+      modifiedTime: 1781621095969
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!pAuiNDr7nvpsW9nG.IiNKOgZ3djF0mBXR'
   - _id: M8QrGIl4ESY4kh6A
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Brass Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -763,7 +664,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -772,8 +673,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        5Z0jybBI8MwnsD61:
           type: attack
           activation:
             type: action
@@ -788,10 +688,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -808,7 +709,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -821,24 +723,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 5Z0jybBI8MwnsD61
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -848,22 +763,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450583745
+      systemVersion: 6.0.0
+      createdTime: 1781621044906
+      modifiedTime: 1781621059432
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!pAuiNDr7nvpsW9nG.M8QrGIl4ESY4kh6A'
   - _id: Iy1UXphRvuXgybrn
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Brass Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1002,6 +919,7 @@ items:
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1011,33 +929,24 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450583745
+      systemVersion: 6.0.0
+      createdTime: 1781621036757
+      modifiedTime: 1781621039600
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!pAuiNDr7nvpsW9nG.Iy1UXphRvuXgybrn'
-  - _id: yJGmBczsD2hSQuzI
-    name: Frightful Presence
+  - _id: jK4McICX2nuFDyip
+    name: Legendary Resistance
     type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
+    img: icons/equipment/shield/targe-steel-blue.webp
     system:
       description:
         value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
       source:
         custom: ''
         book: ''
@@ -1050,13 +959,636 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620938649
+      modifiedTime: 1781620938649
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!pAuiNDr7nvpsW9nG.jK4McICX2nuFDyip'
+  - _id: r3TxMHJEcubjj65c
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 137500
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620939532
+      modifiedTime: 1781620939532
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!pAuiNDr7nvpsW9nG.r3TxMHJEcubjj65c'
+  - _id: SUWwnkaB3MOdOz0b
+    name: Change Shape
+    type: feat
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} magically polymorphs into a
+          humanoid or beast that has a challenge rating no higher than its own,
+          or back into its true form. It reverts to its true form if it dies.
+          Any equipment it is wearing or carrying is absorbed or borne by the
+          new form (the [[lookup @name lowercase]]{monster}'s choice).</p><p>In
+          a new form, the [[lookup @name lowercase]]{monster} retains its
+          alignment, hit points, Hit Dice, ability to speak, proficiencies,
+          Legendary Resistance, lair actions, and Intelligence, Wisdom, and
+          Charisma scores, as well as this action. Its statistics and
+          capabilities are otherwise replaced by those of the new form, except
+          any class features or legendary actions of that form.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} changes its form into a humanoid or
+          beast!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - mgc
+      activities:
+        WgVVVBedNPAgXuDm:
+          type: transform
+          name: Change Shape into Humanoid or Beast
+          _id: WgVVVBedNPAgXuDm
+          img: ''
+          sort: 100000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: false
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: '@details.cr'
+              name: ''
+              _id: hAZbWYsA1wVyGXVn
+              uuid: null
+              sizes: []
+              types:
+                - beast
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings:
+            effects:
+              - all
+            keep:
+              - mental
+              - skills
+              - languages
+              - items
+              - spells
+              - bio
+            preset: polymorph
+            merge: []
+            other: []
+            spellLists: []
+            transformTokens: true
+            minimumAC: ''
+            tempFormula: ''
+          transform:
+            customize: true
+            mode: cr
+            preset: polymorph
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: change-shape
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 1000000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.MO382D2sxtAIuUC5.Item.Fyvg74zRJWn05uhK
+      duplicateSource: Item.gfURBnJDJatlzDXj
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620989304
+      modifiedTime: 1781630691150
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!pAuiNDr7nvpsW9nG.SUWwnkaB3MOdOz0b'
+  - _id: o8kI0IWURJx3MaqK
+    name: Breath Weapons
+    type: feat
+    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Fire Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales fire in an [[lookup
+          @labels.description.template activity=NBdXGRF1vahbq4p8]]. Each
+          creature in that line must make a [[/save activity=NBdXGRF1vahbq4p8]]
+          saving throw, taking [[/damage average activity=NBdXGRF1vahbq4p8]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Sleep Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales sleep gas in a [[lookup
+          @labels.description.template activity=O02zuaLvAqtmgutQ]]. Each
+          creature in that area must succeed on a [[/save
+          activity=O02zuaLvAqtmgutQ]] saving throw or fall
+          &amp;Reference[unconscious] for 10 minutes. This effect ends for a
+          creature if the creature takes damage or someone uses an action to
+          wake it.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        NBdXGRF1vahbq4p8:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales fire in an
+              [[lookup @labels.description.template activity=NBdXGRF1vahbq4p8]].
+              Each creature in that line must make a [[/save
+              activity=NBdXGRF1vahbq4p8]] saving throw, taking [[/damage average
+              activity=NBdXGRF1vahbq4p8]] damage on a failed save, or half as
+              much damage on a successful one.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: line
+              size: '90'
+              width: '5'
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 16
+                denomination: 6
+                bonus: ''
+                types:
+                  - fire
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: NBdXGRF1vahbq4p8
+          name: Fire Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+        O02zuaLvAqtmgutQ:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales sleep gas in a
+              [[lookup @labels.description.template activity=O02zuaLvAqtmgutQ]].
+              Each creature in that area must succeed on a [[/save
+              activity=O02zuaLvAqtmgutQ]] saving throw or fall
+              &amp;Reference[unconscious] for 10 minutes. This effect ends for a
+              creature if the creature takes damage or someone uses an action to
+              wake it.</p>
+          duration:
+            concentration: false
+            value: '10'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: P1rGrKiV7x2OMiN0
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '90'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - con
+            dc:
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: O02zuaLvAqtmgutQ
+          name: Sleep Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: breath-weapons
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Sleep Breath
+        img: icons/magic/control/sleep-bubble-purple.webp
+        origin: Compendium.dnd5e.monsters.Actor.azCbLQt5LAYwTI7U.Item.JmVLjWM4G6OOQxl4
+        transfer: false
+        _id: P1rGrKiV7x2OMiN0
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 10
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[unconcious apply=false] for 10 minutes. This
+          effect ends for you when you take damage or when someone uses and
+          action to wake you.</p>
+        tint: '#ffffff'
+        statuses:
+          - unconscious
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781621001210
+          modifiedTime: 1781621215344
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!pAuiNDr7nvpsW9nG.o8kI0IWURJx3MaqK.P1rGrKiV7x2OMiN0
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781621001210
+      modifiedTime: 1781622862009
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!pAuiNDr7nvpsW9nG.o8kI0IWURJx3MaqK'
+  - _id: aK8gzRFcKnL7yzcH
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        2VOmvThI0bGdUsMt:
           type: save
           activation:
             type: action
@@ -1071,13 +1603,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
-            value: ''
-            units: ''
+            value: '1'
+            units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '120'
             units: ft
@@ -1091,10 +1629,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: any
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1104,43 +1643,107 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
-              calculation: ''
-              formula: '18'
-          sort: 0
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781621006439
+          modifiedTime: 1781621006439
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!pAuiNDr7nvpsW9nG.aK8gzRFcKnL7yzcH.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 450000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450603224
+      systemVersion: 6.0.0
+      createdTime: 1781621006439
+      modifiedTime: 1781621007537
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!pAuiNDr7nvpsW9nG.yJGmBczsD2hSQuzI'
-  - _id: JjvNpMw6JP0A33yu
+    _key: '!actors.items!pAuiNDr7nvpsW9nG.aK8gzRFcKnL7yzcH'
+  - _id: ZTkCj3bm1xkpbnkY
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Brass Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1156,7 +1759,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1203,17 +1805,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1228,780 +1828,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-          duration:
-            concentration: false
             value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '20'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: str
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts: []
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail
-    effects: []
-    folder: null
-    sort: 400000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450583745
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!pAuiNDr7nvpsW9nG.JjvNpMw6JP0A33yu'
-  - _id: qmdYJXoLm52JeDEN
-    name: Breath Weapons
-    type: feat
-    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon uses one of the following breath
-          weapons:</p><p><strong>Fire Breath.</strong> The dragon exhales fire
-          in an 90-foot line that is 10 feet wide. Each creature in that line
-          must make a [[/save activity=6LUqU0VnPwVPnSFZ]] saving throw, taking
-          [[/damage average activity=6LUqU0VnPwVPnSFZ]] damage on a failed save,
-          or half as much damage on a successful one.</p><p><strong>Sleep
-          Breath.</strong> The dragon exhales sleep gas in a 90-foot cone. Each
-          creature in that area must succeed on a [[/save
-          activity=or1E73efg0UfoML2]] saving throw or fall
-          &amp;Reference[unconscious] for 10 minutes. This effect ends for a
-          creature if the creature takes damage or someone uses an action to
-          wake it.</p>
-        chat: <p>The dragon breathes in!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        6LUqU0VnPwVPnSFZ:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: line
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 16
-                denomination: '6'
-                bonus: ''
-                types:
-                  - fire
-          save:
-            ability:
-              - dex
-            dc:
-              calculation: ''
-              formula: '21'
-          sort: 0
-          _id: 6LUqU0VnPwVPnSFZ
-          name: Fire Breath
-          img: ''
-          appliedEffects: []
-        or1E73efg0UfoML2:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '10'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability:
-              - con
-            dc:
-              calculation: ''
-              formula: '21'
-          sort: 0
-          _id: or1E73efg0UfoML2
-          name: Sleep Breath
-          img: ''
-          appliedEffects: []
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: breath-weapons
-    effects: []
-    folder: null
-    sort: 600000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451231361
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!pAuiNDr7nvpsW9nG.qmdYJXoLm52JeDEN'
-  - _id: ffeBuEAJL0Kk0RRk
-    name: Change Shape
-    type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon magically polymorphs into a humanoid or beast that has a
-          challenge rating no higher than its own, or back into its true form.
-          It reverts to its true form if it dies. Any equipment it is wearing or
-          carrying is absorbed or borne by the new form (the dragon's
-          choice).</p><p>In a new form, the dragon retains its alignment, hit
-          points, Hit Dice, ability to speak, proficiencies, Legendary
-          Resistance, lair actions, and Intelligence, Wisdom, and Charisma
-          scores, as well as this action. Its statistics and capabilities are
-          otherwise replaced by those of the new form, except any class features
-          or legendary actions of that form.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: change-shape
-    effects: []
-    folder: null
-    sort: 900000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.JsAys4RSGi4lN5Jy
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450732995
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!pAuiNDr7nvpsW9nG.ffeBuEAJL0Kk0RRk'
-  - _id: BgJf6V68k1OQMyWH
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450581230
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!pAuiNDr7nvpsW9nG.BgJf6V68k1OQMyWH'
-  - _id: FWLpSMrjPPegkAxX
-    name: Detect
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: detect
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450743709
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!pAuiNDr7nvpsW9nG.FWLpSMrjPPegkAxX'
-  - _id: Ru7kWvjTE3H4Qbrh
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
-    system:
-      description:
-        value: <p>The dragon makes a [[/item .JjvNpMw6JP0A33yu]]{tail} attack.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450767829
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!pAuiNDr7nvpsW9nG.Ru7kWvjTE3H4Qbrh'
-  - _id: NgeJhGPvdvOyx7OI
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
-    system:
-      description:
-        value: "<p>The dragon beats its wings. Each creature within\_15 feet\_of the dragon must succeed on a\_[[/save]] saving throw\_or take\_[[/damage average]]\_damage and be knocked &amp;Reference[prone]. The dragon can then fly up to half its flying speed.</p>"
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 15
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: simpleM
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: legendary
-            value: 2
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
           duration:
             concentration: false
             value: ''
@@ -2022,10 +1849,347 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
+            affects:
+              count: '1'
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          attack:
+            ability: ''
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: ''
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
+      ammunition: {}
+      identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 425000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781621011951
+      modifiedTime: 1781621019432
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!pAuiNDr7nvpsW9nG.ZTkCj3bm1xkpbnkY'
+  - _id: 7rEcQDwSZg8VJq8u
+    name: Detect
+    type: feat
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
+          activation:
+            type: legendary
+            override: false
+            value: 1
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781621100236
+      modifiedTime: 1781621100236
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!pAuiNDr7nvpsW9nG.7rEcQDwSZg8VJq8u'
+  - name: Tail Attack
+    type: feat
+    _id: 0RHacNLUyJEOf5Bl
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
+    system:
+      activities:
+        bH5x9SlFErQaWMuP:
+          type: utility
+          activation:
+            type: legendary
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .ZTkCj3bm1xkpbnkY]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781621101152
+      modifiedTime: 1781621132578
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!pAuiNDr7nvpsW9nG.0RHacNLUyJEOf5Bl'
+  - name: Wing Attack
+    type: feat
+    _id: mkwoBCTLQ2aDhYp6
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
+      activities:
+        4U3711rd7WmlJIhy:
+          type: save
+          activation:
+            type: legendary
+            value: 2
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '15'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
               type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -2041,45 +2205,79 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '22'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
       identifier: wing-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 300000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453048621
+      systemVersion: 6.0.0
+      createdTime: 1781621102943
+      modifiedTime: 1781621114469
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!pAuiNDr7nvpsW9nG.NgeJhGPvdvOyx7OI'
+    _key: '!actors.items!pAuiNDr7nvpsW9nG.mkwoBCTLQ2aDhYp6'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -2088,7 +2286,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171258491

--- a/packs/_source/monsters/dragon/ancient-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-bronze-dragon.yml
@@ -980,9 +980,8 @@ items:
       activities: {}
       enchant: {}
       prerequisites:
-        level: 3
-        items:
-          - reptile-bloodline
+        level: null
+        items: []
         repeatable: false
       identifier: amphibious
       advancement: {}

--- a/packs/_source/monsters/dragon/ancient-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-bronze-dragon.yml
@@ -1367,12 +1367,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1538,7 +1539,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781630146899
-      modifiedTime: 1781630147722
+      modifiedTime: 1781632022085
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!35Y64PEFFdvQS0ra.pZcXLBLl3Unn9etS'

--- a/packs/_source/monsters/dragon/ancient-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-bronze-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,161 +478,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 4
 items:
-  - _id: 8ATtkPLmg7NooADy
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1745451285835
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!35Y64PEFFdvQS0ra.8ATtkPLmg7NooADy'
-  - _id: lxwKTlmSXPr3wkUF
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 200000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451285835
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!35Y64PEFFdvQS0ra.lxwKTlmSXPr3wkUF'
   - _id: J1T00n4aCL5ybwJS
     name: Multiattack
     type: feat
@@ -643,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .QUlBJuNL7JOevT7b]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .17bKqeydGVM0tR6p]]{bite} and two with its [[/item
-          .qd5qScYvDjNbDERs]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .QUlBJuNL7JOevT7b]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .17bKqeydGVM0tR6p]]{Bite} and two with its
+          [[/item .qd5qScYvDjNbDERs]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -660,13 +504,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        ELDmyLyylWECD3NF:
           type: utility
           activation:
             type: action
@@ -681,15 +524,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -700,7 +544,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -717,7 +562,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: ELDmyLyylWECD3NF
       enchant: {}
       prerequisites:
         level: null
@@ -731,22 +584,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451296638
+      systemVersion: 6.0.0
+      createdTime: 1781630269837
+      modifiedTime: 1781630279541
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!35Y64PEFFdvQS0ra.J1T00n4aCL5ybwJS'
   - _id: 17bKqeydGVM0tR6p
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Bronze Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -809,7 +664,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -818,8 +673,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        sBRhYjbbOPYry09i:
           type: attack
           activation:
             type: action
@@ -834,10 +688,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -854,7 +709,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -867,24 +723,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: sBRhYjbbOPYry09i
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -894,22 +763,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451295826
+      systemVersion: 6.0.0
+      createdTime: 1781630115411
+      modifiedTime: 1781630128027
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!35Y64PEFFdvQS0ra.17bKqeydGVM0tR6p'
   - _id: qd5qScYvDjNbDERs
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Bronze Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -972,7 +843,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -981,8 +852,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        UmCTA8BwNxEjRNKh:
           type: attack
           activation:
             type: action
@@ -997,10 +867,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1017,7 +888,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1030,24 +902,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: UmCTA8BwNxEjRNKh
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1057,22 +942,252 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451295826
+      systemVersion: 6.0.0
+      createdTime: 1781630087757
+      modifiedTime: 1781630108090
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!35Y64PEFFdvQS0ra.qd5qScYvDjNbDERs'
-  - _id: Vu2UkFmxzWB17KtN
+  - _id: b5erIWKE9DQp2JPR
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: class
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: 3
+        items:
+          - reptile-bloodline
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 25000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781626665676
+      modifiedTime: 1781630079674
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!35Y64PEFFdvQS0ra.b5erIWKE9DQp2JPR'
+  - _id: Kbap7Kabq2cGynt9
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781626666943
+      modifiedTime: 1781626666943
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!35Y64PEFFdvQS0ra.Kbap7Kabq2cGynt9'
+  - _id: TJiBVvomCBsffvwU
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 137500
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781630078203
+      modifiedTime: 1781630078203
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!35Y64PEFFdvQS0ra.TJiBVvomCBsffvwU'
+  - _id: wpTpsq1AANWAs96M
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Bronze Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1088,7 +1203,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1135,17 +1249,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1160,15 +1272,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            value: '20'
+            value: '15'
             units: ft
             special: ''
             override: false
@@ -1180,9 +1293,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1193,60 +1307,78 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
-    folder: null
-    sort: 400000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 350000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451295826
+      systemVersion: 6.0.0
+      createdTime: 1781630135857
+      modifiedTime: 1781630142354
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!35Y64PEFFdvQS0ra.Vu2UkFmxzWB17KtN'
-  - _id: QUlBJuNL7JOevT7b
+    _key: '!actors.items!35Y64PEFFdvQS0ra.wpTpsq1AANWAs96M'
+  - _id: pZcXLBLl3Unn9etS
     name: Frightful Presence
     type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
     system:
       description:
         value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
         chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
       source:
         custom: ''
         book: ''
@@ -1259,13 +1391,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        2VOmvThI0bGdUsMt:
           type: save
           activation:
             type: action
@@ -1280,13 +1411,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '120'
             units: ft
@@ -1300,10 +1437,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: any
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1313,53 +1451,268 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
-              calculation: ''
-              formula: '20'
-          sort: 0
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781630146899
+          modifiedTime: 1781630146899
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!35Y64PEFFdvQS0ra.pZcXLBLl3Unn9etS.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 550000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451541265
+      systemVersion: 6.0.0
+      createdTime: 1781630146899
+      modifiedTime: 1781630147722
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!35Y64PEFFdvQS0ra.QUlBJuNL7JOevT7b'
-  - _id: oVxtfa5RF6ibpTIt
+    _key: '!actors.items!35Y64PEFFdvQS0ra.pZcXLBLl3Unn9etS'
+  - _id: rx63b4lFAvL5HCZb
+    name: Change Shape
+    type: feat
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} magically polymorphs into a
+          humanoid or beast that has a challenge rating no higher than its own,
+          or back into its true form. It reverts to its true form if it dies.
+          Any equipment it is wearing or carrying is absorbed or borne by the
+          new form (the [[lookup @name lowercase]]{monster}'s choice).</p><p>In
+          a new form, the [[lookup @name lowercase]]{monster} retains its
+          alignment, hit points, Hit Dice, ability to speak, proficiencies,
+          Legendary Resistance, lair actions, and Intelligence, Wisdom, and
+          Charisma scores, as well as this action. Its statistics and
+          capabilities are otherwise replaced by those of the new form, except
+          any class features or legendary actions of that form.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} changes its form into a humanoid or
+          beast!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - mgc
+      activities:
+        WgVVVBedNPAgXuDm:
+          type: transform
+          name: Change Shape into Humanoid or Beast
+          _id: WgVVVBedNPAgXuDm
+          img: ''
+          sort: 100000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: false
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: '@details.cr'
+              name: ''
+              _id: hAZbWYsA1wVyGXVn
+              uuid: null
+              sizes: []
+              types:
+                - beast
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings:
+            effects:
+              - all
+            keep:
+              - mental
+              - skills
+              - languages
+              - items
+              - spells
+              - bio
+            preset: polymorph
+            merge: []
+            other: []
+            spellLists: []
+            transformTokens: true
+            minimumAC: ''
+            tempFormula: ''
+          transform:
+            customize: true
+            mode: cr
+            preset: polymorph
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: change-shape
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 1000000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.MO382D2sxtAIuUC5.Item.Fyvg74zRJWn05uhK
+      duplicateSource: Item.gfURBnJDJatlzDXj
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781630153119
+      modifiedTime: 1781630713910
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!35Y64PEFFdvQS0ra.rx63b4lFAvL5HCZb'
+  - _id: fquJJiKubd6XKMXP
     name: Breath Weapons
     type: feat
     img: icons/creatures/abilities/dragon-ice-breath-blue.webp
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Lightning Breath.</strong> The dragon exhales
-          lightning in a 120-foot line that is 10 feet wide. Each creature in
-          that line must make a [[/save activity=w2CftR6CLr5PZ7zY]] saving
-          throw, taking [[/damage average activity=w2CftR6CLr5PZ7zY]] damage on
-          a failed save, or half as much damage on a successful
-          one.</p><p><strong>Repulsion Breath.</strong> The dragon exhales
-          repulsion energy in a 30-foot cone. Each creature in that area must
-          succeed on a [[/save activity=YElWYv6C5UfhAu48]] saving throw. On a
-          failed save, the creature is pushed 60 feet away from the dragon.</p>
-        chat: <p>The dragon breathes in!</p>
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Lightning Breath.</strong> The [[lookup
+          @name lowercase]]{monster} exhales lightning in a [[lookup
+          @labels.description.template activity=w2CftR6CLr5PZ7zY]]. Each
+          creature in that line must make a [[/save activity=w2CftR6CLr5PZ7zY]]
+          saving throw, taking [[/damage average activity=w2CftR6CLr5PZ7zY]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Repulsion Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales repulsion energy in a [[lookup
+          @labels.description.template activity=YElWYv6C5UfhAu48]]. Each
+          creature in that area must succeed on a [[/save
+          activity=YElWYv6C5UfhAu48]] saving throw. On a failed save, the
+          creature is pushed 60 feet away from the [[lookup @name
+          lowercase]]{monster}.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -1375,7 +1728,7 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -1392,12 +1745,20 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales lightning in a
+              [[lookup @labels.description.template activity=w2CftR6CLr5PZ7zY]].
+              Each creature in that line must make a [[/save
+              activity=w2CftR6CLr5PZ7zY]] saving throw, taking [[/damage average
+              activity=w2CftR6CLr5PZ7zY]] damage on a failed save, or half as
+              much damage on a successful one.</p>
           duration:
             concentration: false
             value: ''
@@ -1415,12 +1776,13 @@ items:
               contiguous: false
               type: line
               size: '120'
-              width: ''
+              width: '10'
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1436,21 +1798,33 @@ items:
                   enabled: false
                   formula: ''
                 number: 16
-                denomination: '10'
+                denomination: 10
                 bonus: ''
                 types:
                   - lightning
+                scaling:
+                  number: 1
           save:
             ability:
               - dex
             dc:
-              calculation: ''
-              formula: '23'
+              calculation: con
+              formula: '12'
+            bonus: ''
+            visible: true
           sort: 0
           _id: w2CftR6CLr5PZ7zY
           name: Lightning Breath
           img: ''
-          appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
         YElWYv6C5UfhAu48:
           type: save
           activation:
@@ -1463,12 +1837,20 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales repulsion
+              energy in a [[lookup @labels.description.template
+              activity=YElWYv6C5UfhAu48]]. Each creature in that area must
+              succeed on a [[/save activity=YElWYv6C5UfhAu48]] saving throw. On
+              a failed save, the creature is pushed 60 feet away from the
+              [[lookup @name lowercase]]{monster}.</p>
           duration:
             concentration: false
             value: ''
@@ -1489,9 +1871,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1501,62 +1884,65 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability:
               - str
             dc:
-              calculation: ''
-              formula: '23'
+              calculation: con
+              formula: '12'
+            bonus: ''
+            visible: true
           sort: 0
           _id: YElWYv6C5UfhAu48
           name: Repulsion Breath
           img: ''
-          appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
       enchant: {}
       prerequisites:
         level: null
+        repeatable: false
+        items: []
       identifier: breath-weapons
+      advancement: {}
+      cover: null
+      crewed: false
     effects: []
     folder: null
     sort: 600000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451447256
+      systemVersion: 6.0.0
+      createdTime: 1781630161242
+      modifiedTime: 1781630186505
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!35Y64PEFFdvQS0ra.oVxtfa5RF6ibpTIt'
-  - _id: YNplj2D0sAC6OT7z
-    name: Change Shape
+    _key: '!actors.items!35Y64PEFFdvQS0ra.fquJJiKubd6XKMXP'
+  - _id: WgUegZGipkJq5dgj
+    name: Detect
     type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
     system:
       description:
         value: >-
-          <p>The dragon magically polymorphs into a humanoid or beast that has a
-          challenge rating no higher than its own, or back into its true form.
-          It reverts to its true form if it dies. Any equipment it is wearing or
-          carrying is absorbed or borne by the new form (the dragon's
-          choice).</p><p>In a new form, the dragon retains its alignment, hit
-          points, Hit Dice, ability to speak, proficiencies, Legendary
-          Resistance, lair actions, and Intelligence, Wisdom, and Charisma
-          scores, as well as this action. Its statistics and capabilities are
-          otherwise replaced by those of the new form, except any class features
-          or legendary actions of that form.</p>
-        chat: ''
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
       source:
         custom: ''
         book: ''
@@ -1569,383 +1955,120 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: change-shape
-    effects: []
-    folder: null
-    sort: 900000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.JsAys4RSGi4lN5Jy
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451372330
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!35Y64PEFFdvQS0ra.YNplj2D0sAC6OT7z'
-  - _id: LxYk4BFUh3Qo9b9U
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451293645
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!35Y64PEFFdvQS0ra.LxYk4BFUh3Qo9b9U'
-  - _id: KgtmSzFoi9FmWEvj
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
-    system:
-      description:
-        value: <p>The dragon makes a [[/item .Vu2UkFmxzWB17KtN]]{tail} attack.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: simpleM
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
           activation:
             type: legendary
+            override: false
             value: 1
             condition: ''
-            override: false
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
+              type: self
               special: ''
-            prompt: true
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
+    folder: 5cwqjeuI64dkrUa8
     sort: 100000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451591778
+      systemVersion: 6.0.0
+      createdTime: 1781630201600
+      modifiedTime: 1781630201600
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!35Y64PEFFdvQS0ra.KgtmSzFoi9FmWEvj'
-  - _id: lUgfHIerFG9DvYSB
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
+    _key: '!actors.items!35Y64PEFFdvQS0ra.WgUegZGipkJq5dgj'
+  - name: Tail Attack
+    type: feat
+    _id: hRzHiaEGCGpfC1cj
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
-      description:
-        value: "<p>The dragon beats its wings. Each creature within\_15 feet\_of the dragon must succeed on a\_[[/save]] saving throw\_or take\_[[/damage average]]\_damage and be knocked &amp;Reference[prone]. The dragon can then fly up to half its flying speed.</p>"
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
+        bH5x9SlFErQaWMuP:
+          type: utility
           activation:
             type: legendary
-            value: 2
+            value: 1
             condition: ''
             override: false
           consumption:
-            targets:
-              - type: attribute
-                value: '2'
-                target: resources.legact.value
+            targets: []
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1954,7 +2077,7 @@ items:
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1965,10 +2088,128 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .wpTpsq1AANWAs96M]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781630202512
+      modifiedTime: 1781630233642
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!35Y64PEFFdvQS0ra.hRzHiaEGCGpfC1cj'
+  - name: Wing Attack
+    type: feat
+    _id: KJWOOKbRqafMpKNb
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
+      activities:
+        4U3711rd7WmlJIhy:
+          type: save
+          activation:
+            type: legendary
+            value: 2
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '15'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
               type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1984,148 +2225,79 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '24'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: wing-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453038417
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!35Y64PEFFdvQS0ra.lUgfHIerFG9DvYSB'
-  - _id: b7ej3RkphhDGh617
-    name: Detect
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
       uses:
-        max: ''
-        recovery: []
         spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
+      identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
       enchant: {}
       prerequisites:
+        items: []
+        repeatable: false
         level: null
-      identifier: detect
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 0
+    folder: 5cwqjeuI64dkrUa8
+    sort: 350000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451573653
+      systemVersion: 6.0.0
+      createdTime: 1781630203727
+      modifiedTime: 1781630217709
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!35Y64PEFFdvQS0ra.b7ej3RkphhDGh617'
+    _key: '!actors.items!35Y64PEFFdvQS0ra.KJWOOKbRqafMpKNb'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -2134,7 +2306,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171200112

--- a/packs/_source/monsters/dragon/ancient-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-bronze-dragon.yml
@@ -1134,7 +1134,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1174,7 +1176,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781630078203
-      modifiedTime: 1781630078203
+      modifiedTime: 1781897401194
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!35Y64PEFFdvQS0ra.TJiBVvomCBsffvwU'

--- a/packs/_source/monsters/dragon/ancient-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-bronze-dragon.yml
@@ -489,8 +489,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .QUlBJuNL7JOevT7b]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .17bKqeydGVM0tR6p]]{Bite} and two with its
-          [[/item .qd5qScYvDjNbDERs]]{Claws}.</p>
+          one with its [[/item .17bKqeydGVM0tR6p]]{bite} and two with its
+          [[/item .qd5qScYvDjNbDERs]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -588,7 +588,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781630269837
-      modifiedTime: 1781630279541
+      modifiedTime: 1783371727158
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!35Y64PEFFdvQS0ra.J1T00n4aCL5ybwJS'
@@ -2130,7 +2130,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .wpTpsq1AANWAs96M]]{Tail} attack.</p>
+          .wpTpsq1AANWAs96M]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -2160,7 +2160,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781630202512
-      modifiedTime: 1781630233642
+      modifiedTime: 1783371735182
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/ancient-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-copper-dragon.yml
@@ -1130,12 +1130,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1301,7 +1302,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625790796
-      modifiedTime: 1781625791839
+      modifiedTime: 1781632007075
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!u0FWdplSOMTXGnN1.t7C48MOTONNfLBUV'
@@ -1327,8 +1328,9 @@ items:
           creature can't use reactions, its speed is halved, and it can't make
           more than one attack on its turn. In addition, the creature can use
           either an action or a bonus action on its turn, but not both. These
-          effects last for 1 minute. The creature can repeat the saving throw at
-          the end of each of its turns, ending the effect on itself with a
+          effects last for [[lookup @labels.duration
+          activity=CkPMajPOZWWj3gl0]]. The creature can repeat the saving throw
+          at the end of each of its turns, ending the effect on itself with a
           successful save.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
@@ -1470,9 +1472,10 @@ items:
               creature can't use reactions, its speed is halved, and it can't
               make more than one attack on its turn. In addition, the creature
               can use either an action or a bonus action on its turn, but not
-              both. These effects last for 1 minute. The creature can repeat the
-              saving throw at the end of each of its turns, ending the effect on
-              itself with a successful save.</p>
+              both. These effects last for [[lookup @labels.duration
+              activity=CkPMajPOZWWj3gl0]]. The creature can repeat the saving
+              throw at the end of each of its turns, ending the effect on itself
+              with a successful save.</p>
           duration:
             concentration: false
             value: '1'
@@ -1624,7 +1627,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625796706
-      modifiedTime: 1781625888736
+      modifiedTime: 1781631732953
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!u0FWdplSOMTXGnN1.A9Cya4gGBfMB0WCr'

--- a/packs/_source/monsters/dragon/ancient-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-copper-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,169 +478,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 4
 items:
-  - _id: hGGrGcyo6L62I2rM
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451751466
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!u0FWdplSOMTXGnN1.hGGrGcyo6L62I2rM'
-  - _id: CXPSEbsRqSkZnER8
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451759096
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!u0FWdplSOMTXGnN1.CXPSEbsRqSkZnER8'
   - _id: eCpXCLFLV7W22orV
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Copper Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -706,7 +552,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -715,8 +561,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        X6siNdYF97zOuYzV:
           type: attack
           activation:
             type: action
@@ -731,10 +576,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -751,7 +597,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -764,24 +611,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: X6siNdYF97zOuYzV
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -791,22 +651,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451769571
+      systemVersion: 6.0.0
+      createdTime: 1781625727451
+      modifiedTime: 1781625745028
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!u0FWdplSOMTXGnN1.eCpXCLFLV7W22orV'
   - _id: lsey8RJZiuByt97z
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Copper Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -869,7 +731,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -878,8 +740,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        kovuvZZgS4bVUNJF:
           type: attack
           activation:
             type: action
@@ -894,10 +755,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -914,7 +776,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -927,24 +790,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: kovuvZZgS4bVUNJF
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -954,400 +830,14 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451769571
+      systemVersion: 6.0.0
+      createdTime: 1781625751876
+      modifiedTime: 1781625775484
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!u0FWdplSOMTXGnN1.lsey8RJZiuByt97z'
-  - _id: SvpSnbfGzHw6dW0p
-    name: Tail
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
-    system:
-      description:
-        value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Copper Dragon attacks with its Tail.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 20
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 8
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: attack
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '20'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: str
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts: []
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail
-    effects: []
-    folder: null
-    sort: 400000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451769571
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!u0FWdplSOMTXGnN1.SvpSnbfGzHw6dW0p'
-  - _id: YkCurZ53A7ciRit3
-    name: Frightful Presence
-    type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
-    system:
-      description:
-        value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: creature
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '19'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452004218
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!u0FWdplSOMTXGnN1.YkCurZ53A7ciRit3'
-  - _id: gkVpkxWRXjzllWOH
-    name: Change Shape
-    type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon magically polymorphs into a humanoid or beast that has a
-          challenge rating no higher than its own, or back into its true form.
-          It reverts to its true form if it dies. Any equipment it is wearing or
-          carrying is absorbed or borne by the new form (the dragon's
-          choice).</p><p>In a new form, the dragon retains its alignment, hit
-          points, Hit Dice, ability to speak, proficiencies, Legendary
-          Resistance, lair actions, and Intelligence, Wisdom, and Charisma
-          scores, as well as this action. Its statistics and capabilities are
-          otherwise replaced by those of the new form, except any class features
-          or legendary actions of that form.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: change-shape
-    effects: []
-    folder: null
-    sort: 600000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.JsAys4RSGi4lN5Jy
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451785355
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!u0FWdplSOMTXGnN1.gkVpkxWRXjzllWOH'
   - _id: 8GXBUXkbu1e62ZDK
     name: Multiattack
     type: feat
@@ -1443,7 +933,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -1451,120 +941,16 @@ items:
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!u0FWdplSOMTXGnN1.8GXBUXkbu1e62ZDK'
-  - _id: O2pIuhKov4RccvzH
-    name: Detect
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-          name: ''
-          img: ''
-          appliedEffects: []
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: detect
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452018529
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!u0FWdplSOMTXGnN1.O2pIuhKov4RccvzH'
-  - _id: oSQ8xmkOOeRaSlFz
-    name: Tail Attack
+  - _id: o9fC6jOW8DlJCqT6
+    name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
-        value: <p>The dragon makes a [[/item .SvpSnbfGzHw6dW0p]]{tail} attack.</p>
-        chat: ''
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1580,165 +966,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452034456
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!u0FWdplSOMTXGnN1.oSQ8xmkOOeRaSlFz'
-  - _id: sacY5ISgjFZCSNUi
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon beats its wings. Each creature within 15 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1746,7 +973,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: 15
+        reach: 20
       uses:
         max: ''
         recovery: []
@@ -1766,7 +993,7 @@ items:
             formula: ''
         base:
           number: 2
-          denomination: 6
+          denomination: 8
           bonus: ''
           types:
             - bludgeoning
@@ -1785,17 +1012,1008 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
+          type: attack
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '15'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: '1'
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          attack:
+            ability: ''
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: ''
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
+      ammunition: {}
+      identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 450000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625779714
+      modifiedTime: 1781625786400
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!u0FWdplSOMTXGnN1.o9fC6jOW8DlJCqT6'
+  - _id: t7C48MOTONNfLBUV
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        2VOmvThI0bGdUsMt:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '120'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781625790796
+          modifiedTime: 1781625790796
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!u0FWdplSOMTXGnN1.t7C48MOTONNfLBUV.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 475000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625790796
+      modifiedTime: 1781625791839
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!u0FWdplSOMTXGnN1.t7C48MOTONNfLBUV'
+  - _id: A9Cya4gGBfMB0WCr
+    name: Breath Weapons
+    type: feat
+    img: icons/magic/acid/projectile-faceted-glob.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Acid Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales acid in an [[lookup
+          @labels.description.template activity=zTWpuajI6meBb52D]]. Each
+          creature in that line must make a [[/save activity=zTWpuajI6meBb52D]]
+          saving throw, taking [[/damage average activity=zTWpuajI6meBb52D]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Slowing Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales gas in a [[lookup
+          @labels.description.template activity=zTWpuajI6meBb52D]]. Each
+          creature in that area must succeed on a [[/save
+          activity=CkPMajPOZWWj3gl0]] saving throw. On a failed save, the
+          creature can't use reactions, its speed is halved, and it can't make
+          more than one attack on its turn. In addition, the creature can use
+          either an action or a bonus action on its turn, but not both. These
+          effects last for 1 minute. The creature can repeat the saving throw at
+          the end of each of its turns, ending the effect on itself with a
+          successful save.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        zTWpuajI6meBb52D:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales acid in an
+              [[lookup @labels.description.template activity=zTWpuajI6meBb52D]].
+              Each creature in that line must make a [[/save
+              activity=zTWpuajI6meBb52D]] saving throw, taking [[/damage average
+              activity=zTWpuajI6meBb52D]] damage on a failed save, or half as
+              much damage on a successful one.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: line
+              size: '90'
+              width: '10'
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 14
+                denomination: 8
+                bonus: ''
+                types:
+                  - acid
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: zTWpuajI6meBb52D
+          name: Acid Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+        CkPMajPOZWWj3gl0:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=zTWpuajI6meBb52D]].
+              Each creature in that area must succeed on a [[/save
+              activity=CkPMajPOZWWj3gl0]] saving throw. On a failed save, the
+              creature can't use reactions, its speed is halved, and it can't
+              make more than one attack on its turn. In addition, the creature
+              can use either an action or a bonus action on its turn, but not
+              both. These effects last for 1 minute. The creature can repeat the
+              saving throw at the end of each of its turns, ending the effect on
+              itself with a successful save.</p>
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: 5E6iveIba4rYeUbc
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '90'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - con
+            dc:
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: CkPMajPOZWWj3gl0
+          name: Slowing Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        repeatable: false
+        items: []
+      identifier: breath-weapons
+      advancement: {}
+      cover: null
+      crewed: false
+    effects:
+      - name: Slowed
+        img: icons/skills/movement/arrow-down-pink.webp
+        origin: Compendium.dnd5e.monsters.Actor.AyvniEKtyroOe83p.Item.XuuhDCc4RQcZOXUL
+        transfer: false
+        _id: 5E6iveIba4rYeUbc
+        type: base
+        system:
+          changes:
+            - key: system.attributes.movement.burrow
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.climb
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.fly
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.swim
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.walk
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are slowed. While slowed, you can't use reactions, your speed
+          is halved, and you can't make more than one attack on your turn. In
+          addition, you can use either an action or a bonus action on your turn,
+          but not both.</p><p>These effects last for 1 minute. You can repeat
+          the saving throw at the end of each of your turns, ending the effect
+          on yourself with a succesful save.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781625796706
+          modifiedTime: 1781625796706
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!u0FWdplSOMTXGnN1.A9Cya4gGBfMB0WCr.5E6iveIba4rYeUbc
+    folder: null
+    sort: 550000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625796706
+      modifiedTime: 1781625888736
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!u0FWdplSOMTXGnN1.A9Cya4gGBfMB0WCr'
+  - _id: d7cYSxr8w2VZkBrf
+    name: Change Shape
+    type: feat
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} magically polymorphs into a
+          humanoid or beast that has a challenge rating no higher than its own,
+          or back into its true form. It reverts to its true form if it dies.
+          Any equipment it is wearing or carrying is absorbed or borne by the
+          new form (the [[lookup @name lowercase]]{monster}'s choice).</p><p>In
+          a new form, the [[lookup @name lowercase]]{monster} retains its
+          alignment, hit points, Hit Dice, ability to speak, proficiencies,
+          Legendary Resistance, lair actions, and Intelligence, Wisdom, and
+          Charisma scores, as well as this action. Its statistics and
+          capabilities are otherwise replaced by those of the new form, except
+          any class features or legendary actions of that form.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} changes its form into a humanoid or
+          beast!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - mgc
+      activities:
+        WgVVVBedNPAgXuDm:
+          type: transform
+          name: Change Shape into Humanoid or Beast
+          _id: WgVVVBedNPAgXuDm
+          img: ''
+          sort: 100000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: false
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: '@details.cr'
+              name: ''
+              _id: hAZbWYsA1wVyGXVn
+              uuid: null
+              sizes: []
+              types:
+                - beast
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings:
+            effects:
+              - all
+            keep:
+              - mental
+              - skills
+              - languages
+              - items
+              - spells
+              - bio
+            preset: polymorph
+            merge: []
+            other: []
+            spellLists: []
+            transformTokens: true
+            minimumAC: ''
+            tempFormula: ''
+          transform:
+            customize: true
+            mode: cr
+            preset: polymorph
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: change-shape
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 700000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.MO382D2sxtAIuUC5.Item.Fyvg74zRJWn05uhK
+      duplicateSource: Item.gfURBnJDJatlzDXj
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625801055
+      modifiedTime: 1781630669036
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!u0FWdplSOMTXGnN1.d7cYSxr8w2VZkBrf'
+  - _id: A1WQMCZWph8N0Scn
+    name: Detect
+    type: feat
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
+          activation:
+            type: legendary
+            override: false
+            value: 1
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625807771
+      modifiedTime: 1781625807771
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!u0FWdplSOMTXGnN1.A1WQMCZWph8N0Scn'
+  - name: Tail Attack
+    type: feat
+    _id: sUIbO0yWyrbrjmsL
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
+    system:
+      activities:
+        bH5x9SlFErQaWMuP:
+          type: utility
+          activation:
+            type: legendary
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .o9fC6jOW8DlJCqT6]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625808799
+      modifiedTime: 1781625912347
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!u0FWdplSOMTXGnN1.sUIbO0yWyrbrjmsL'
+  - name: Wing Attack
+    type: feat
+    _id: zSDxMl2fiuqd2N4r
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
+      activities:
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1803,16 +2021,14 @@ items:
             condition: ''
             override: false
           consumption:
-            targets:
-              - type: attribute
-                value: '2'
-                target: resources.legact.value
+            targets: []
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1834,6 +2050,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1852,68 +2069,87 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '23'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: wing-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453027938
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!u0FWdplSOMTXGnN1.sacY5ISgjFZCSNUi'
-  - _id: TXjalusRqJTJKFCq
-    name: Breath Weapons
-    type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
-    system:
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Acid Breath.</strong> The dragon exhales acid
-          in an 90-foot line that is 10 feet wide. Each creature in that line
-          must make a [[/save activity=zTWpuajI6meBb52D]] saving throw, taking
-          [[/damage average activity=zTWpuajI6meBb52D]] damage on a failed save,
-          or half as much damage on a successful one.</p><p><strong>Slowing
-          Breath.</strong> The dragon exhales gas in a 90-foot cone. Each
-          creature in that area must succeed on a [[/save
-          activity=CkPMajPOZWWj3gl0]] saving throw. On a failed save, the
-          creature can't use reactions, its speed is halved, and it can't make
-          more than one attack on its turn. In addition, the creature can use
-          either an action or a bonus action on its turn, but not both. These
-          effects last for 1 minute. The creature can repeat the saving throw at
-          the end of each of its turns, ending the effect on itself with a
-          successful save.</p>
-        chat: <p>The dragon breathes in!</p>
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
+      identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625809570
+      modifiedTime: 1781625829423
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
+      exportSource: null
+    _key: '!actors.items!u0FWdplSOMTXGnN1.zSDxMl2fiuqd2N4r'
+  - _id: AbImHzl7eSNwo4ju
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
       source:
         custom: ''
         book: ''
@@ -1922,36 +2158,90 @@ items:
         rules: '2014'
         revision: 1
       uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
+        max: ''
         spent: 0
+        recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 137500
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625916573
+      modifiedTime: 1781625916573
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!u0FWdplSOMTXGnN1.AbImHzl7eSNwo4ju'
+  - _id: IZK4PMn9zx7Ddwoo
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
       activities:
-        zTWpuajI6meBb52D:
-          type: save
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
           activation:
-            type: action
-            value: 1
-            condition: ''
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
             override: false
           consumption:
             targets:
-              - type: itemUses
+              - type: attribute
                 value: '1'
-                target: ''
+                target: resources.legres.value
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1967,14 +2257,15 @@ items:
             template:
               count: ''
               contiguous: false
-              type: line
-              size: '90'
+              type: ''
+              size: ''
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1983,116 +2274,48 @@ items:
             spent: 0
             max: ''
             recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 14
-                denomination: '8'
-                bonus: ''
-                types:
-                  - acid
-          save:
-            ability:
-              - dex
-            dc:
-              calculation: ''
-              formula: '22'
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
           sort: 0
-          _id: zTWpuajI6meBb52D
-          name: Acid Breath
+          name: Persevere
           img: ''
-          appliedEffects: []
-        CkPMajPOZWWj3gl0:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability:
-              - con
-            dc:
-              calculation: ''
-              formula: '22'
-          sort: 0
-          _id: CkPMajPOZWWj3gl0
-          name: Slowing Breath
-          img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
       enchant: {}
       prerequisites:
         level: null
-      identifier: breath-weapons
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
-    sort: 550000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 125000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451884341
+      systemVersion: 6.0.0
+      createdTime: 1781625917313
+      modifiedTime: 1781625917313
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!u0FWdplSOMTXGnN1.TXjalusRqJTJKFCq'
+    _key: '!actors.items!u0FWdplSOMTXGnN1.IZK4PMn9zx7Ddwoo'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -2101,7 +2324,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171264253

--- a/packs/_source/monsters/dragon/ancient-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-copper-dragon.yml
@@ -2152,7 +2152,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -2192,7 +2194,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625916573
-      modifiedTime: 1781625916573
+      modifiedTime: 1781897396541
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!u0FWdplSOMTXGnN1.AbImHzl7eSNwo4ju'

--- a/packs/_source/monsters/dragon/ancient-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-copper-dragon.yml
@@ -1135,7 +1135,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/ancient-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-copper-dragon.yml
@@ -845,10 +845,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .YkCurZ53A7ciRit3]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .eCpXCLFLV7W22orV]]{bite} and two with its [[/item
-          .lsey8RJZiuByt97z]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .YkCurZ53A7ciRit3]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .eCpXCLFLV7W22orV]]{bite} and two with its
+          [[/item .lsey8RJZiuByt97z]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -862,7 +862,7 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -935,9 +935,9 @@ items:
       duplicateSource: null
       coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451770318
+      systemVersion: 6.0.0
+      createdTime: 1783371749027
+      modifiedTime: 1783371750815
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!u0FWdplSOMTXGnN1.8GXBUXkbu1e62ZDK'
@@ -1974,7 +1974,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .o9fC6jOW8DlJCqT6]]{Tail} attack.</p>
+          .o9fC6jOW8DlJCqT6]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -2004,7 +2004,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625808799
-      modifiedTime: 1781625912347
+      modifiedTime: 1783371764494
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/ancient-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-gold-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,161 +478,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 4
 items:
-  - _id: 1k9ihUu6sedelfkA
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1745452173061
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ckOF3vQrnjFnZIDU.1k9ihUu6sedelfkA'
-  - _id: SG0kdaxjbJFUtdrJ
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 200000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452173061
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ckOF3vQrnjFnZIDU.SG0kdaxjbJFUtdrJ'
   - _id: GlvW2Ae0hvh1zCOV
     name: Multiattack
     type: feat
@@ -643,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .ncKFI8v5vPO7kOFi]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .BFbR0db4At8TQY91]]{bite} and two with its [[/item
-          .iqduxJQPzhHPTJp2]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .EIQHfjph1Viay95e]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .BFbR0db4At8TQY91]]{Bite} and two with its
+          [[/item .iqduxJQPzhHPTJp2]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -660,13 +504,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bZR5WrnW63Pq7dKR:
           type: utility
           activation:
             type: action
@@ -681,15 +524,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -700,7 +544,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -717,7 +562,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 200000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: bZR5WrnW63Pq7dKR
       enchant: {}
       prerequisites:
         level: null
@@ -731,22 +584,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452186992
+      systemVersion: 6.0.0
+      createdTime: 1781620442010
+      modifiedTime: 1781620464384
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ckOF3vQrnjFnZIDU.GlvW2Ae0hvh1zCOV'
   - _id: BFbR0db4At8TQY91
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Gold Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -809,7 +664,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -818,8 +673,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        2Uui3pY3SznnAUeI:
           type: attack
           activation:
             type: action
@@ -834,10 +688,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -854,7 +709,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -867,24 +723,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2Uui3pY3SznnAUeI
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -894,22 +763,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452186306
+      systemVersion: 6.0.0
+      createdTime: 1781620023247
+      modifiedTime: 1781620036348
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ckOF3vQrnjFnZIDU.BFbR0db4At8TQY91'
   - _id: iqduxJQPzhHPTJp2
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Gold Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -971,7 +842,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -980,8 +851,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        HVSLj8taf6IXcCe7:
           type: attack
           activation:
             type: action
@@ -996,10 +866,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1016,7 +887,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1029,24 +901,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: HVSLj8taf6IXcCe7
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1056,22 +941,802 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452186306
+      systemVersion: 6.0.0
+      createdTime: 1781620043521
+      modifiedTime: 1781620265840
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ckOF3vQrnjFnZIDU.iqduxJQPzhHPTJp2'
-  - _id: 5dpAWzBBJmkzgvGY
+  - _id: rvfBnm5NdOYH4IrU
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: class
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: 3
+        items:
+          - reptile-bloodline
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 25000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781619998793
+      modifiedTime: 1781620015136
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ckOF3vQrnjFnZIDU.rvfBnm5NdOYH4IrU'
+  - _id: IinZa0G44HlZL1nq
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620000820
+      modifiedTime: 1781620000820
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ckOF3vQrnjFnZIDU.IinZa0G44HlZL1nq'
+  - _id: iLeisecvMZY53czy
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 137500
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620001893
+      modifiedTime: 1781620001893
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ckOF3vQrnjFnZIDU.iLeisecvMZY53czy'
+  - name: Tail Attack
+    type: feat
+    _id: SlyHowiRkRtierXI
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
+    system:
+      activities:
+        bH5x9SlFErQaWMuP:
+          type: utility
+          activation:
+            type: legendary
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .Th6mPQnbWZHsARf4]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620003764
+      modifiedTime: 1781620628959
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!ckOF3vQrnjFnZIDU.SlyHowiRkRtierXI'
+  - _id: EIQHfjph1Viay95e
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        2VOmvThI0bGdUsMt:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '120'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781620005674
+          modifiedTime: 1781620005674
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!ckOF3vQrnjFnZIDU.EIQHfjph1Viay95e.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 450000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620005674
+      modifiedTime: 1781620270690
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ckOF3vQrnjFnZIDU.EIQHfjph1Viay95e'
+  - name: Wing Attack
+    type: feat
+    _id: I5ZsIqGdxTsJxGW4
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
+      activities:
+        4U3711rd7WmlJIhy:
+          type: save
+          activation:
+            type: legendary
+            value: 2
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '15'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
+                denomination: 6
+                bonus: '@mod'
+                types:
+                  - bludgeoning
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: str
+              formula: '18'
+            visible: true
+            bonus: ''
+          sort: 0
+          name: Flap Wings
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
+      identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620007462
+      modifiedTime: 1781620607426
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
+      exportSource: null
+    _key: '!actors.items!ckOF3vQrnjFnZIDU.I5ZsIqGdxTsJxGW4'
+  - _id: ly0rceQFqZCbZTZH
+    name: Detect
+    type: feat
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
+          activation:
+            type: legendary
+            override: false
+            value: 1
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620008656
+      modifiedTime: 1781620008656
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ckOF3vQrnjFnZIDU.ly0rceQFqZCbZTZH'
+  - _id: Th6mPQnbWZHsARf4
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Gold Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1087,7 +1752,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1134,17 +1798,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1159,786 +1821,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-          duration:
-            concentration: false
             value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '20'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: str
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts: []
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail
-    effects: []
-    folder: null
-    sort: 400000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452186306
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ckOF3vQrnjFnZIDU.5dpAWzBBJmkzgvGY'
-  - _id: ncKFI8v5vPO7kOFi
-    name: Frightful Presence
-    type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
-    system:
-      description:
-        value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: creature
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '24'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452401875
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ckOF3vQrnjFnZIDU.ncKFI8v5vPO7kOFi'
-  - _id: j2nbvKIkKdNI32hU
-    name: Breath Weapons
-    type: feat
-    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Fire Breath.</strong> The dragon exhales fire
-          in a 90-foot cone. Each creature in that area must make a [[/save
-          activity=o8fOmWWIqCYwGu3C]] saving throw, taking [[/damage average
-          activity=o8fOmWWIqCYwGu3C]] damage on a failed save, or half as much
-          damage on a successful one.</p><p><strong>Weakening Breath.</strong>
-          The dragon exhales gas in a 90-foot cone. Each creature in that area
-          must succeed on a [[/save activity=J4QhEMZOdsyIy2D6]] saving throw or
-          have disadvantage on Strength-based attack rolls, Strength checks, and
-          Strength saving throws for 1 minute. A creature can repeat the saving
-          throw at the end of each of its turns, ending the effect on itself on
-          a success.</p>
-        chat: <p>The dragon breathes in!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        o8fOmWWIqCYwGu3C:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 13
-                denomination: '10'
-                bonus: ''
-                types:
-                  - fire
-          save:
-            ability:
-              - dex
-            dc:
-              calculation: ''
-              formula: '24'
-          sort: 0
-          _id: o8fOmWWIqCYwGu3C
-          name: Fire Breath
-          img: ''
-          appliedEffects: []
-        J4QhEMZOdsyIy2D6:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability:
-              - str
-            dc:
-              calculation: ''
-              formula: '24'
-          sort: 0
-          _id: J4QhEMZOdsyIy2D6
-          name: Weakening Breath
-          img: ''
-          appliedEffects: []
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: breath-weapons
-    effects: []
-    folder: null
-    sort: 600000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452310838
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ckOF3vQrnjFnZIDU.j2nbvKIkKdNI32hU'
-  - _id: XRmYEohSc8WQkWYT
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452179885
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ckOF3vQrnjFnZIDU.XRmYEohSc8WQkWYT'
-  - _id: MEN285wvE8ocd3E3
-    name: Detect
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: detect
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452432017
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ckOF3vQrnjFnZIDU.MEN285wvE8ocd3E3'
-  - _id: eIY2gDYaffnDNdh3
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
-    system:
-      description:
-        value: <p>The dragon makes a [[/item .5dpAWzBBJmkzgvGY]]{tail} attack.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452457991
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ckOF3vQrnjFnZIDU.eIY2gDYaffnDNdh3'
-  - _id: GZdNj6f2SdN1fr4A
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon beats its wings. Each creature within 15 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 15
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: legendary
-            value: 2
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
           duration:
             concentration: false
             value: ''
@@ -1959,7 +1842,162 @@ items:
               size: ''
               width: ''
               height: ''
-              units: any
+              units: ft
+              stationary: false
+            affects:
+              count: '1'
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          attack:
+            ability: ''
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: ''
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
+      ammunition: {}
+      identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 350000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781620275860
+      modifiedTime: 1781620284726
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ckOF3vQrnjFnZIDU.Th6mPQnbWZHsARf4'
+  - _id: rkt5Li8O6ix5LCKf
+    name: Breath Weapons
+    type: feat
+    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Fire Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=o8fOmWWIqCYwGu3C]]. Each
+          creature in that area must make a [[/save activity=o8fOmWWIqCYwGu3C]]
+          saving throw, taking [[/damage average activity=o8fOmWWIqCYwGu3C]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Weakening Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales gas in a [[lookup
+          @labels.description.template activity=J4QhEMZOdsyIy2D6]]. Each
+          creature in that area must succeed on a [[/save
+          activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+          Strength-based attack rolls, Strength checks, and Strength saving
+          throws for 1 minute. A creature can repeat the saving throw at the end
+          of each of its turns, ending the effect on itself on a success.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        o8fOmWWIqCYwGu3C:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=J4QhEMZOdsyIy2D6]].
+              Each creature in that area must succeed on a [[/save
+              activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+              Strength-based attack rolls, Strength checks, and Strength saving
+              throws for 1 minute. A creature can repeat the saving throw at the
+              end of each of its turns, ending the effect on itself on a
+              success.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '90'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1977,64 +2015,213 @@ items:
               - custom:
                   enabled: false
                   formula: ''
-                number: 2
-                denomination: '6'
-                bonus: '@mod'
+                number: 13
+                denomination: 10
+                bonus: ''
                 types:
-                  - bludgeoning
+                  - fire
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
-              calculation: str
-              formula: '25'
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
           sort: 0
-          name: ''
+          _id: o8fOmWWIqCYwGu3C
+          name: Fire Breath
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: wing-attack
-      mastery: ''
-    effects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+        J4QhEMZOdsyIy2D6:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: a5q0M5lHMSOhKxFi
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '90'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - str
+            dc:
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: J4QhEMZOdsyIy2D6
+          name: Weakening Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        repeatable: false
+        items: []
+      identifier: breath-weapons
+      advancement: {}
+      cover: null
+      crewed: false
+    effects:
+      - name: Weakened
+        img: icons/magic/death/hand-withered-gray.webp
+        origin: Compendium.dnd5e.monsters.Actor.naSoHU9KbkgeNIwB.Item.5vCVx0zwz1FKIvTX
+        transfer: false
+        _id: a5q0M5lHMSOhKxFi
+        type: base
+        system:
+          changes:
+            - key: system.abilities.str.save.roll.mode
+              type: add
+              value: -1
+              phase: initial
+              priority: null
+            - key: system.abilities.str.check.roll.mode
+              type: add
+              value: -1
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are weakened. While weakened, you have disadavntage on
+          Strength-based attack rolls, Strength checks, and Strength saving
+          throws for 1 minute. You can repeat the saving throw at the end of
+          each of your turns, ending the effect on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781620293571
+          modifiedTime: 1781620293571
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!ckOF3vQrnjFnZIDU.rkt5Li8O6ix5LCKf.a5q0M5lHMSOhKxFi
     folder: null
-    sort: 300000
+    sort: 600000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452512059
+      systemVersion: 6.0.0
+      createdTime: 1781620293571
+      modifiedTime: 1781630338783
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!ckOF3vQrnjFnZIDU.GZdNj6f2SdN1fr4A'
-  - _id: 1KAScMfU0fdHhR2g
+    _key: '!actors.items!ckOF3vQrnjFnZIDU.rkt5Li8O6ix5LCKf'
+  - _id: 8Q24x67dK90knBLu
     name: Change Shape
     type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
     system:
       description:
         value: >-
-          <p>The dragon magically polymorphs into a humanoid or beast that has a
-          challenge rating no higher than its own, or back into its true form.
-          It reverts to its true form if it dies. Any equipment it is wearing or
-          carrying is absorbed or borne by the new form (the dragon's
-          choice).</p><p>In a new form, the dragon retains its alignment, hit
-          points, Hit Dice, ability to speak, proficiencies, Legendary
-          Resistance, lair actions, and Intelligence, Wisdom, and Charisma
-          scores, as well as this action. Its statistics and capabilities are
-          otherwise replaced by those of the new form, except any class features
-          or legendary actions of that form.</p>
-        chat: ''
+          <p>The [[lookup @name lowercase]]{monster} magically polymorphs into a
+          humanoid or beast that has a challenge rating no higher than its own,
+          or back into its true form. It reverts to its true form if it dies.
+          Any equipment it is wearing or carrying is absorbed or borne by the
+          new form (the [[lookup @name lowercase]]{monster}'s choice).</p><p>In
+          a new form, the [[lookup @name lowercase]]{monster} retains its
+          alignment, hit points, Hit Dice, ability to speak, proficiencies,
+          Legendary Resistance, lair actions, and Intelligence, Wisdom, and
+          Charisma scores, as well as this action. Its statistics and
+          capabilities are otherwise replaced by those of the new form, except
+          any class features or legendary actions of that form.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} changes its form into a humanoid or
+          beast!</p>
       source:
         custom: ''
         book: ''
@@ -2047,68 +2234,105 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        WgVVVBedNPAgXuDm:
+          type: transform
+          name: Change Shape into Humanoid or Beast
+          _id: WgVVVBedNPAgXuDm
+          img: ''
+          sort: 100000
           activation:
             type: action
-            value: 1
-            condition: ''
             override: false
+            condition: ''
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
-              special: ''
-            prompt: true
+              type: ''
             override: false
+            prompt: false
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: '@details.cr'
+              name: ''
+              _id: hAZbWYsA1wVyGXVn
+              uuid: null
+              sizes: []
+              types:
+                - beast
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings:
+            effects:
+              - all
+            keep:
+              - mental
+              - skills
+              - languages
+              - items
+              - spells
+              - bio
+            preset: polymorph
+            merge: []
+            other: []
+            spellLists: []
+            transformTokens: true
+            minimumAC: ''
+            tempFormula: ''
+          transform:
+            customize: true
+            mode: cr
+            preset: polymorph
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: change-shape
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
     sort: 900000
@@ -2118,14 +2342,14 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.JsAys4RSGi4lN5Jy
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452422280
+      systemVersion: 6.0.0
+      createdTime: 1781620294996
+      modifiedTime: 1781630611911
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!ckOF3vQrnjFnZIDU.1KAScMfU0fdHhR2g'
+    _key: '!actors.items!ckOF3vQrnjFnZIDU.8Q24x67dK90knBLu'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -2134,7 +2358,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171243705

--- a/packs/_source/monsters/dragon/ancient-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-gold-dragon.yml
@@ -979,9 +979,8 @@ items:
       activities: {}
       enchant: {}
       prerequisites:
-        level: 3
-        items:
-          - reptile-bloodline
+        level: null
+        items: []
         repeatable: false
       identifier: amphibious
       advancement: {}

--- a/packs/_source/monsters/dragon/ancient-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-gold-dragon.yml
@@ -489,8 +489,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .EIQHfjph1Viay95e]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .BFbR0db4At8TQY91]]{Bite} and two with its
-          [[/item .iqduxJQPzhHPTJp2]]{Claws}.</p>
+          one with its [[/item .BFbR0db4At8TQY91]]{bite} and two with its
+          [[/item .iqduxJQPzhHPTJp2]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -588,7 +588,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620442010
-      modifiedTime: 1781620464384
+      modifiedTime: 1783371777528
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ckOF3vQrnjFnZIDU.GlvW2Ae0hvh1zCOV'
@@ -1259,7 +1259,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .Th6mPQnbWZHsARf4]]{Tail} attack.</p>
+          .Th6mPQnbWZHsARf4]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -1289,7 +1289,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620003764
-      modifiedTime: 1781620628959
+      modifiedTime: 1783371784933
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/ancient-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-gold-dragon.yml
@@ -1133,7 +1133,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1173,7 +1175,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620001893
-      modifiedTime: 1781620001893
+      modifiedTime: 1781897392307
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ckOF3vQrnjFnZIDU.iLeisecvMZY53czy'

--- a/packs/_source/monsters/dragon/ancient-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-gold-dragon.yml
@@ -1303,12 +1303,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1474,7 +1475,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620005674
-      modifiedTime: 1781620270690
+      modifiedTime: 1781631999268
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ckOF3vQrnjFnZIDU.EIQHfjph1Viay95e'
@@ -1926,8 +1927,9 @@ items:
           creature in that area must succeed on a [[/save
           activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
           Strength-based attack rolls, Strength checks, and Strength saving
-          throws for 1 minute. A creature can repeat the saving throw at the end
-          of each of its turns, ending the effect on itself on a success.</p>
+          throws for [[lookup @labels.duration activity=J4QhEMZOdsyIy2D6]]. A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -2062,7 +2064,15 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-            value: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=J4QhEMZOdsyIy2D6]].
+              Each creature in that area must succeed on a [[/save
+              activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+              Strength-based attack rolls, Strength checks, and Strength saving
+              throws for [[lookup @labels.duration activity=J4QhEMZOdsyIy2D6]].
+              A creature can repeat the saving throw at the end of each of its
+              turns, ending the effect on itself on a success.</p>
           duration:
             concentration: false
             value: '1'
@@ -2197,7 +2207,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781620293571
-      modifiedTime: 1781630338783
+      modifiedTime: 1781631556977
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ckOF3vQrnjFnZIDU.rkt5Li8O6ix5LCKf'

--- a/packs/_source/monsters/dragon/ancient-green-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-green-dragon.yml
@@ -1205,7 +1205,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/ancient-green-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-green-dragon.yml
@@ -1198,12 +1198,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1369,7 +1370,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605400992
-      modifiedTime: 1781605403184
+      modifiedTime: 1781631990367
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!zjqjcRWKDMc59Tnx.CowO8pcqsA4xwGf7'

--- a/packs/_source/monsters/dragon/ancient-green-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-green-dragon.yml
@@ -445,9 +445,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -462,7 +459,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -482,161 +479,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 4
 items:
-  - _id: AyIhVI6Kj5ONGc6I
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1745449430581
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!zjqjcRWKDMc59Tnx.AyIhVI6Kj5ONGc6I'
-  - _id: hu8nutF4VrQWCe3U
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 200000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449430581
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!zjqjcRWKDMc59Tnx.hu8nutF4VrQWCe3U'
   - _id: lQLxY76Q2g6iB9UT
     name: Multiattack
     type: feat
@@ -644,10 +488,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .kZAndihX3RcDqN5P]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .qq17e5u6Bey1aHqo]]{bite} and two with its [[/item
-          .Ja5vvhGRJnCi9YGT]]{claws}.</p>
+          <p>The [[lookup @name lowercase]}{monster} can use its [[/item
+          .CowO8pcqsA4xwGf7]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .qq17e5u6Bey1aHqo]]{Bite} and two with its
+          [[/item .Ja5vvhGRJnCi9YGT]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -661,13 +505,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        wkL79n5qEUxAnBo8:
           type: utility
           activation:
             type: action
@@ -682,15 +525,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -701,7 +545,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -718,7 +563,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: wkL79n5qEUxAnBo8
       enchant: {}
       prerequisites:
         level: null
@@ -732,22 +585,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449433340
+      systemVersion: 6.0.0
+      createdTime: 1781605634044
+      modifiedTime: 1781605638666
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!zjqjcRWKDMc59Tnx.lQLxY76Q2g6iB9UT'
   - _id: qq17e5u6Bey1aHqo
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Green Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -810,7 +665,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -819,8 +674,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        wypPq7iLvOVj4wHT:
           type: attack
           activation:
             type: action
@@ -835,10 +689,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -855,7 +710,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -868,36 +724,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 3
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
                 denomination: 6
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: wypPq7iLvOVj4wHT
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -907,22 +774,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449432537
+      systemVersion: 6.0.0
+      createdTime: 1781605447040
+      modifiedTime: 1781605460508
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!zjqjcRWKDMc59Tnx.qq17e5u6Bey1aHqo'
   - _id: Ja5vvhGRJnCi9YGT
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Green Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -985,7 +854,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -994,8 +863,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        HM0GY7AZbsQ5fpco:
           type: attack
           activation:
             type: action
@@ -1010,10 +878,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1030,7 +899,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1043,24 +913,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: HM0GY7AZbsQ5fpco
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1070,22 +953,436 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449432537
+      systemVersion: 6.0.0
+      createdTime: 1781605469942
+      modifiedTime: 1781605481592
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!zjqjcRWKDMc59Tnx.Ja5vvhGRJnCi9YGT'
-  - _id: X1d4jzEXKYOuvEjT
+  - _id: ZznV7xb0PUnGP7vv
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605387996
+      modifiedTime: 1781605387996
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!zjqjcRWKDMc59Tnx.ZznV7xb0PUnGP7vv'
+  - _id: TBCkZRWkPiWO3Dtp
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605390339
+      modifiedTime: 1781605390339
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!zjqjcRWKDMc59Tnx.TBCkZRWkPiWO3Dtp'
+  - _id: SUKhk8zGKPn2Yrrb
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 600000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605391629
+      modifiedTime: 1781605391629
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!zjqjcRWKDMc59Tnx.SUKhk8zGKPn2Yrrb'
+  - _id: CowO8pcqsA4xwGf7
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        2VOmvThI0bGdUsMt:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '120'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781605400992
+          modifiedTime: 1781605400992
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!zjqjcRWKDMc59Tnx.CowO8pcqsA4xwGf7.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 450000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605400992
+      modifiedTime: 1781605403184
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!zjqjcRWKDMc59Tnx.CowO8pcqsA4xwGf7'
+  - _id: 2SnNjPODAdUjDoaQ
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Green Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1101,7 +1398,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1148,17 +1444,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1173,15 +1467,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            value: '20'
+            value: '15'
             units: ft
             special: ''
             override: false
@@ -1193,9 +1488,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1206,171 +1502,72 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
       mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
     folder: null
-    sort: 400000
+    sort: 425000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449498569
+      systemVersion: 6.0.0
+      createdTime: 1781605408006
+      modifiedTime: 1781605418340
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!zjqjcRWKDMc59Tnx.X1d4jzEXKYOuvEjT'
-  - _id: kZAndihX3RcDqN5P
-    name: Frightful Presence
-    type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
-    system:
-      description:
-        value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: creature
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '19'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449455388
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!zjqjcRWKDMc59Tnx.kZAndihX3RcDqN5P'
-  - _id: 4Ntr5H946Prr6gC0
+    _key: '!actors.items!zjqjcRWKDMc59Tnx.2SnNjPODAdUjDoaQ'
+  - _id: 24ASM5lkwXZkQtEC
     name: Poison Breath
     type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
+    img: icons/skills/toxins/cauldron-bubbles-overflow-green.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales poisonous gas in a 90-foot cone. Each creature
-          in that area must make a [[/save]] saving throw, taking [[/damage
-          average]] damage on a failed save, or half as much damage on a
-          successful one.</p>
+          <p>The [[lookup @name lowercase]]{monster} exhales poisonous gas in a
+          [[lookup @labels.description.template activity=MiNhGAqISi8NVtZa]].
+          Each creature in that area must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
         chat: >-
-          <p>The dragon exhales poisonous gas in a 90-foot cone. Each creature
-          in that area must make a <strong>Constitution</strong> saving
-          throw.</p>
+          <p>The [[lookup @name]]{monster} exhales poisonous gas in a [[lookup
+          @labels.description.template activity=MiNhGAqISi8NVtZa]]. Each
+          creature in that area must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1386,13 +1583,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        MiNhGAqISi8NVtZa:
           type: save
           activation:
             type: action
@@ -1402,17 +1598,16 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1433,9 +1628,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1447,99 +1643,72 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 22
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 22
                 denomination: 6
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
-              calculation: ''
-              formula: '22'
-          sort: 0
+              calculation: con
+              formula: '11'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: MiNhGAqISi8NVtZa
+          name: Exhale Poison
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: poison-breath
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
-    sort: 600000
+    sort: 700000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.JAEclghgOT24pQD9
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449470372
+      systemVersion: 6.0.0
+      createdTime: 1781605487597
+      modifiedTime: 1781605503712
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!zjqjcRWKDMc59Tnx.4Ntr5H946Prr6gC0'
-  - _id: 6y5ZnqreJDNfNzBm
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449430581
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!zjqjcRWKDMc59Tnx.6y5ZnqreJDNfNzBm'
-  - _id: JYKvD7WqfnM7mgru
+    _key: '!actors.items!zjqjcRWKDMc59Tnx.24ASM5lkwXZkQtEC'
+  - _id: 7781gKbWcPVddYQw
     name: Detect
     type: feat
     img: icons/creatures/eyes/lizard-single-slit-blue.webp
     system:
       description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
       source:
         custom: ''
         book: ''
@@ -1552,166 +1721,105 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
           activation:
             type: legendary
+            override: false
             value: 1
             condition: ''
-            override: false
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
+              type: self
               special: ''
-            prompt: true
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: detect
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
-    sort: 0
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449491420
+      systemVersion: 6.0.0
+      createdTime: 1781605520888
+      modifiedTime: 1781605520888
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!zjqjcRWKDMc59Tnx.JYKvD7WqfnM7mgru'
-  - _id: bsXRf7yffdCDv9xp
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!zjqjcRWKDMc59Tnx.7781gKbWcPVddYQw'
+  - name: Tail Attack
+    type: feat
+    _id: rZi8AQyzLC8MWpbv
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
-      description:
-        value: <p>The dragon makes a [[/item .X1d4jzEXKYOuvEjT]]{tail} attack.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bH5x9SlFErQaWMuP:
           type: utility
           activation:
             type: legendary
@@ -1726,15 +1834,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1745,10 +1854,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1763,117 +1873,69 @@ items:
             prompt: false
             visible: false
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449534550
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!zjqjcRWKDMc59Tnx.bsXRf7yffdCDv9xp'
-  - _id: X7cYMwpdqWU6j4kt
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
-    system:
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
       description:
         value: >-
-          <p>The dragon beats its wings. Each creature within 15 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: ''
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .2SnNjPODAdUjDoaQ]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
       source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 15
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
+        rules: '2014'
       crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781605522344
+      modifiedTime: 1781605599743
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!zjqjcRWKDMc59Tnx.rZi8AQyzLC8MWpbv'
+  - name: Wing Attack
+    type: feat
+    _id: ZQgu7hPgoqbnKm1m
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1888,6 +1950,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1909,6 +1972,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1927,45 +1991,79 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '23'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
       identifier: wing-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 300000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453013903
+      systemVersion: 6.0.0
+      createdTime: 1781605524152
+      modifiedTime: 1781605535592
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!zjqjcRWKDMc59Tnx.X7cYMwpdqWU6j4kt'
+    _key: '!actors.items!zjqjcRWKDMc59Tnx.ZQgu7hPgoqbnKm1m'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1974,7 +2072,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171268133

--- a/packs/_source/monsters/dragon/ancient-green-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-green-dragon.yml
@@ -488,10 +488,10 @@ items:
     system:
       description:
         value: >-
-          <p>The [[lookup @name lowercase]}{monster} can use its [[/item
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .CowO8pcqsA4xwGf7]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .qq17e5u6Bey1aHqo]]{Bite} and two with its
-          [[/item .Ja5vvhGRJnCi9YGT]]{Claws}.</p>
+          one with its [[/item .qq17e5u6Bey1aHqo]]{bite} and two with its
+          [[/item .Ja5vvhGRJnCi9YGT]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -589,7 +589,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605634044
-      modifiedTime: 1781605638666
+      modifiedTime: 1783371803733
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!zjqjcRWKDMc59Tnx.lQLxY76Q2g6iB9UT'
@@ -1896,7 +1896,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .2SnNjPODAdUjDoaQ]]{Tail} attack.</p>
+          .2SnNjPODAdUjDoaQ]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -1926,7 +1926,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605522344
-      modifiedTime: 1781605599743
+      modifiedTime: 1783371813712
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/ancient-green-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-green-dragon.yml
@@ -1144,7 +1144,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1184,7 +1186,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781605391629
-      modifiedTime: 1781605391629
+      modifiedTime: 1781897330573
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!zjqjcRWKDMc59Tnx.SUKhk8zGKPn2Yrrb'

--- a/packs/_source/monsters/dragon/ancient-red-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-red-dragon.yml
@@ -1151,7 +1151,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/ancient-red-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-red-dragon.yml
@@ -857,8 +857,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .NMJFBWWE31eRqrxX]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .nOBAY4ulYbWMc8Pz]]{Bite} and two with its
-          [[/item .AheA06jKecElYrVt]]{Claws}.</p>
+          one with its [[/item .nOBAY4ulYbWMc8Pz]]{bite} and two with its
+          [[/item .AheA06jKecElYrVt]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -872,7 +872,7 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -956,7 +956,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781604979567
-      modifiedTime: 1781604987162
+      modifiedTime: 1783371827181
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!vFeFRlF2FOgf2HIL.Whn4pPAB1YSnvocN'
@@ -1842,7 +1842,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .lHDYbbw8RwxjajYk]]{Tail} attack.</p>
+          .lHDYbbw8RwxjajYk]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -1872,7 +1872,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781604995337
-      modifiedTime: 1781605038460
+      modifiedTime: 1783371838099
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/ancient-red-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-red-dragon.yml
@@ -1144,12 +1144,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1315,7 +1316,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781604693834
-      modifiedTime: 1781604695178
+      modifiedTime: 1781631982256
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!vFeFRlF2FOgf2HIL.NMJFBWWE31eRqrxX'

--- a/packs/_source/monsters/dragon/ancient-red-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-red-dragon.yml
@@ -1090,7 +1090,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1130,7 +1132,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781604683518
-      modifiedTime: 1781604683518
+      modifiedTime: 1781897323044
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!vFeFRlF2FOgf2HIL.FQS33bP0xH27cjqc'

--- a/packs/_source/monsters/dragon/ancient-red-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-red-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,15 +478,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 4
 items:
   - _id: nOBAY4ulYbWMc8Pz
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Red Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -552,7 +552,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -561,8 +561,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        48SWm1ImazXc5Vz4:
           type: attack
           activation:
             type: action
@@ -577,10 +576,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -597,7 +597,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -610,36 +611,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 4
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 4
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 48SWm1ImazXc5Vz4
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -649,22 +661,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449914908
+      systemVersion: 6.0.0
+      createdTime: 1781604940039
+      modifiedTime: 1781604951904
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!vFeFRlF2FOgf2HIL.nOBAY4ulYbWMc8Pz'
   - _id: AheA06jKecElYrVt
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Red Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -736,8 +750,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        OiowNXL1vO7gB4qU:
           type: attack
           activation:
             type: action
@@ -752,10 +765,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -772,7 +786,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -785,24 +800,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: OiowNXL1vO7gB4qU
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -812,22 +840,642 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449914908
+      systemVersion: 6.0.0
+      createdTime: 1781604919397
+      modifiedTime: 1781604933846
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!vFeFRlF2FOgf2HIL.AheA06jKecElYrVt'
-  - _id: EjnCigBWyq30VL4S
+  - _id: Whn4pPAB1YSnvocN
+    name: Multiattack
+    type: feat
+    img: icons/skills/melee/blade-tips-triple-steel.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .NMJFBWWE31eRqrxX]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .nOBAY4ulYbWMc8Pz]]{Bite} and two with its
+          [[/item .AheA06jKecElYrVt]]{Claws}.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: ''
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        S9M1XMtTfRQDncpG:
+          type: utility
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 200000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: S9M1XMtTfRQDncpG
+      enchant: {}
+      prerequisites:
+        level: null
+      identifier: multiattack
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604979567
+      modifiedTime: 1781604987162
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!vFeFRlF2FOgf2HIL.Whn4pPAB1YSnvocN'
+  - _id: fuH403ILEZZDG3Zr
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604682404
+      modifiedTime: 1781604682404
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!vFeFRlF2FOgf2HIL.fuH403ILEZZDG3Zr'
+  - _id: FQS33bP0xH27cjqc
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 600000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604683518
+      modifiedTime: 1781604683518
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!vFeFRlF2FOgf2HIL.FQS33bP0xH27cjqc'
+  - _id: NMJFBWWE31eRqrxX
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        2VOmvThI0bGdUsMt:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '120'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781604693834
+          modifiedTime: 1781604693834
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!vFeFRlF2FOgf2HIL.NMJFBWWE31eRqrxX.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 450000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604693834
+      modifiedTime: 1781604695178
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!vFeFRlF2FOgf2HIL.NMJFBWWE31eRqrxX'
+  - _id: YNcRo7g6odnkv8XG
+    name: Fire Breath
+    type: feat
+    img: icons/magic/fire/flame-burning-earth-orange.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=dN04D22jj4eo1ERu]]. Each
+          creature in that area must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=dN04D22jj4eo1ERu]]. Each
+          creature in that area must make a Dexterity saving throw.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        dN04D22jj4eo1ERu:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '90'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 26
+                denomination: 6
+                bonus: ''
+                types:
+                  - fire
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '13'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: dN04D22jj4eo1ERu
+          name: Exhale Fire
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: fire-breath
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.bGSW8IuWURWiWtxr
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604700890
+      modifiedTime: 1781604718849
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!vFeFRlF2FOgf2HIL.YNcRo7g6odnkv8XG'
+  - _id: lHDYbbw8RwxjajYk
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Red Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -843,7 +1491,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -890,17 +1537,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -915,15 +1560,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            value: '20'
+            value: '15'
             units: ft
             special: ''
             override: false
@@ -935,9 +1581,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -948,60 +1595,66 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
     folder: null
-    sort: 400000
+    sort: 425000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449914908
+      systemVersion: 6.0.0
+      createdTime: 1781604888849
+      modifiedTime: 1781604897789
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!vFeFRlF2FOgf2HIL.EjnCigBWyq30VL4S'
-  - _id: LQKBexRS91dTMEKa
-    name: Frightful Presence
+    _key: '!actors.items!vFeFRlF2FOgf2HIL.lHDYbbw8RwxjajYk'
+  - _id: 2lNyRKaXxiaVtDb8
+    name: Detect
     type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
     system:
       description:
         value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
       source:
         custom: ''
         book: ''
@@ -1014,16 +1667,108 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
           activation:
-            type: action
+            type: legendary
+            override: false
+            value: 1
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781604993802
+      modifiedTime: 1781604993802
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!vFeFRlF2FOgf2HIL.2lNyRKaXxiaVtDb8'
+  - name: Tail Attack
+    type: feat
+    _id: F0esYcVWv0S1hxwl
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
+    system:
+      activities:
+        bH5x9SlFErQaWMuP:
+          type: utility
+          activation:
+            type: legendary
             value: 1
             condition: ''
             override: false
@@ -1035,123 +1780,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: creature
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: wis
-            dc:
-              calculation: ''
-              formula: '21'
-          sort: 0
-          name: ''
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449936582
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!vFeFRlF2FOgf2HIL.LQKBexRS91dTMEKa'
-  - _id: wUEVmK5TEnYsMuwJ
-    name: Fire Breath
-    type: feat
-    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon exhales fire in a 90-foot cone. Each creature in that
-          area must make a [[/save]] saving throw, taking [[/damage average]]
-          damage on a failed save, or half as much damage on a successful
-          one.</p>
-        chat: >-
-          <p>The dragon exhales fire in a 90-foot cone. Each creature in that
-          area must make a <strong>Dexterity</strong> saving throw.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-                scaling: {}
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1167,14 +1796,15 @@ items:
             template:
               count: ''
               contiguous: false
-              type: cone
-              size: '90'
+              type: ''
+              size: ''
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1183,543 +1813,75 @@ items:
             spent: 0
             max: ''
             recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 26
-                denomination: 6
-                bonus: ''
-                types:
-                  - fire
-                scaling:
-                  number: 1
-          save:
-            ability: dex
-            dc:
-              calculation: ''
-              formula: '24'
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
           sort: 0
-          name: ''
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: fire-breath
-    effects: []
-    folder: null
-    sort: 600000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.bGSW8IuWURWiWtxr
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449953643
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!vFeFRlF2FOgf2HIL.wUEVmK5TEnYsMuwJ'
-  - _id: CGGqslZMTHbSwRwP
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
       description:
         value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449906861
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!vFeFRlF2FOgf2HIL.CGGqslZMTHbSwRwP'
-  - _id: Whn4pPAB1YSnvocN
-    name: Multiattack
-    type: feat
-    img: icons/skills/melee/blade-tips-triple-steel.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon can use its [[/item .LQKBexRS91dTMEKa]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .nOBAY4ulYbWMc8Pz]]{bite} and two with its [[/item
-          .AheA06jKecElYrVt]]{claws}.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: multiattack
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449915623
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!vFeFRlF2FOgf2HIL.Whn4pPAB1YSnvocN'
-  - _id: diR3Lju2cmIwIOyG
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449912158
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!vFeFRlF2FOgf2HIL.diR3Lju2cmIwIOyG'
-  - _id: rOXIh3YF5Aiu8aVC
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
-    system:
-      description:
-        value: <p>The dragon makes a [[/item .EjnCigBWyq30VL4S]]{tail} attack.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: simpleM
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .lHDYbbw8RwxjajYk]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
       identifier: tail-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 100000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449985142
+      systemVersion: 6.0.0
+      createdTime: 1781604995337
+      modifiedTime: 1781605038460
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
       exportSource: null
-    _key: '!actors.items!vFeFRlF2FOgf2HIL.rOXIh3YF5Aiu8aVC'
-  - _id: 0fheJO7kmH1UV99g
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
+    _key: '!actors.items!vFeFRlF2FOgf2HIL.F0esYcVWv0S1hxwl'
+  - name: Wing Attack
+    type: feat
+    _id: H9jw4u1UuLiO3nGr
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
     system:
-      description:
-        value: >-
-          <p>The dragon beats its wings. Each creature within 15 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 15
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1727,16 +1889,14 @@ items:
             condition: ''
             override: false
           consumption:
-            targets:
-              - type: attribute
-                value: '2'
-                target: resources.legact.value
+            targets: []
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1758,6 +1918,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1776,148 +1937,79 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '25'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      mastery: ''
-      identifier: wing-attack
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745453002000
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!vFeFRlF2FOgf2HIL.0fheJO7kmH1UV99g'
-  - _id: 7WxDZHowVjqC4DfC
-    name: Detect
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
       uses:
-        max: ''
-        recovery: []
         spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
+      identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
       enchant: {}
       prerequisites:
+        items: []
+        repeatable: false
         level: null
-      identifier: detect
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 0
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449967366
+      systemVersion: 6.0.0
+      createdTime: 1781604996590
+      modifiedTime: 1781605004724
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
       exportSource: null
-    _key: '!actors.items!vFeFRlF2FOgf2HIL.7WxDZHowVjqC4DfC'
+    _key: '!actors.items!vFeFRlF2FOgf2HIL.H9jw4u1UuLiO3nGr'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1926,7 +2018,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171265139

--- a/packs/_source/monsters/dragon/ancient-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-silver-dragon.yml
@@ -1071,7 +1071,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1111,7 +1113,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625087365
-      modifiedTime: 1781625087365
+      modifiedTime: 1781897317817
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!gf9QbHdMAfvFtxcv.NUJIqHFBI9Bjuxae'

--- a/packs/_source/monsters/dragon/ancient-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-silver-dragon.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,115 +478,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 4
 items:
-  - _id: gcXX5P25Hed1CHt2
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties:
-        - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452619613
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!gf9QbHdMAfvFtxcv.gcXX5P25Hed1CHt2'
   - _id: shoHSForHM2cwBtd
     name: Multiattack
     type: feat
@@ -597,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .ohWgcdw603aWWXum]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .YCbR7M5CKKCFWLvk]]{bite} and two with its [[/item
-          .YHoeJdvSJaT3qblq]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster] can use its [[/item
+          .mkEH0cxZiY4KL8Hq]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .YCbR7M5CKKCFWLvk]]{Bite} and two with its
+          [[/item .YHoeJdvSJaT3qblq]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -614,13 +504,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        mcp0tpw8LTE4uzL3:
           type: utility
           activation:
             type: action
@@ -635,15 +524,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -654,7 +544,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -671,7 +562,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: mcp0tpw8LTE4uzL3
       enchant: {}
       prerequisites:
         level: null
@@ -685,22 +584,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452622572
+      systemVersion: 6.0.0
+      createdTime: 1781625291738
+      modifiedTime: 1781625297645
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!gf9QbHdMAfvFtxcv.shoHSForHM2cwBtd'
   - _id: YCbR7M5CKKCFWLvk
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Silver Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -763,7 +664,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -772,8 +673,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        0FLT9se4d2caBraE:
           type: attack
           activation:
             type: action
@@ -788,10 +688,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -808,7 +709,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -821,24 +723,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 0FLT9se4d2caBraE
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -848,22 +763,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452621883
+      systemVersion: 6.0.0
+      createdTime: 1781625166467
+      modifiedTime: 1781625181434
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!gf9QbHdMAfvFtxcv.YCbR7M5CKKCFWLvk'
   - _id: YHoeJdvSJaT3qblq
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Silver Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -926,7 +843,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -935,8 +852,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        fHEfC68h7SFKbq2g:
           type: attack
           activation:
             type: action
@@ -951,10 +867,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -971,7 +888,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -984,24 +902,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 300000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: fHEfC68h7SFKbq2g
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1011,22 +942,312 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452621883
+      systemVersion: 6.0.0
+      createdTime: 1781625128404
+      modifiedTime: 1781625161572
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!gf9QbHdMAfvFtxcv.YHoeJdvSJaT3qblq'
-  - _id: VlNQwm636T7qIEoQ
+  - _id: GMOVbnqJ2kl00H9C
+    name: Detect
+    type: feat
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
+          activation:
+            type: legendary
+            override: false
+            value: 1
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625086357
+      modifiedTime: 1781625086357
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!gf9QbHdMAfvFtxcv.GMOVbnqJ2kl00H9C'
+  - _id: NUJIqHFBI9Bjuxae
+    name: Legendary Actions
+    type: feat
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
+    system:
+      description:
+        value: <p>[[lookup @resources.legact.label]]</p>
+        chat: <p>The dragon can take 3 legendary actions. </p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 137500
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625087365
+      modifiedTime: 1781625087365
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!gf9QbHdMAfvFtxcv.NUJIqHFBI9Bjuxae'
+  - _id: uHduVzkHsopciFzV
+    name: Legendary Resistance
+    type: feat
+    img: icons/equipment/shield/targe-steel-blue.webp
+    system:
+      description:
+        value: >-
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625088403
+      modifiedTime: 1781625088403
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!gf9QbHdMAfvFtxcv.uHduVzkHsopciFzV'
+  - _id: xYyW1XeR1TcbHh8p
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient Silver Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1042,7 +1263,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1089,17 +1309,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1114,15 +1332,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            value: '20'
+            value: '15'
             units: ft
             special: ''
             override: false
@@ -1134,9 +1353,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1147,60 +1367,328 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
-    folder: null
-    sort: 400000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 375000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452621883
+      systemVersion: 6.0.0
+      createdTime: 1781625089324
+      modifiedTime: 1781625122080
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!gf9QbHdMAfvFtxcv.VlNQwm636T7qIEoQ'
-  - _id: ohWgcdw603aWWXum
-    name: Frightful Presence
+    _key: '!actors.items!gf9QbHdMAfvFtxcv.xYyW1XeR1TcbHh8p'
+  - name: Tail Attack
     type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
+    _id: XoxXuh9qfCZ9Z4tT
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
+    system:
+      activities:
+        bH5x9SlFErQaWMuP:
+          type: utility
+          activation:
+            type: legendary
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .xYyW1XeR1TcbHh8p]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
+      identifier: tail-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625090327
+      modifiedTime: 1781625336529
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
+      exportSource: null
+    _key: '!actors.items!gf9QbHdMAfvFtxcv.XoxXuh9qfCZ9Z4tT'
+  - name: Wing Attack
+    type: feat
+    _id: sNdseIDCIfYFVjrX
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
+    system:
+      activities:
+        4U3711rd7WmlJIhy:
+          type: save
+          activation:
+            type: legendary
+            value: 2
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '15'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: any
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
+                denomination: 6
+                bonus: '@mod'
+                types:
+                  - bludgeoning
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: str
+              formula: '18'
+            visible: true
+            bonus: ''
+          sort: 0
+          name: Flap Wings
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
+      identifier: wing-attack
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 350000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625091573
+      modifiedTime: 1781625322817
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
+      exportSource: null
+    _key: '!actors.items!gf9QbHdMAfvFtxcv.sNdseIDCIfYFVjrX'
+  - _id: Tg07Xnjs5DvVFYmM
+    name: Change Shape
+    type: feat
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
     system:
       description:
         value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically polymorphs into a
+          humanoid or beast that has a challenge rating no higher than its own,
+          or back into its true form. It reverts to its true form if it dies.
+          Any equipment it is wearing or carrying is absorbed or borne by the
+          new form (the [[lookup @name lowercase]]{monster}'s choice).</p><p>In
+          a new form, the [[lookup @name lowercase]]{monster} retains its
+          alignment, hit points, Hit Dice, ability to speak, proficiencies,
+          Legendary Resistance, lair actions, and Intelligence, Wisdom, and
+          Charisma scores, as well as this action. Its statistics and
+          capabilities are otherwise replaced by those of the new form, except
+          any class features or legendary actions of that form.</p>
         chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
+          <p>The [[lookup @name]]{monster} changes its form into a humanoid or
+          beast!</p>
       source:
         custom: ''
         book: ''
@@ -1213,13 +1701,162 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - mgc
+      activities:
+        WgVVVBedNPAgXuDm:
+          type: transform
+          name: Change Shape into Humanoid or Beast
+          _id: WgVVVBedNPAgXuDm
+          img: ''
+          sort: 100000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: false
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: '@details.cr'
+              name: ''
+              _id: hAZbWYsA1wVyGXVn
+              uuid: null
+              sizes: []
+              types:
+                - beast
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings:
+            effects:
+              - all
+            keep:
+              - mental
+              - skills
+              - languages
+              - items
+              - spells
+              - bio
+            preset: polymorph
+            merge: []
+            other: []
+            spellLists: []
+            transformTokens: true
+            minimumAC: ''
+            tempFormula: ''
+          transform:
+            customize: true
+            mode: cr
+            preset: polymorph
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: change-shape
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 1000000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.MO382D2sxtAIuUC5.Item.Fyvg74zRJWn05uhK
+      duplicateSource: Item.gfURBnJDJatlzDXj
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781625093000
+      modifiedTime: 1781630635074
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!gf9QbHdMAfvFtxcv.Tg07Xnjs5DvVFYmM'
+  - _id: mkEH0cxZiY4KL8Hq
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        2VOmvThI0bGdUsMt:
           type: save
           activation:
             type: action
@@ -1234,13 +1871,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '120'
             units: ft
@@ -1255,6 +1898,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1267,55 +1911,119 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
-              calculation: ''
-              formula: '21'
-          sort: 0
-          name: ''
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 500000
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781625096712
+          modifiedTime: 1781625096712
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!gf9QbHdMAfvFtxcv.mkEH0cxZiY4KL8Hq.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 450000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452799050
+      systemVersion: 6.0.0
+      createdTime: 1781625096712
+      modifiedTime: 1781625098474
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!gf9QbHdMAfvFtxcv.ohWgcdw603aWWXum'
-  - _id: oL7vyWwH6bvXyl95
+    _key: '!actors.items!gf9QbHdMAfvFtxcv.mkEH0cxZiY4KL8Hq'
+  - _id: eBC65VcONbhbFHwI
     name: Breath Weapons
     type: feat
     img: icons/creatures/abilities/dragon-ice-breath-blue.webp
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Cold Breath.</strong> The dragon exhales an icy
-          blast in a 90-foot cone. Each creature in that area must make a
-          [[/save activity=U5F5qe2Hu0r0yHmk]] saving throw, taking [[/damage
-          average activity=U5F5qe2Hu0r0yHmk]] damage on a failed save, or half
-          as much damage on a successful one.</p><p><strong>Paralyzing
-          Breath.</strong> The dragon exhales paralyzing gas in a 90- foot cone.
-          Each creature in that area must succeed on a [[/save
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Cold Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales an icy blast in a [[lookup
+          @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
+          creature in that area must make a [[/save activity=U5F5qe2Hu0r0yHmk]]
+          saving throw, taking [[/damage average activity=U5F5qe2Hu0r0yHmk]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Paralyzing Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales paralyzing gas in a [[lookup
+          @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
+          creature in that area must succeed on a [[/save
           activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for 1 minute.
           A creature can repeat the saving throw at the end of each of its
           turns, ending the effect on itself on a success.</p>
-        chat: <p>The dragon breathes in!</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -1331,7 +2039,7 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -1348,12 +2056,20 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales an icy blast in
+              a [[lookup @labels.description.labels activity=9gMvqjbgKK42uyzr]].
+              Each creature in that area must make a [[/save
+              activity=U5F5qe2Hu0r0yHmk]] saving throw, taking [[/damage average
+              activity=U5F5qe2Hu0r0yHmk]] damage on a failed save, or half as
+              much damage on a successful one.</p>
           duration:
             concentration: false
             value: ''
@@ -1374,9 +2090,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1392,21 +2109,33 @@ items:
                   enabled: false
                   formula: ''
                 number: 15
-                denomination: '8'
+                denomination: 8
                 bonus: ''
                 types:
                   - cold
+                scaling:
+                  number: 1
           save:
             ability:
               - con
             dc:
-              calculation: ''
-              formula: '24'
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
           sort: 0
           _id: U5F5qe2Hu0r0yHmk
           name: Cold Breath
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
         9gMvqjbgKK42uyzr:
           type: save
           activation:
@@ -1419,19 +2148,33 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales paralyzing gas
+              in a [[lookup @labels.description.template
+              activity=9gMvqjbgKK42uyzr]]. Each creature in that area must
+              succeed on a [[/save activity=9gMvqjbgKK42uyzr]] saving throw or
+              be paralyzed for 1 minute. A creature can repeat the saving throw
+              at the end of each of its turns, ending the effect on itself on a
+              success.</p>
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: yYbmtst3L1jGwwbF
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             units: self
             special: ''
@@ -1445,9 +2188,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1457,637 +2201,96 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability:
               - con
             dc:
-              calculation: ''
-              formula: '24'
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
           sort: 0
           _id: 9gMvqjbgKK42uyzr
           name: Paralyzing Breath
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
       enchant: {}
       prerequisites:
         level: null
+        repeatable: false
+        items: []
       identifier: breath-weapons
-    effects: []
+      advancement: {}
+      cover: null
+      crewed: false
+    effects:
+      - name: Paralyzing Breath
+        img: icons/magic/control/debuff-chains-shackles-movement-purple.webp
+        origin: Compendium.dnd5e.monsters.Actor.J1QVPd8POvcPaqx4.Item.ENcwNUKxDAqH6V9l
+        transfer: false
+        _id: yYbmtst3L1jGwwbF
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[paralyzed apply=false] for 1 minute. You can
+          repeat the saving throw at the end of each of your turns, ending the
+          effect on yourself.</p>
+        tint: '#ffffff'
+        statuses:
+          - paralyzed
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781625100983
+          modifiedTime: 1781625100983
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!gf9QbHdMAfvFtxcv.eBC65VcONbhbFHwI.yYbmtst3L1jGwwbF
     folder: null
     sort: 600000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452691089
+      systemVersion: 6.0.0
+      createdTime: 1781625100983
+      modifiedTime: 1781625212413
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!gf9QbHdMAfvFtxcv.oL7vyWwH6bvXyl95'
-  - _id: nnMmiUPuJEyViPaq
-    name: Change Shape
-    type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon magically polymorphs into a humanoid or beast that has a
-          challenge rating no higher than its own, or back into its true form.
-          It reverts to its true form if it dies. Any equipment it is wearing or
-          carrying is absorbed or borne by the new form (the dragon's
-          choice).</p><p>In a new form, the dragon retains its alignment, hit
-          points, Hit Dice, ability to speak, proficiencies, Legendary
-          Resistance, lair actions, and Intelligence, Wisdom, and Charisma
-          scores, as well as this action. Its statistics and capabilities are
-          otherwise replaced by those of the new form, except any class features
-          or legendary actions of that form.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: change-shape
-    effects: []
-    folder: null
-    sort: 900000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.JsAys4RSGi4lN5Jy
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452830733
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!gf9QbHdMAfvFtxcv.nnMmiUPuJEyViPaq'
-  - _id: yAVNzttgGO1cHIlQ
-    name: Legendary Actions
-    type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon can take 3 legendary actions. Only one legendary action
-          option can be used at a time and only at the end of another creature's
-          turn. The dragon regains spent legendary actions at the start of its
-          turn.</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.2.0
-      createdTime: null
-      modifiedTime: 1736804677031
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!gf9QbHdMAfvFtxcv.yAVNzttgGO1cHIlQ'
-  - _id: tg4h1Ht7X4YmDTd9
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
-    system:
-      description:
-        value: <p>The dragon makes a [[/item .VlNQwm636T7qIEoQ]]{tail} attack.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: tail-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452889994
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!gf9QbHdMAfvFtxcv.tg4h1Ht7X4YmDTd9'
-  - _id: saU6KEYGTm2SZ3jv
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
-    system:
-      description:
-        value: "<p>The dragon beats its wings. Each creature within\_15 feet of the dragon must succeed on a\_[[/save]] saving throw\_or take\_[[/damage average]]\_damage and be knocked &amp;Reference[prone]. The dragon can then fly up to half its flying speed.</p>"
-        chat: >-
-          <p>The dragon beats its wings! Each creature within 15 feet of the
-          dragon must make a <strong>Dexterity</strong> saving throw.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: legendary
-            value: 2
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                value: '2'
-                target: resources.legact.value
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 2
-                denomination: '6'
-                bonus: '@mod'
-                types:
-                  - bludgeoning
-          save:
-            ability: dex
-            dc:
-              calculation: str
-              formula: '25'
-          sort: 0
-          name: ''
-          img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: wing-attack
-      mastery: ''
-    effects: []
-    folder: null
-    sort: 300000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452954488
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!gf9QbHdMAfvFtxcv.saU6KEYGTm2SZ3jv'
-  - _id: fu7gTjVI9Dk9J8tT
-    name: Detect
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: detect
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452842489
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!gf9QbHdMAfvFtxcv.fu7gTjVI9Dk9J8tT'
+    _key: '!actors.items!gf9QbHdMAfvFtxcv.eBC65VcONbhbFHwI'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -2096,7 +2299,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171248471

--- a/packs/_source/monsters/dragon/ancient-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-silver-dragon.yml
@@ -1834,7 +1834,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/ancient-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-silver-dragon.yml
@@ -2235,7 +2235,7 @@ items:
       crewed: false
     effects:
       - name: Paralyzing Breath
-        img: icons/magic/control/debuff-chains-shackles-movement-purple.webp
+        img: icons/magic/unholy/energy-smoke-pink.webp
         origin: Compendium.dnd5e.monsters.Actor.J1QVPd8POvcPaqx4.Item.ENcwNUKxDAqH6V9l
         transfer: false
         _id: yYbmtst3L1jGwwbF
@@ -2268,7 +2268,7 @@ items:
           systemId: dnd5e
           systemVersion: 6.0.0
           createdTime: 1781625100983
-          modifiedTime: 1781625100983
+          modifiedTime: 1781630936796
           lastModifiedBy: dnd5ebuilder0000
           compendiumSource: null
           duplicateSource: null

--- a/packs/_source/monsters/dragon/ancient-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-silver-dragon.yml
@@ -489,8 +489,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster] can use its [[/item
           .mkEH0cxZiY4KL8Hq]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .YCbR7M5CKKCFWLvk]]{Bite} and two with its
-          [[/item .YHoeJdvSJaT3qblq]]{Claws}.</p>
+          one with its [[/item .YCbR7M5CKKCFWLvk]]{bite} and two with its
+          [[/item .YHoeJdvSJaT3qblq]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -588,7 +588,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625291738
-      modifiedTime: 1781625297645
+      modifiedTime: 1783371847464
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!gf9QbHdMAfvFtxcv.shoHSForHM2cwBtd'
@@ -1499,7 +1499,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .xYyW1XeR1TcbHh8p]]{Tail} attack.</p>
+          .xYyW1XeR1TcbHh8p]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -1529,7 +1529,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625090327
-      modifiedTime: 1781625336529
+      modifiedTime: 1783371854136
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/ancient-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-silver-dragon.yml
@@ -1827,12 +1827,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1998,7 +1999,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625096712
-      modifiedTime: 1781625098474
+      modifiedTime: 1781631975518
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!gf9QbHdMAfvFtxcv.mkEH0cxZiY4KL8Hq'
@@ -2020,9 +2021,10 @@ items:
           lowercase]]{monster} exhales paralyzing gas in a [[lookup
           @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
           creature in that area must succeed on a [[/save
-          activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for 1 minute.
-          A creature can repeat the saving throw at the end of each of its
-          turns, ending the effect on itself on a success.</p>
+          activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for [[lookup
+          @labels.duration activity=9gMvqjbgKK42uyzr]]. A creature can repeat
+          the saving throw at the end of each of its turns, ending the effect on
+          itself on a success.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -2160,9 +2162,10 @@ items:
               in a [[lookup @labels.description.template
               activity=9gMvqjbgKK42uyzr]]. Each creature in that area must
               succeed on a [[/save activity=9gMvqjbgKK42uyzr]] saving throw or
-              be paralyzed for 1 minute. A creature can repeat the saving throw
-              at the end of each of its turns, ending the effect on itself on a
-              success.</p>
+              be paralyzed for [[lookup @labels.duration
+              activity=9gMvqjbgKK42uyzr]]. A creature can repeat the saving
+              throw at the end of each of its turns, ending the effect on itself
+              on a success.</p>
           duration:
             concentration: false
             value: '1'
@@ -2287,7 +2290,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781625100983
-      modifiedTime: 1781625212413
+      modifiedTime: 1781631645881
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!gf9QbHdMAfvFtxcv.eBC65VcONbhbFHwI'

--- a/packs/_source/monsters/dragon/ancient-white-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-white-dragon.yml
@@ -1095,7 +1095,9 @@ items:
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
-        chat: <p>The dragon can take 3 legendary actions. </p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} can take [[lookup
+          @resources.legact.max]] legendary actions.</p>
       source:
         custom: ''
         book: ''
@@ -1135,7 +1137,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567200316
-      modifiedTime: 1781567200316
+      modifiedTime: 1781897312124
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!aTITHYYxthuZBPBn.5tvfgCEHBBQj7IzQ'

--- a/packs/_source/monsters/dragon/ancient-white-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-white-dragon.yml
@@ -1204,12 +1204,13 @@ items:
           <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
           that is within [[lookup @labels.description.range
           activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
-          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
-          minute.</p><p>A creature can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success. If a
-          creature's saving throw is successful or the effect ends for it, the
-          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
-          [[lookup @item.name]] for the next 24 hours.</p>
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=2VOmvThI0bGdUsMt]].</p><p>A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success. If a creature's saving throw
+          is successful or the effect ends for it, the creature is immune to the
+          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is
           within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
@@ -1375,7 +1376,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567214326
-      modifiedTime: 1781567351471
+      modifiedTime: 1781631968071
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!aTITHYYxthuZBPBn.DeqgPZF8smOMxmVH'

--- a/packs/_source/monsters/dragon/ancient-white-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-white-dragon.yml
@@ -72,6 +72,11 @@ system:
       walk: 40
       units: ft
       hover: false
+      bonus: ''
+      ignoredDifficultTerrain:
+        - snow
+        - ice
+      special: ''
     attunement:
       max: 3
     senses:
@@ -444,9 +449,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +463,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,15 +483,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 4
 items:
   - _id: NB88hf8oRtLwBolX
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient White Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -552,7 +557,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -561,8 +566,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        Y7PXRUvePPyCIKRn:
           type: attack
           activation:
             type: action
@@ -577,10 +581,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -597,7 +602,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -610,61 +616,74 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 8
                 bonus: ''
                 types:
                   - cold
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: Y7PXRUvePPyCIKRn
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
-    sort: 100000
+    sort: 200000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450227090
+      systemVersion: 6.0.0
+      createdTime: 1781567351470
+      modifiedTime: 1781567416092
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!aTITHYYxthuZBPBn.NB88hf8oRtLwBolX'
   - _id: Cz5xqvQ50f5zxuNY
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient White Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -727,7 +746,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -736,8 +755,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        EWWd3aT1Vm8VIsJq:
           type: attack
           activation:
             type: action
@@ -752,10 +770,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -772,7 +791,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -785,24 +805,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: EWWd3aT1Vm8VIsJq
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -812,28 +845,26 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450227090
+      systemVersion: 6.0.0
+      createdTime: 1781567387034
+      modifiedTime: 1781567398580
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!aTITHYYxthuZBPBn.Cz5xqvQ50f5zxuNY'
-  - _id: VtIk8lLDM4Qj3uOl
-    name: Cold Breath
+  - _id: UGfL5qnzzi2y2pNj
+    name: Multiattack
     type: feat
-    img: icons/creatures/abilities/dragon-ice-breath-blue.webp
+    img: icons/skills/melee/blade-tips-triple-steel.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales an icy blast in a 90-foot cone. Each creature in
-          that area must make a [[/save]] saving throw, taking [[/damage
-          average]] damage on a failed save, or half as much damage on a
-          successful one.</p>
-        chat: >-
-          <p>The dragon exhales an icy blast in a 90-foot cone. Each creature in
-          that area must make a <strong>Constitution</strong> saving throw.</p>
+          <p>The [[lookup @name lowercase]]{monster} can use its [[/item
+          .DeqgPZF8smOMxmVH]]{Frightful Presence}. It then makes three attacks:
+          one with its [[/item .NB88hf8oRtLwBolX]]{Bite} and two with its
+          [[/item .Cz5xqvQ50f5zxuNY]]{Claws}.</p>
+        chat: ''
       source:
         custom: ''
         book: ''
@@ -842,40 +873,31 @@ items:
         rules: '2014'
         revision: 1
       uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
+        max: ''
+        recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
+        ldzmPAis9plip4SR:
+          type: utility
           activation:
             type: action
             value: 1
             condition: ''
             override: false
           consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+            targets: []
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -891,125 +913,12 @@ items:
             template:
               count: ''
               contiguous: false
-              type: cone
-              size: '90'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - number: 16
-                denomination: 8
-                bonus: ''
-                types:
-                  - cold
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          save:
-            ability: con
-            dc:
-              calculation: ''
-              formula: '22'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: cold-breath
-    effects: []
-    folder: null
-    sort: 500000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.iHOaiOqwUWIfCljJ
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450271778
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!aTITHYYxthuZBPBn.VtIk8lLDM4Qj3uOl'
-  - _id: 2LAZaoPDRIvnHwtf
-    name: Detect
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>The dragon makes a Wisdom (Perception) check.</p>
-        chat: <p>The dragon watches its surrounding...</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: legendary
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
               type: ''
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1026,156 +935,45 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: ldzmPAis9plip4SR
       enchant: {}
       prerequisites:
         level: null
-      identifier: detect
+      identifier: multiattack
     effects: []
     folder: null
-    sort: 200000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450283331
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!aTITHYYxthuZBPBn.2LAZaoPDRIvnHwtf'
-  - _id: sYtyFXYWqxWT1uUI
-    name: Frightful Presence
-    type: feat
-    img: icons/creatures/unholy/demons-horned-glowing-pink.webp
-    system:
-      description:
-        value: >-
-          <p>Each creature of the dragon's choice that is within 120 feet of the
-          dragon and aware of it must succeed on a [[/save]] saving throw or
-          become &amp;Reference[frightened] for 1 minute.</p><p>A creature can
-          repeat the saving throw at the end of each of its turns, ending the
-          effect on itself on a success. If a creature's saving throw is
-          successful or the effect ends for it, the creature is immune to the
-          dragon's Frightful Presence for the next 24 hours .</p>
-        chat: >-
-          <p>Each creature of the dragon's choice that is <strong>within 120
-          feet</strong> of the dragon and aware of it must succeed on a Wisdom
-          saving throw. A creature can repeat the saving throw at the end of
-          each of its turns.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '1'
-            units: minute
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '120'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: ''
-              width: ''
-              height: ''
-              units: any
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability: cha
-            dc:
-              calculation: ''
-              formula: '16'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: frightful-presence
-    effects: []
-    folder: null
-    sort: 450000
+    sort: 100000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nb6zOmwIIJBLz4iT
+      compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450255291
+      systemVersion: 6.0.0
+      createdTime: 1781567311729
+      modifiedTime: 1781567351470
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!aTITHYYxthuZBPBn.sYtyFXYWqxWT1uUI'
-  - _id: fgHGU46JtSboc23B
-    name: Ice Walk
+    _key: '!actors.items!aTITHYYxthuZBPBn.UGfL5qnzzi2y2pNj'
+  - _id: bAsXALDREBIsF9y9
+    name: Legendary Resistance
     type: feat
-    img: icons/magic/water/water-iceberg-bubbles.webp
+    img: icons/equipment/shield/targe-steel-blue.webp
     system:
       description:
         value: >-
-          <p>The dragon can move across and climb icy surfaces without needing
-          to make an ability check. Additionally, difficult terrain composed of
-          ice or snow doesn't cost it extra movement.</p>
+          <p>If the [[lookup @name lowercase]]{monster} fails a saving throw, it
+          can choose to succeed instead.</p>
         chat: ''
       source:
         custom: ''
@@ -1186,39 +984,114 @@ items:
         revision: 1
       uses:
         max: ''
-        spent: 0
         recovery: []
+        spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
-      activities: {}
+      properties:
+        - trait
+      activities:
+        dnd5eactivity000:
+          _id: dnd5eactivity000
+          type: utility
+          activation:
+            type: special
+            value: null
+            condition: When the [[lookup @name lowercase]]{monster} fails a saving throw.
+            override: false
+          consumption:
+            targets:
+              - type: attribute
+                value: '1'
+                target: resources.legres.value
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 0
+          name: Persevere
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
       enchant: {}
       prerequisites:
         level: null
-      identifier: ice-walk
+        items: []
+        repeatable: false
+      identifier: legendary-resistance
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
-    sort: 100000
+    sort: 500000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.YKC7pwYkJSKn1vuw
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.6gjpG1ezpMNyJDGc
+      duplicateSource: Item.MwYDaI9opLjPGaPA
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1745450214566
+      systemVersion: 6.0.0
+      createdTime: 1781567198622
+      modifiedTime: 1781567198622
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!aTITHYYxthuZBPBn.fgHGU46JtSboc23B'
-  - _id: rtz0KAuj9DeBKT8A
+    _key: '!actors.items!aTITHYYxthuZBPBn.bAsXALDREBIsF9y9'
+  - _id: 5tvfgCEHBBQj7IzQ
     name: Legendary Actions
     type: feat
-    img: icons/magic/light/hand-sparks-glow-yellow.webp
+    img: icons/skills/melee/weapons-crossed-swords-teal.webp
     system:
       description:
         value: <p>[[lookup @resources.legact.label]]</p>
@@ -1235,152 +1108,114 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: legendary-actions
-    effects: []
-    folder: null
-    sort: 400000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.terEuqr148hQBkIq
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450223573
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!aTITHYYxthuZBPBn.rtz0KAuj9DeBKT8A'
-  - _id: b8vjJzQ5ha5CqneP
-    name: Legendary Resistance
-    type: feat
-    img: icons/equipment/shield/kite-wooden-oak-glow.webp
-    system:
-      description:
-        value: >-
-          <p>If the dragon fails a saving throw, it can choose to succeed
-          instead.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties:
         - trait
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: special
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: attribute
-                target: resources.legres.value
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+      activities: {}
       enchant: {}
       prerequisites:
         level: null
-      identifier: legendary-resistance
+        items: []
+        repeatable: false
+      identifier: legendary-actions
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
-    sort: 200000
+    sort: 600000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.J1NxNTJ2qi05iAFF
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.tWGObm0RZMwSrQLU
+      duplicateSource: Item.iG1TPGZxSyxA5B9l
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450214566
+      systemVersion: 6.0.0
+      createdTime: 1781567200316
+      modifiedTime: 1781567200316
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!aTITHYYxthuZBPBn.b8vjJzQ5ha5CqneP'
-  - _id: UGfL5qnzzi2y2pNj
-    name: Multiattack
+    _key: '!actors.items!aTITHYYxthuZBPBn.5tvfgCEHBBQj7IzQ'
+  - _id: imkVNL6yWfO8SvHL
+    name: Ice Walk
     type: feat
-    img: icons/skills/melee/blade-tips-triple-steel.webp
+    img: icons/magic/water/water-iceberg-bubbles.webp
     system:
       description:
         value: >-
-          <p>The dragon can use its [[/item .sYtyFXYWqxWT1uUI]]{Frightful
-          Presence}. It then makes three attacks: one with its [[/item
-          .NB88hf8oRtLwBolX]]{bite} and two with its [[/item
-          .Cz5xqvQ50f5zxuNY]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can move across and climb
+          icy surfaces without needing to make an ability check. Additionally,
+          &amp;reference[difficult terrain] composed of ice or snow doesn't cost
+          it extra movement.</p>
         chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: ice-walk
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.3uIursokd3KdZrW3.Item.xlZuzbYZtDVFGyVz
+      duplicateSource: Item.0jxdFtoxuJFkRe8R
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567202542
+      modifiedTime: 1781567202542
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!aTITHYYxthuZBPBn.imkVNL6yWfO8SvHL'
+  - _id: DeqgPZF8smOMxmVH
+    name: Frightful Presence
+    type: feat
+    img: icons/creatures/reptiles/dragon-horned-blue.webp
+    system:
+      description:
+        value: >-
+          <p>Each creature of the [[lookup @name lowercase]]{monster}'s choice
+          that is within [[lookup @labels.description.range
+          activity=2VOmvThI0bGdUsMt]] of the dragon and aware of it must succeed
+          on a [[/save]] saving throw or become &amp;Reference[frightened] for 1
+          minute.</p><p>A creature can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{mosnter}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
+        chat: >-
+          <p>Each creature of the [[lookup @name]]{monster}'s choice that is
+          within [[lookup @labels.description.range activity=2VOmvThI0bGdUsMt]]
+          of the [[lookup @name]]{monster} and aware of it must succeed on a
+          Wisdom saving throw. A creature can repeat the saving throw at the end
+          of each of its turns.</p>
       source:
         custom: ''
         book: ''
@@ -1393,14 +1228,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        2VOmvThI0bGdUsMt:
+          type: save
           activation:
             type: action
             value: 1
@@ -1414,15 +1248,22 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
-            value: ''
-            units: ''
+            value: '1'
+            units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: JG2uXIqEJlTnRHpq
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
-            units: ''
+            value: '120'
+            units: ft
             special: ''
             override: false
           target:
@@ -1433,10 +1274,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: any
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1445,41 +1287,108 @@ items:
             spent: 0
             max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - wis
+            dc:
+              calculation: cha
+              formula: '16'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2VOmvThI0bGdUsMt
       enchant: {}
       prerequisites:
         level: null
-      identifier: multiattack
-    effects: []
-    folder: null
-    sort: 0
+        items: []
+        repeatable: false
+      identifier: frightful-presence
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Frightful Presence
+        img: icons/creatures/reptiles/dragon-horned-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+        transfer: false
+        _id: JG2uXIqEJlTnRHpq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success. If your saving
+          throw is successful or the effect ends for you, you are immune to the
+          dragon's Frightful Presence for the next 24 hours.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781567214326
+          modifiedTime: 1781567214326
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!aTITHYYxthuZBPBn.DeqgPZF8smOMxmVH.JG2uXIqEJlTnRHpq
+    folder: 5cwqjeuI64dkrUa8
+    sort: 500000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.A3azHlbNcHLRgogu
+      duplicateSource: Item.MsuiWclOG7d6FE0U
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450227849
+      systemVersion: 6.0.0
+      createdTime: 1781567214326
+      modifiedTime: 1781567351471
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!aTITHYYxthuZBPBn.UGfL5qnzzi2y2pNj'
-  - _id: Q3Nd59qtQ5rsGs6c
+    _key: '!actors.items!aTITHYYxthuZBPBn.DeqgPZF8smOMxmVH'
+  - _id: qxKOBs4I2CLSeCJY
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ancient White Dragon attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1495,7 +1404,6 @@ items:
         value: 0
         denomination: gp
       attunement: ''
-      equipped: true
       rarity: ''
       identified: true
       cover: null
@@ -1542,17 +1450,15 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: natural
         baseItem: ''
       container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        RceN2X8wNhuTxjLr:
           type: attack
           activation:
             type: action
@@ -1567,15 +1473,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            value: '20'
+            value: '15'
             units: ft
             special: ''
             override: false
@@ -1587,9 +1494,10 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
+              count: '1'
               type: ''
               choice: false
               special: ''
@@ -1600,24 +1508,39 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-      attuned: false
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: RceN2X8wNhuTxjLr
+          name: ''
       ammunition: {}
-      magicalBonus: null
       identifier: tail
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
     effects: []
     folder: null
     sort: 400000
@@ -1625,24 +1548,26 @@ items:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.t9FrDQLVCU8x4obw
+      duplicateSource: Item.bz6wDllAaYd7bwWv
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450227090
+      systemVersion: 6.0.0
+      createdTime: 1781567345617
+      modifiedTime: 1781567369304
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!aTITHYYxthuZBPBn.Q3Nd59qtQ5rsGs6c'
-  - _id: zu4q8DV9mStLmBeN
-    name: Tail Attack
-    type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    _key: '!actors.items!aTITHYYxthuZBPBn.qxKOBs4I2CLSeCJY'
+  - _id: nCeKL8yoB4CR1Enc
+    name: Detect
+    type: feat
+    img: icons/creatures/eyes/lizard-single-slit-blue.webp
     system:
       description:
-        value: <p>The dragon makes a [[/item .Q3Nd59qtQ5rsGs6c]]{tail} attack.</p>
-        chat: ''
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a Wisdom (Perception)
+          check.</p>
+        chat: <p>The [[lookup @name]]{monster} watches its surrounding...</p>
       source:
         custom: ''
         book: ''
@@ -1650,68 +1575,110 @@ items:
         license: CC-BY-4.0
         rules: '2014'
         revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ''
-        reach: null
       uses:
         max: ''
         recovery: []
         spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: null
-          denomination: 0
-          types: []
-          custom:
-            enabled: false
-          scaling:
-            number: 1
-          bonus: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
       type:
-        value: simpleM
-        baseItem: ''
-      container: null
-      crewed: false
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        efOEi8J50goW5M9v:
+          type: check
+          name: Look Around
+          _id: efOEi8J50goW5M9v
+          img: ''
+          sort: 100000
+          activation:
+            type: legendary
+            override: false
+            value: 1
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - prc
+            dc:
+              calculation: ''
+              formula: ''
+            visible: true
+            ability: ''
+            bonus: ''
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: detect
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.RnqMV5Ur5n9S3wIt
+      duplicateSource: Item.oTLqdQ8KvIfo9Fbc
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567426256
+      modifiedTime: 1781567426256
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!aTITHYYxthuZBPBn.nCeKL8yoB4CR1Enc'
+  - name: Tail Attack
+    type: feat
+    _id: Fx66mIor2imnS9m9
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
+    system:
+      activities:
+        bH5x9SlFErQaWMuP:
           type: utility
           activation:
             type: legendary
@@ -1726,15 +1693,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1745,10 +1713,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1763,117 +1732,69 @@ items:
             prompt: false
             visible: false
           sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bH5x9SlFErQaWMuP
+          name: Swing Tail
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes a [[/item
+          .qxKOBs4I2CLSeCJY]]{Tail} attack.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} slams its long tail against its
+          foe!</p>
       identifier: tail-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
+    folder: 5cwqjeuI64dkrUa8
     sort: 250000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450307289
+      systemVersion: 6.0.0
+      createdTime: 1781567432641
+      modifiedTime: 1781567610082
       lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
+      duplicateSource: Item.MNSBoigqkD6fGpA2
       exportSource: null
-    _key: '!actors.items!aTITHYYxthuZBPBn.zu4q8DV9mStLmBeN'
-  - _id: DQGSNN2zFqmnBy9R
-    name: Wing Attack
-    type: weapon
-    img: icons/creatures/abilities/wing-batlike-white-blue.webp
+    _key: '!actors.items!aTITHYYxthuZBPBn.Fx66mIor2imnS9m9'
+  - name: Wing Attack
+    type: feat
+    _id: pGuesBrMPVXJKZuN
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
     system:
-      description:
-        value: >-
-          <p>The dragon beats its wings. Each creature within 15 feet of the
-          dragon must succeed on a [[/save]] saving throw or take [[/damage
-          average]] damage and be knocked &amp;Reference[prone]. The dragon can
-          then fly up to half its flying speed.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 15
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 6
-          bonus: ''
-          types:
-            - bludgeoning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4U3711rd7WmlJIhy:
           type: save
           activation:
             type: legendary
@@ -1888,6 +1809,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1909,6 +1831,7 @@ items:
               width: ''
               height: ''
               units: any
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -1927,45 +1850,226 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '6'
+                denomination: 6
                 bonus: '@mod'
                 types:
                   - bludgeoning
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: str
-              formula: '22'
+              formula: '18'
+            visible: true
+            bonus: ''
           sort: 0
-          name: ''
+          name: Flap Wings
           img: ''
-          appliedEffects: []
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4U3711rd7WmlJIhy
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} beats its wings. Each
+          creature within [[lookup @labels.description.range
+          activity=4U3711rd7WmlJIhy]] of the [[lookup @name lowercase]]{monster}
+          must succeed on a [[/save]] saving throw or take [[/damage average]]
+          damage and be knocked &amp;Reference[prone]. The [[lookup @name
+          lowercase]]{monster} can then fly up to half its flying speed.</p>
+        chat: <p>The [[lookup @name]]{monster} beats its wings!</p>
       identifier: wing-attack
-      mastery: ''
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties: []
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
     effects: []
-    folder: null
-    sort: 300000
+    folder: 5cwqjeuI64dkrUa8
+    sort: 275000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452985457
+      systemVersion: 6.0.0
+      createdTime: 1781567437139
+      modifiedTime: 1781567460469
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iUiQzMwuCHfvZMPB
+      duplicateSource: Item.FGCzDDxM3wgj2EUY
+      exportSource: null
+    _key: '!actors.items!aTITHYYxthuZBPBn.pGuesBrMPVXJKZuN'
+  - _id: B6x6ELPZ0slZPuXN
+    name: Cold Breath
+    type: feat
+    img: icons/magic/water/projectile-ice-orb-white.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} exhales an icy blast of
+          hail in a [[lookup @labels.description.template
+          activity=UF4fJlhyYiLM7XeM]]. Each creature in that area must make a
+          [[/save]] saving throw, taking [[/damage average]] damage on a failed
+          save, or half as much damage on a successful one.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} exhales an icy blast of hail in a
+          [[lookup @labels.description.template activity=UF4fJlhyYiLM7XeM]].
+          Each creature in that area must make a Constitution saving throw.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: ''
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        UF4fJlhyYiLM7XeM:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '90'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 16
+                denomination: 8
+                bonus: ''
+                types:
+                  - cold
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - con
+            dc:
+              calculation: con
+              formula: '12'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: UF4fJlhyYiLM7XeM
+          name: Exhale Ice
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: cold-breath
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 700000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.iHOaiOqwUWIfCljJ
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781567619761
+      modifiedTime: 1781567631951
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!aTITHYYxthuZBPBn.DQGSNN2zFqmnBy9R'
+    _key: '!actors.items!aTITHYYxthuZBPBn.B6x6ELPZ0slZPuXN'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1974,11 +2078,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 6.0.0
   createdTime: 1726171240847
-  modifiedTime: 1745450344984
+  modifiedTime: 1781567660121
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!aTITHYYxthuZBPBn'

--- a/packs/_source/monsters/dragon/ancient-white-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-white-dragon.yml
@@ -862,8 +862,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can use its [[/item
           .DeqgPZF8smOMxmVH]]{Frightful Presence}. It then makes three attacks:
-          one with its [[/item .NB88hf8oRtLwBolX]]{Bite} and two with its
-          [[/item .Cz5xqvQ50f5zxuNY]]{Claws}.</p>
+          one with its [[/item .NB88hf8oRtLwBolX]]{bite} and two with its
+          [[/item .Cz5xqvQ50f5zxuNY]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -961,7 +961,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567311729
-      modifiedTime: 1781567351470
+      modifiedTime: 1783371870941
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!aTITHYYxthuZBPBn.UGfL5qnzzi2y2pNj'
@@ -1755,7 +1755,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes a [[/item
-          .qxKOBs4I2CLSeCJY]]{Tail} attack.</p>
+          .qxKOBs4I2CLSeCJY]]{tail} attack.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} slams its long tail against its
           foe!</p>
@@ -1785,7 +1785,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781567432641
-      modifiedTime: 1781567610082
+      modifiedTime: 1783371860717
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: Compendium.dnd5e.monsters.Actor.M4eX4Mu5IHCr3TMf.Item.iXsGJD1VHeJYYSev
       duplicateSource: Item.MNSBoigqkD6fGpA2

--- a/packs/_source/monsters/dragon/ancient-white-dragon.yml
+++ b/packs/_source/monsters/dragon/ancient-white-dragon.yml
@@ -1211,7 +1211,7 @@ items:
           creature can repeat the saving throw at the end of each of its turns,
           ending the effect on itself on a success. If a creature's saving throw
           is successful or the effect ends for it, the creature is immune to the
-          [[lookup @name lowercase]]{mosnter}'s [[lookup @item.name]] for the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
           next 24 hours.</p>
         chat: >-
           <p>Each creature of the [[lookup @name]]{monster}'s choice that is

--- a/packs/_source/monsters/dragon/black-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/black-dragon-wyrmling.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,22 +480,24 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: ABS9Om2RejM5wrRF
     name: Acid Breath
     type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
+    img: icons/magic/acid/projectile-faceted-glob.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales acid in a 15-foot line that is 5 feet wide. Each
+          <p>The [[lookup @name lowercase]]{monster} exhales acid in a [[lookup
+          @labels.description.template activity=KkzK6MGHKa5GCAwQ]]. Each
           creature in that line must make a [[/save]] saving throw, taking
           [[/damage average]] damage on a failed save, or half as much damage on
           a successful one.</p>
         chat: >-
-          <p>The dragon exhales acid in a 15-foot line that is 5 feet wide. Each
-          creature in that line must make a <strong>Dexterity</strong> saving
-          throw.</p>
+          <p>The [[lookup @name]]{monster} exhales acid in a [[lookup
+          @labels.description.template activity=KkzK6MGHKa5GCAwQ]]. Each
+          creature in that line must make a Dexterity saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -519,8 +518,7 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        KkzK6MGHKa5GCAwQ:
           type: save
           activation:
             type: action
@@ -530,17 +528,16 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -558,12 +555,13 @@ items:
               contiguous: false
               type: line
               size: '15'
-              width: ''
+              width: '5'
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -575,99 +573,68 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 5
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 5
                 denomination: 8
                 bonus: ''
                 types:
                   - acid
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '11'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: KkzK6MGHKa5GCAwQ
+          name: Exhale Acid
       enchant: {}
       prerequisites:
         level: null
       identifier: acid-breath
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.zjcGly9P3Gn9MXt7
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448963548
+      systemVersion: 6.0.0
+      createdTime: 1781551660439
+      modifiedTime: 1781556527305
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!IZMbiAHqQpzPo0CX.ABS9Om2RejM5wrRF'
-  - _id: 50udgXso5dIQmQfv
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!IZMbiAHqQpzPo0CX.50udgXso5dIQmQfv'
   - _id: dmLvn6VGNA20rMvC
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Black Dragon Wyrmling attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -730,7 +697,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -739,8 +706,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        qepPwTFb858W2XhE:
           type: attack
           activation:
             type: action
@@ -755,6 +721,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -763,7 +730,7 @@ items:
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -774,7 +741,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -787,14 +755,14 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
@@ -804,14 +772,25 @@ items:
                   enabled: false
                   formula: ''
                 number: 1
-                denomination: '4'
+                denomination: 4
                 bonus: ''
                 types:
                   - acid
-          sort: 0
+                scaling:
+                  number: 1
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: qepPwTFb858W2XhE
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -822,22 +801,71 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448943537
+      systemVersion: 6.0.0
+      createdTime: 1781551683596
+      modifiedTime: 1781551703825
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!IZMbiAHqQpzPo0CX.dmLvn6VGNA20rMvC'
+  - _id: ysyx12MLFCQpD3NA
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781551656651
+      modifiedTime: 1781551656651
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!IZMbiAHqQpzPo0CX.ysyx12MLFCQpD3NA'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -846,7 +874,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171219596

--- a/packs/_source/monsters/dragon/blue-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/blue-dragon-wyrmling.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,15 +480,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: VkmpLaL0RYt8WrzR
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Blue Dragon Wyrmling attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -554,7 +554,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -563,8 +563,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        xlQg7811Srm0CIDf:
           type: attack
           activation:
             type: action
@@ -579,10 +578,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -599,7 +599,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -612,36 +613,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 6
                 bonus: ''
                 types:
                   - lightning
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: xlQg7811Srm0CIDf
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -651,29 +663,30 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107553347
+      systemVersion: 6.0.0
+      createdTime: 1781556559109
+      modifiedTime: 1781556575122
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!najtPRiHLR6buSWe.VkmpLaL0RYt8WrzR'
   - _id: 7LCUjJcHm3odI9C8
     name: Lightning Breath
     type: feat
-    img: icons/magic/lightning/bolt-strike-blue.webp
+    img: icons/magic/lightning/bolt-beam-strike-blue.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales lightning in a 30-foot line that is 5 feet wide.
-          Each creature in that line must make a [[/save]] saving throw, taking
+          <p>The dragon exhales lightning in a [[lookup
+          @labels.description.template activity=GSQtl90Opu6WzZk4]]. Each
+          creature in that line must make a [[/save]] saving throw, taking
           [[/damage average]] damage on a failed save, or half as much damage on
           a successful one.</p>
         chat: >-
-          <p>The dragon exhales lightning in a 30-foot line that is 5 feet wide.
-          Each creature in that line must make a <strong>Dexterity</strong>
-          saving throw.</p>
+          <p>The [[lookup @name]]{monster} exhales lightning in a [[lookup
+          @labels.description.template activity=GSQtl90Opu6WzZk4]]. Each
+          creature in that line must make a Dexterity saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -694,8 +707,7 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        GSQtl90Opu6WzZk4:
           type: save
           activation:
             type: action
@@ -705,17 +717,16 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -733,12 +744,13 @@ items:
               contiguous: false
               type: line
               size: '30'
-              width: ''
+              width: '5'
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -750,24 +762,37 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 4
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 4
                 denomination: 10
                 bonus: ''
                 types:
                   - lightning
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
-              calculation: ''
+              calculation: con
               formula: '12'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: GSQtl90Opu6WzZk4
+          name: Exhale Lightning
       enchant: {}
       prerequisites:
         level: null
@@ -781,11 +806,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.LVnd9fq9cQj7rR0Q
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449334034
+      systemVersion: 6.0.0
+      createdTime: 1781556592369
+      modifiedTime: 1781561997913
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!najtPRiHLR6buSWe.7LCUjJcHm3odI9C8'
@@ -797,7 +822,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171256690

--- a/packs/_source/monsters/dragon/brass-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/brass-dragon-wyrmling.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,15 +480,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: K4qz0HVrX4JxcUvf
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Brass Dragon Wyrmling attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -554,7 +554,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -563,8 +563,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        IeVp0dLBwMeEgH7m:
           type: attack
           activation:
             type: action
@@ -579,10 +578,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -599,7 +599,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -612,24 +613,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: IeVp0dLBwMeEgH7m
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -639,11 +653,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107552334
+      systemVersion: 6.0.0
+      createdTime: 1781557803960
+      modifiedTime: 1781557818477
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!azCbLQt5LAYwTI7U.K4qz0HVrX4JxcUvf'
@@ -654,19 +668,22 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Fire Breath.</strong> The dragon exhales fire
-          in an 20-foot line that is 5 feet wide. Each creature in that line
-          must make a [[/save activity=NBdXGRF1vahbq4p8]] saving throw, taking
-          [[/damage average activity=NBdXGRF1vahbq4p8]] damage on a failed save,
-          or half as much damage on a successful one.</p><p><strong>Sleep
-          Breath.</strong> The dragon exhales sleep gas in a 15-foot cone. Each
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Fire Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales fire in an [[lookup
+          @labels.description.template activity=NBdXGRF1vahbq4p8]]. Each
+          creature in that line must make a [[/save activity=NBdXGRF1vahbq4p8]]
+          saving throw, taking [[/damage average activity=NBdXGRF1vahbq4p8]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Sleep Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales sleep gas in a [[lookup
+          @labels.description.template activity=O02zuaLvAqtmgutQ]]. Each
           creature in that area must succeed on a [[/save
           activity=O02zuaLvAqtmgutQ]] saving throw or fall
           &amp;Reference[unconscious] for 1 minute. This effect ends for a
           creature if the creature takes damage or someone uses an action to
           wake it.</p>
-        chat: <p>The dragon breathes in!</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -682,7 +699,7 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -705,6 +722,13 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales fire in an
+              [[lookup @labels.description.template activity=NBdXGRF1vahbq4p8]].
+              Each creature in that line must make a [[/save
+              activity=NBdXGRF1vahbq4p8]] saving throw, taking [[/damage average
+              activity=NBdXGRF1vahbq4p8]] damage on a failed save, or half as
+              much damage on a successful one.</p>
           duration:
             concentration: false
             value: ''
@@ -727,7 +751,7 @@ items:
               units: ft
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -751,13 +775,19 @@ items:
             ability:
               - dex
             dc:
-              calculation: ''
+              calculation: con
               formula: '11'
+            bonus: ''
           sort: 0
           _id: NBdXGRF1vahbq4p8
           name: Fire Breath
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
         O02zuaLvAqtmgutQ:
           type: save
           activation:
@@ -776,13 +806,26 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales sleep gas in a
+              [[lookup @labels.description.template activity=O02zuaLvAqtmgutQ]].
+              Each creature in that area must succeed on a [[/save
+              activity=O02zuaLvAqtmgutQ]] saving throw or fall
+              &amp;Reference[unconscious] for 1 minute. This effect ends for a
+              creature if the creature takes damage or someone uses an action to
+              wake it.</p>
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: P1rGrKiV7x2OMiN0
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             units: self
             special: ''
@@ -798,7 +841,7 @@ items:
               units: ft
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -808,41 +851,84 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability:
               - con
             dc:
-              calculation: ''
+              calculation: con
               formula: '11'
+            bonus: ''
           sort: 0
           _id: O02zuaLvAqtmgutQ
           name: Sleep Breath
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
       enchant: {}
       prerequisites:
         level: null
       identifier: breath-weapons
-    effects: []
+    effects:
+      - name: Sleep Breath
+        img: icons/magic/control/sleep-bubble-purple.webp
+        origin: Compendium.dnd5e.monsters.Actor.azCbLQt5LAYwTI7U.Item.JmVLjWM4G6OOQxl4
+        transfer: false
+        _id: P1rGrKiV7x2OMiN0
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[unconcious apply=false] for 1 minute. This
+          effect ends for you when you take damage or when someone uses and
+          action to wake you.</p>
+        tint: '#ffffff'
+        statuses:
+          - unconscious
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781558004553
+          modifiedTime: 1781558077291
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!azCbLQt5LAYwTI7U.JmVLjWM4G6OOQxl4.P1rGrKiV7x2OMiN0
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451197657
+      systemVersion: 6.0.0
+      createdTime: 1781557850642
+      modifiedTime: 1781620840512
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!azCbLQt5LAYwTI7U.JmVLjWM4G6OOQxl4'
@@ -854,7 +940,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171241110

--- a/packs/_source/monsters/dragon/brass-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/brass-dragon-wyrmling.yml
@@ -680,9 +680,9 @@ items:
           @labels.description.template activity=O02zuaLvAqtmgutQ]]. Each
           creature in that area must succeed on a [[/save
           activity=O02zuaLvAqtmgutQ]] saving throw or fall
-          &amp;Reference[unconscious] for 1 minute. This effect ends for a
-          creature if the creature takes damage or someone uses an action to
-          wake it.</p>
+          &amp;Reference[unconscious] for [[lookup @labels.duration
+          activity=O02zuaLvAqtmgutQ]]. This effect ends for a creature if the
+          creature takes damage or someone uses an action to wake it.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -811,9 +811,10 @@ items:
               [[lookup @labels.description.template activity=O02zuaLvAqtmgutQ]].
               Each creature in that area must succeed on a [[/save
               activity=O02zuaLvAqtmgutQ]] saving throw or fall
-              &amp;Reference[unconscious] for 1 minute. This effect ends for a
-              creature if the creature takes damage or someone uses an action to
-              wake it.</p>
+              &amp;Reference[unconscious] for [[lookup @labels.duration
+              activity=O02zuaLvAqtmgutQ]]. This effect ends for a creature if
+              the creature takes damage or someone uses an action to wake
+              it.</p>
           duration:
             concentration: false
             value: '1'
@@ -928,7 +929,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781557850642
-      modifiedTime: 1781620840512
+      modifiedTime: 1781631823320
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!azCbLQt5LAYwTI7U.JmVLjWM4G6OOQxl4'

--- a/packs/_source/monsters/dragon/bronze-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/bronze-dragon-wyrmling.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,61 +480,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
-  - _id: H2dPYlwoo8MOstEQ
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!hY9ptpO5Xl2tfkcj.H2dPYlwoo8MOstEQ'
   - _id: Vq0dUbodqBggQAVQ
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Bronze Dragon Wyrmling attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -600,7 +554,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -609,8 +563,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        gN4otqBKsGr3vuL6:
           type: attack
           activation:
             type: action
@@ -625,10 +578,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -645,7 +599,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -658,24 +613,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: gN4otqBKsGr3vuL6
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -685,11 +653,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107552828
+      systemVersion: 6.0.0
+      createdTime: 1781558277369
+      modifiedTime: 1781558290052
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!hY9ptpO5Xl2tfkcj.Vq0dUbodqBggQAVQ'
@@ -700,17 +668,21 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Lightning Breath.</strong> The dragon exhales
-          lightning in a 120-foot line that is 10 feet wide. Each creature in
-          that line must make a [[/save activity=w2CftR6CLr5PZ7zY]] saving
-          throw, taking [[/damage average activity=w2CftR6CLr5PZ7zY]] damage on
-          a failed save, or half as much damage on a successful
-          one.</p><p><strong>Repulsion Breath.</strong> The dragon exhales
-          repulsion energy in a 30-foot cone. Each creature in that area must
-          succeed on a [[/save activity=YElWYv6C5UfhAu48]] saving throw. On a
-          failed save, the creature is pushed 60 feet away from the dragon.</p>
-        chat: <p>The dragon breathes in!</p>
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Lightning Breath.</strong> The [[lookup
+          @name lowercase]]{monster} exhales lightning in a [[lookup
+          @labels.description.template activity=w2CftR6CLr5PZ7zY]]. Each
+          creature in that line must make a [[/save activity=w2CftR6CLr5PZ7zY]]
+          saving throw, taking [[/damage average activity=w2CftR6CLr5PZ7zY]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Repulsion Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales repulsion energy in a [[lookup
+          @labels.description.template activity=YElWYv6C5UfhAu48]]. Each
+          creature in that area must succeed on a [[/save
+          activity=YElWYv6C5UfhAu48]] saving throw. On a failed save, the
+          creature is pushed 60 feet away from the [[lookup @name
+          lowercase]]{monster}.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -726,7 +698,7 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -749,6 +721,13 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales lightning in a
+              [[lookup @labels.description.template activity=w2CftR6CLr5PZ7zY]].
+              Each creature in that line must make a [[/save
+              activity=w2CftR6CLr5PZ7zY]] saving throw, taking [[/damage average
+              activity=w2CftR6CLr5PZ7zY]] damage on a failed save, or half as
+              much damage on a successful one.</p>
           duration:
             concentration: false
             value: ''
@@ -766,12 +745,12 @@ items:
               contiguous: false
               type: line
               size: '120'
-              width: ''
+              width: '5'
               height: ''
               units: ft
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -795,13 +774,19 @@ items:
             ability:
               - dex
             dc:
-              calculation: ''
+              calculation: con
               formula: '12'
+            bonus: ''
           sort: 0
           _id: w2CftR6CLr5PZ7zY
           name: Lightning Breath
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
         YElWYv6C5UfhAu48:
           type: save
           activation:
@@ -820,6 +805,13 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales repulsion
+              energy in a [[lookup @labels.description.template
+              activity=YElWYv6C5UfhAu48]]. Each creature in that area must
+              succeed on a [[/save activity=YElWYv6C5UfhAu48]] saving throw. On
+              a failed save, the creature is pushed 60 feet away from the
+              [[lookup @name lowercase]]{monster}.</p>
           duration:
             concentration: false
             value: ''
@@ -842,7 +834,7 @@ items:
               units: ft
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -852,19 +844,25 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability:
               - str
             dc:
-              calculation: ''
+              calculation: con
               formula: '12'
+            bonus: ''
           sort: 0
           _id: YElWYv6C5UfhAu48
           name: Repulsion Breath
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
       enchant: {}
       prerequisites:
         level: null
@@ -878,22 +876,71 @@ items:
     sort: 600000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
+      systemVersion: 6.0.0
       createdTime: 1745451478894
-      modifiedTime: 1745451510953
+      modifiedTime: 1781562678621
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!hY9ptpO5Xl2tfkcj.DogAlXwHCyvsBynk'
+  - _id: HhVw9jFpoaxhcvrn
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781558272817
+      modifiedTime: 1781558272817
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!hY9ptpO5Xl2tfkcj.HhVw9jFpoaxhcvrn'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -902,7 +949,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171249513

--- a/packs/_source/monsters/dragon/copper-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/copper-dragon-wyrmling.yml
@@ -683,8 +683,9 @@ items:
           creature can't use reactions, its speed is halved, and it can't make
           more than one attack on its turn. In addition, the creature can use
           either an action or a bonus action on its turn, but not both. These
-          effects last for 1 minute. The creature can repeat the saving throw at
-          the end of each of its turns, ending the effect on itself with a
+          effects last for [[lookup @labels.duration
+          activity=CkPMajPOZWWj3gl0]]. The creature can repeat the saving throw
+          at the end of each of its turns, ending the effect on itself with a
           successful save.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
@@ -817,9 +818,10 @@ items:
               creature can't use reactions, its speed is halved, and it can't
               make more than one attack on its turn. In addition, the creature
               can use either an action or a bonus action on its turn, but not
-              both. These effects last for 1 minute. The creature can repeat the
-              saving throw at the end of each of its turns, ending the effect on
-              itself with a successful save.</p>
+              both. These effects last for [[lookup @labels.duration
+              activity=CkPMajPOZWWj3gl0]]. The creature can repeat the saving
+              throw at the end of each of its turns, ending the effect on itself
+              with a successful save.</p>
           duration:
             concentration: false
             value: '1'
@@ -828,8 +830,10 @@ items:
             override: false
           effects:
             - _id: 5E6iveIba4rYeUbc
-              level: {}
               onSave: false
+              level:
+                min: null
+                max: null
           range:
             units: self
             special: ''
@@ -963,7 +967,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1745451913418
-      modifiedTime: 1781559031574
+      modifiedTime: 1781631716703
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!AyvniEKtyroOe83p.XuuhDCc4RQcZOXUL'

--- a/packs/_source/monsters/dragon/copper-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/copper-dragon-wyrmling.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,15 +480,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: BQZkHEsVvkPuGJKq
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Copper Dragon Wyrmling attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -563,8 +563,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        jS1zO7mRwk4Ka3LE:
           type: attack
           activation:
             type: action
@@ -579,10 +578,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -599,7 +599,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -612,24 +613,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: jS1zO7mRwk4Ka3LE
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -639,28 +653,31 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107550611
+      systemVersion: 6.0.0
+      createdTime: 1781562701316
+      modifiedTime: 1781562711743
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!AyvniEKtyroOe83p.BQZkHEsVvkPuGJKq'
   - _id: XuuhDCc4RQcZOXUL
     name: Breath Weapons
     type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
+    img: icons/magic/acid/projectile-faceted-glob.webp
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Acid Breath.</strong> The dragon exhales acid
-          in an 90-foot line that is 10 feet wide. Each creature in that line
-          must make a [[/save activity=zTWpuajI6meBb52D]] saving throw, taking
-          [[/damage average activity=zTWpuajI6meBb52D]] damage on a failed save,
-          or half as much damage on a successful one.</p><p><strong>Slowing
-          Breath.</strong> The dragon exhales gas in a 90-foot cone. Each
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Acid Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales acid in an [[lookup
+          @labels.description.template activity=zTWpuajI6meBb52D]]. Each
+          creature in that line must make a [[/save activity=zTWpuajI6meBb52D]]
+          saving throw, taking [[/damage average activity=zTWpuajI6meBb52D]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Slowing Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales gas in a [[lookup
+          @labels.description.template activity=zTWpuajI6meBb52D]]. Each
           creature in that area must succeed on a [[/save
           activity=CkPMajPOZWWj3gl0]] saving throw. On a failed save, the
           creature can't use reactions, its speed is halved, and it can't make
@@ -669,7 +686,7 @@ items:
           effects last for 1 minute. The creature can repeat the saving throw at
           the end of each of its turns, ending the effect on itself with a
           successful save.</p>
-        chat: <p>The dragon breathes in!</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -685,7 +702,7 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -708,6 +725,13 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales acid in an
+              [[lookup @labels.description.template activity=zTWpuajI6meBb52D]].
+              Each creature in that line must make a [[/save
+              activity=zTWpuajI6meBb52D]] saving throw, taking [[/damage average
+              activity=zTWpuajI6meBb52D]] damage on a failed save, or half as
+              much damage on a successful one.</p>
           duration:
             concentration: false
             value: ''
@@ -724,13 +748,13 @@ items:
               count: ''
               contiguous: false
               type: line
-              size: '90'
-              width: ''
+              size: '20'
+              width: '5'
               height: ''
               units: ft
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -754,13 +778,19 @@ items:
             ability:
               - dex
             dc:
-              calculation: ''
+              calculation: con
               formula: '11'
+            bonus: ''
           sort: 0
           _id: zTWpuajI6meBb52D
           name: Acid Breath
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
         CkPMajPOZWWj3gl0:
           type: save
           activation:
@@ -779,13 +809,27 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=zTWpuajI6meBb52D]].
+              Each creature in that area must succeed on a [[/save
+              activity=CkPMajPOZWWj3gl0]] saving throw. On a failed save, the
+              creature can't use reactions, its speed is halved, and it can't
+              make more than one attack on its turn. In addition, the creature
+              can use either an action or a bonus action on its turn, but not
+              both. These effects last for 1 minute. The creature can repeat the
+              saving throw at the end of each of its turns, ending the effect on
+              itself with a successful save.</p>
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: 5E6iveIba4rYeUbc
+              level: {}
+              onSave: false
           range:
             units: self
             special: ''
@@ -795,13 +839,13 @@ items:
               count: ''
               contiguous: false
               type: cone
-              size: '90'
+              size: '15'
               width: ''
               height: ''
               units: ft
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -811,19 +855,25 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability:
               - con
             dc:
-              calculation: ''
+              calculation: con
               formula: '11'
+            bonus: ''
           sort: 0
           _id: CkPMajPOZWWj3gl0
           name: Slowing Breath
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
       enchant: {}
       prerequisites:
         level: null
@@ -832,24 +882,88 @@ items:
       advancement: []
       cover: null
       crewed: false
-    effects: []
+    effects:
+      - name: Slowed
+        img: icons/skills/movement/arrow-down-pink.webp
+        origin: Compendium.dnd5e.monsters.Actor.AyvniEKtyroOe83p.Item.XuuhDCc4RQcZOXUL
+        transfer: false
+        _id: 5E6iveIba4rYeUbc
+        type: base
+        system:
+          changes:
+            - key: system.attributes.movement.burrow
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.climb
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.fly
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.swim
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.walk
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are slowed. While slowed, you can't use reactions, your speed
+          is halved, and you can't make more than one attack on your turn. In
+          addition, you can use either an action or a bonus action on your turn,
+          but not both.</p><p>These effects last for 1 minute. You can repeat
+          the saving throw at the end of each of your turns, ending the effect
+          on yourself with a succesful save.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781558835328
+          modifiedTime: 1781558987014
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!AyvniEKtyroOe83p.XuuhDCc4RQcZOXUL.5E6iveIba4rYeUbc
     folder: null
     sort: 550000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
+      systemVersion: 6.0.0
       createdTime: 1745451913418
-      modifiedTime: 1745451949665
+      modifiedTime: 1781559031574
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!AyvniEKtyroOe83p.XuuhDCc4RQcZOXUL'
@@ -861,7 +975,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171210692

--- a/packs/_source/monsters/dragon/dragon-turtle.yml
+++ b/packs/_source/monsters/dragon/dragon-turtle.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,53 +481,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 4
 items:
-  - _id: Pu7Q4aCRVqVqVkeM
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon turtle can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!ijsfYEDqSuwQXwNN.Pu7Q4aCRVqVqVkeM'
   - _id: 2m2mkUSBJi2QOZje
     name: Multiattack
     type: feat
@@ -538,10 +490,10 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon turtle makes three attacks: one with its [[/item
-          .7QJr0VCtVk2wtZ78]]{bite} and two with its [[/item
-          .P4joxK4BwyYsPfJv]]{claws}. It can make one [[/item
-          .zNDI1LvLKZ9Hi2Ew]]{tail} attack in place of its two claw attacks.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .7QJr0VCtVk2wtZ78]]{Bite} and two with its [[/item
+          .P4joxK4BwyYsPfJv]]{Claws}. It can make one [[/item
+          .zNDI1LvLKZ9Hi2Ew]]{Tail} attack in place of its two claw attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -555,13 +507,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        pPPba24FXwuHsnbU:
           type: utility
           activation:
             type: action
@@ -576,15 +527,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -595,7 +547,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -612,7 +565,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: pPPba24FXwuHsnbU
       enchant: {}
       prerequisites:
         level: null
@@ -626,22 +587,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448418235
+      systemVersion: 6.0.0
+      createdTime: 1781550294809
+      modifiedTime: 1781550300368
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ijsfYEDqSuwQXwNN.2m2mkUSBJi2QOZje'
   - _id: 7QJr0VCtVk2wtZ78
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Dragon Turtle attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -704,7 +667,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -713,8 +676,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        K99jewYF6rSzbYcU:
           type: attack
           activation:
             type: action
@@ -729,10 +691,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -749,7 +712,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -762,24 +726,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: K99jewYF6rSzbYcU
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -789,22 +766,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448417424
+      systemVersion: 6.0.0
+      createdTime: 1781550305837
+      modifiedTime: 1781550365433
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ijsfYEDqSuwQXwNN.7QJr0VCtVk2wtZ78'
   - _id: P4joxK4BwyYsPfJv
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/commodities/claws/claw-lizard-white-black.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Dragon Turtle attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -867,7 +846,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -876,8 +855,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        dB1ARqTthnAXU642:
           type: attack
           activation:
             type: action
@@ -892,10 +870,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -912,7 +891,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -925,24 +905,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: dB1ARqTthnAXU642
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -952,18 +945,18 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448417424
+      systemVersion: 6.0.0
+      createdTime: 1781550389199
+      modifiedTime: 1781550418379
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ijsfYEDqSuwQXwNN.P4joxK4BwyYsPfJv'
   - _id: zNDI1LvLKZ9Hi2Ew
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: >-
@@ -972,8 +965,9 @@ items:
           up to 10 feet away from the dragon turtle and knocked
           &amp;Reference[prone].</p>
         chat: >-
-          <p>The Dragon Turtle attacks with its Tail. If the target is a
-          creature, it must make a <strong>Strength</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. If the target is a creature, it must make a Strength
+          saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1045,8 +1039,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        BhqI2QbOe0Qee4TM:
           type: attack
           activation:
             type: action
@@ -1061,10 +1054,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1081,7 +1075,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1107,14 +1102,21 @@ items:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: BhqI2QbOe0Qee4TM
+        cW425UuJbXKMBAPa:
           type: save
           activation:
-            type: action
+            type: special
             value: 1
-            condition: ''
+            condition: When a creature is hit by this attack.
             override: false
           consumption:
             targets: []
@@ -1124,10 +1126,14 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>If the target is a creature, it must succeed on a [[/save]]
+              saving throw or be pushed up to 10 feet away from the dragon
+              turtle and knocked &amp;Reference[prone].</p>
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1144,10 +1150,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1157,14 +1164,29 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: str
+            ability:
+              - str
             dc:
               calculation: ''
               formula: '20'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: cW425UuJbXKMBAPa
+          name: Prone Save
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1175,38 +1197,35 @@ items:
     sort: 400000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448451475
+      systemVersion: 6.0.0
+      createdTime: 1781550427806
+      modifiedTime: 1781550515403
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ijsfYEDqSuwQXwNN.zNDI1LvLKZ9Hi2Ew'
   - _id: UjT93YD55B87gMqZ
     name: Steam Breath
     type: feat
-    img: icons/creatures/abilities/dragon-ice-breath-blue.webp
+    img: icons/magic/fire/projectile-fireball-embers-yellow.webp
     system:
       description:
         value: >-
-          <p>The dragon turtle exhales scalding steam in a 60-foot cone. Each
-          creature in that area must make a [[/save]] saving throw, taking
+          <p>The [[lookup @name lowercase]]{monster} exhales scalding steam in a
+          [[lookup @labels.description.template activity=4P1o1KZZ4sUzsAOu]].
+          Each creature in that area must make a [[/save]] saving throw, taking
           [[/damage average]] damage on a failed save, or half as much damage on
           a successful one.</p><p>Being underwater doesn't grant resistance
           against this damage.</p>
         chat: >-
-          <p>The dragon turtle exhales scalding steam in a 60-foot cone. Each
-          creature in that area must make a <strong>Constitution</strong> saving
-          throw.</p>
+          <p>The [[lookup @name]]{monster} exhales scalding steam in a [[lookup
+          @labels.description.template activity=4P1o1KZZ4sUzsAOu]]. Each
+          creature in that area must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1222,13 +1241,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4P1o1KZZ4sUzsAOu:
           type: save
           activation:
             type: action
@@ -1238,17 +1256,16 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1269,9 +1286,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1283,24 +1301,37 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 15
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 15
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '18'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4P1o1KZZ4sUzsAOu
+          name: Exhale Steam
       enchant: {}
       prerequisites:
         level: null
@@ -1314,14 +1345,67 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.4UuuUKjATTixrZGP
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448483290
+      systemVersion: 6.0.0
+      createdTime: 1781550543822
+      modifiedTime: 1781550901986
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ijsfYEDqSuwQXwNN.UjT93YD55B87gMqZ'
+  - _id: kz0dD5J9FQTTryWp
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781550269624
+      modifiedTime: 1781550269624
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ijsfYEDqSuwQXwNN.kz0dD5J9FQTTryWp'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1330,7 +1414,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171251099

--- a/packs/_source/monsters/dragon/dragon-turtle.yml
+++ b/packs/_source/monsters/dragon/dragon-turtle.yml
@@ -491,9 +491,9 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
-          with its [[/item .7QJr0VCtVk2wtZ78]]{Bite} and two with its [[/item
-          .P4joxK4BwyYsPfJv]]{Claws}. It can make one [[/item
-          .zNDI1LvLKZ9Hi2Ew]]{Tail} attack in place of its two claw attacks.</p>
+          with its [[/item .7QJr0VCtVk2wtZ78]]{bite} and two with its [[/item
+          .P4joxK4BwyYsPfJv]]{claws}. It can make one [[/item
+          .zNDI1LvLKZ9Hi2Ew]]{tail} attack in place of its two claw attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -591,7 +591,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781550294809
-      modifiedTime: 1781550300368
+      modifiedTime: 1783371895976
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ijsfYEDqSuwQXwNN.2m2mkUSBJi2QOZje'

--- a/packs/_source/monsters/dragon/gold-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/gold-dragon-wyrmling.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,61 +480,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
-  - _id: hTsrzcY4zYsqqzPf
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!naSoHU9KbkgeNIwB.hTsrzcY4zYsqqzPf'
   - _id: s90OWDANSrZ1ttWp
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Gold Dragon Wyrmling attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -600,7 +554,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -609,8 +563,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        prNI633DLuHXh0BE:
           type: attack
           activation:
             type: action
@@ -625,10 +578,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -645,7 +599,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -658,24 +613,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: prNI633DLuHXh0BE
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -685,11 +653,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107553339
+      systemVersion: 6.0.0
+      createdTime: 1781559077298
+      modifiedTime: 1781559221383
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!naSoHU9KbkgeNIwB.s90OWDANSrZ1ttWp'
@@ -700,19 +668,22 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Fire Breath.</strong> The dragon exhales fire
-          in a 90-foot cone. Each creature in that area must make a [[/save
-          activity=o8fOmWWIqCYwGu3C]] saving throw, taking [[/damage average
-          activity=o8fOmWWIqCYwGu3C]] damage on a failed save, or half as much
-          damage on a successful one.</p><p><strong>Weakening Breath.</strong>
-          The dragon exhales gas in a 90-foot cone. Each creature in that area
-          must succeed on a [[/save activity=J4QhEMZOdsyIy2D6]] saving throw or
-          have disadvantage on Strength-based attack rolls, Strength checks, and
-          Strength saving throws for 1 minute. A creature can repeat the saving
-          throw at the end of each of its turns, ending the effect on itself on
-          a success.</p>
-        chat: <p>The dragon breathes in!</p>
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Fire Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=o8fOmWWIqCYwGu3C]]. Each
+          creature in that area must make a [[/save activity=o8fOmWWIqCYwGu3C]]
+          saving throw, taking [[/damage average activity=o8fOmWWIqCYwGu3C]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Weakening Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales gas in a [[lookup
+          @labels.description.template activity=J4QhEMZOdsyIy2D6]]. Each
+          creature in that area must succeed on a [[/save
+          activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+          Strength-based attack rolls, Strength checks, and Strength saving
+          throws for 1 minute. A creature can repeat the saving throw at the end
+          of each of its turns, ending the effect on itself on a success.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -721,11 +692,14 @@ items:
         rules: '2014'
         revision: 1
       uses:
-        max: ''
-        recovery: []
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -748,6 +722,15 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=J4QhEMZOdsyIy2D6]].
+              Each creature in that area must succeed on a [[/save
+              activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+              Strength-based attack rolls, Strength checks, and Strength saving
+              throws for 1 minute. A creature can repeat the saving throw at the
+              end of each of its turns, ending the effect on itself on a
+              success.</p>
           duration:
             concentration: false
             value: ''
@@ -764,13 +747,13 @@ items:
               count: ''
               contiguous: false
               type: cone
-              size: '90'
+              size: '15'
               width: ''
               height: ''
               units: ft
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -794,13 +777,19 @@ items:
             ability:
               - dex
             dc:
-              calculation: ''
+              calculation: con
               formula: '13'
+            bonus: ''
           sort: 0
           _id: o8fOmWWIqCYwGu3C
           name: Fire Breath
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
         J4QhEMZOdsyIy2D6:
           type: save
           activation:
@@ -825,7 +814,12 @@ items:
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: a5q0M5lHMSOhKxFi
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             units: self
             special: ''
@@ -835,13 +829,13 @@ items:
               count: ''
               contiguous: false
               type: cone
-              size: '90'
+              size: '15'
               width: ''
               height: ''
               units: ft
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -851,19 +845,25 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability:
               - str
             dc:
-              calculation: ''
+              calculation: con
               formula: '13'
+            bonus: ''
           sort: 0
           _id: J4QhEMZOdsyIy2D6
           name: Weakening Breath
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
       enchant: {}
       prerequisites:
         level: null
@@ -872,27 +872,127 @@ items:
       advancement: []
       cover: null
       crewed: false
-    effects: []
+    effects:
+      - name: Weakened
+        img: icons/magic/death/hand-withered-gray.webp
+        origin: Compendium.dnd5e.monsters.Actor.naSoHU9KbkgeNIwB.Item.5vCVx0zwz1FKIvTX
+        transfer: false
+        _id: a5q0M5lHMSOhKxFi
+        type: base
+        system:
+          changes:
+            - key: system.abilities.str.save.roll.mode
+              type: add
+              value: -1
+              phase: initial
+              priority: null
+            - key: system.abilities.str.check.roll.mode
+              type: add
+              value: -1
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are weakened. While weakened, you have disadavntage on
+          Strength-based attack rolls, Strength checks, and Strength saving
+          throws for 1 minute. You can repeat the saving throw at the end of
+          each of your turns, ending the effect on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781559724245
+          modifiedTime: 1781559847768
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!naSoHU9KbkgeNIwB.5vCVx0zwz1FKIvTX.a5q0M5lHMSOhKxFi
     folder: null
     sort: 600000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
+      systemVersion: 6.0.0
       createdTime: 1745452319939
-      modifiedTime: 1745452376794
+      modifiedTime: 1781630351517
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!naSoHU9KbkgeNIwB.5vCVx0zwz1FKIvTX'
+  - _id: KlIuOYFx8OUMjbZU
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781559068876
+      modifiedTime: 1781559068876
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!naSoHU9KbkgeNIwB.KlIuOYFx8OUMjbZU'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -901,7 +1001,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171256525

--- a/packs/_source/monsters/dragon/gold-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/gold-dragon-wyrmling.yml
@@ -681,8 +681,9 @@ items:
           creature in that area must succeed on a [[/save
           activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
           Strength-based attack rolls, Strength checks, and Strength saving
-          throws for 1 minute. A creature can repeat the saving throw at the end
-          of each of its turns, ending the effect on itself on a success.</p>
+          throws for [[lookup @labels.duration activity=J4QhEMZOdsyIy2D6]]. A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -808,6 +809,15 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=J4QhEMZOdsyIy2D6]].
+              Each creature in that area must succeed on a [[/save
+              activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+              Strength-based attack rolls, Strength checks, and Strength saving
+              throws for [[lookup @labels.duration activity=J4QhEMZOdsyIy2D6]].
+              A creature can repeat the saving throw at the end of each of its
+              turns, ending the effect on itself on a success.</p>
           duration:
             concentration: false
             value: '1'
@@ -936,7 +946,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1745452319939
-      modifiedTime: 1781630351517
+      modifiedTime: 1781631543895
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!naSoHU9KbkgeNIwB.5vCVx0zwz1FKIvTX'

--- a/packs/_source/monsters/dragon/green-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/green-dragon-wyrmling.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,22 +481,24 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: pFFlq9KvfXzAxhU8
     name: Poison Breath
     type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
+    img: icons/skills/toxins/cauldron-bubbles-overflow-green.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales poisonous gas in a 15-foot cone. Each creature
-          in that area must make a [[/save]] saving throw, taking [[/damage
-          average]] damage on a failed save, or half as much damage on a
-          successful one.</p>
+          <p>The [[lookup @name lowercase]]{monster} exhales poisonous gas in a
+          [[lookup @labels.description.template activity=MiNhGAqISi8NVtZa]].
+          Each creature in that area must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
         chat: >-
-          <p>The dragon exhales poisonous gas in a 15-foot cone. Each creature
-          in that area must make a <strong>Constitution</strong> saving
-          throw.</p>
+          <p>The [[lookup @name]]{monster} exhales poisonous gas in a [[lookup
+          @labels.description.template activity=MiNhGAqISi8NVtZa]]. Each
+          creature in that area must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -515,13 +514,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        MiNhGAqISi8NVtZa:
           type: save
           activation:
             type: action
@@ -531,17 +529,16 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -562,9 +559,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -576,53 +574,68 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 6
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 6
                 denomination: 6
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
-              calculation: ''
+              calculation: con
               formula: '11'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: MiNhGAqISi8NVtZa
+          name: Exhale Poison
       enchant: {}
       prerequisites:
         level: null
       identifier: poison-breath
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.JAEclghgOT24pQD9
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449881089
+      systemVersion: 6.0.0
+      createdTime: 1781557132616
+      modifiedTime: 1781605757432
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KH6ZrUiUOKQCOlRH.pFFlq9KvfXzAxhU8'
   - _id: zii9P95YmeE6b4km
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Green Dragon Wyrmling attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -685,7 +698,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -694,8 +707,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bnR3jz0lzHjGfBBV:
           type: attack
           activation:
             type: action
@@ -710,10 +722,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -730,7 +743,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -743,36 +757,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 6
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bnR3jz0lzHjGfBBV
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -782,21 +807,23 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107551230
+      systemVersion: 6.0.0
+      createdTime: 1781557135397
+      modifiedTime: 1781557156128
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KH6ZrUiUOKQCOlRH.zii9P95YmeE6b4km'
-  - _id: 8U6fHYSsBSDhYHpr
+  - _id: NKSFy0qwS1M30Mb4
     name: Amphibious
     type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
     system:
       description:
-        value: <p>The dragon can breathe air and water.</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
         chat: ''
       source:
         custom: ''
@@ -810,32 +837,37 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: amphibious
+      advancement: {}
+      crewed: false
     effects: []
-    folder: null
-    sort: 0
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781557130325
+      modifiedTime: 1781557130325
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!KH6ZrUiUOKQCOlRH.8U6fHYSsBSDhYHpr'
+    _key: '!actors.items!KH6ZrUiUOKQCOlRH.NKSFy0qwS1M30Mb4'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -844,7 +876,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171222365

--- a/packs/_source/monsters/dragon/pseudodragon.yml
+++ b/packs/_source/monsters/dragon/pseudodragon.yml
@@ -443,9 +443,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -460,7 +457,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -480,16 +477,17 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 0.5
 items:
   - _id: heZCHSZEeLLiweK7
     name: Keen Senses
     type: feat
-    img: icons/magic/perception/eye-ringed-glow-angry-large-teal.webp
+    img: icons/creatures/mammals/wolf-howl-moon-forest-blue.webp
     system:
       description:
         value: >-
-          <p>The pseudodragon has advantage on Wisdom (Perception) checks that
-          rely on sight, hearing, or smell.</p>
+          <p>The [[lookup @name lowercase]]{monster} has advantage on Wisdom
+          (Perception) checks that rely on sight, hearing, or smell.</p>
         chat: ''
       source:
         custom: ''
@@ -503,10 +501,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -514,79 +513,31 @@ items:
       identifier: keen-senses
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.JnLN0Rz60WHXk2Fr
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448365509
+      systemVersion: 6.0.0
+      createdTime: 1781550954040
+      modifiedTime: 1781550985682
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!fkCNtbvPOMd7mipF.heZCHSZEeLLiweK7'
-  - _id: GAzi14ICaeeOAO8J
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The pseudodragon has advantage on saving throws against spells and
-          other magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448371907
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!fkCNtbvPOMd7mipF.GAzi14ICaeeOAO8J'
   - _id: aIqOpP93mUsy9yD1
     name: Limited Telepathy
     type: feat
-    img: icons/magic/defensive/illusion-evasion-echo-purple.webp
+    img: icons/magic/movement/trail-streak-impact-blue.webp
     system:
       description:
         value: >-
-          <p>The pseudodragon can magically communicate simple ideas, emotions,
-          and images telepathically with any creature within 100 ft. of it that
-          can understand a language.</p>
+          <p>The [[lookup @name lowercase]]{monster} can magically communicate
+          simple ideas, emotions, and images telepathically with any creature
+          within 100 feet of it that can understand a language.</p>
         chat: ''
       source:
         custom: ''
@@ -600,10 +551,12 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -611,29 +564,31 @@ items:
       identifier: limited-telepathy
     effects: []
     folder: null
-    sort: 0
+    sort: 400000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.xna3UTd4EFLCZMt9
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448376708
+      systemVersion: 6.0.0
+      createdTime: 1781550954041
+      modifiedTime: 1781551014082
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!fkCNtbvPOMd7mipF.aIqOpP93mUsy9yD1'
   - _id: GJgN3Qy49XCaKmTc
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Pseudodragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -696,7 +651,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -705,8 +660,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        004d07O7VXJAAKjj:
           type: attack
           activation:
             type: action
@@ -721,10 +675,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -741,7 +696,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -754,20 +710,32 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          name: ''
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 004d07O7VXJAAKjj
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -782,18 +750,18 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448382139
+      systemVersion: 6.0.0
+      createdTime: 1781551019205
+      modifiedTime: 1781551040839
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!fkCNtbvPOMd7mipF.GJgN3Qy49XCaKmTc'
   - _id: MKFXRWP55I1bVlyD
     name: Sting
     type: weapon
-    img: icons/creatures/abilities/fang-tooth-venomous.webp
+    img: icons/creatures/abilities/stinger-poison-green.webp
     system:
       description:
         value: >-
@@ -803,8 +771,8 @@ items:
           the same duration, or until it takes damage or another creature uses
           an action to shake it awake.</p>
         chat: >-
-          <p>The Pseudodragon attacks with its Sting. The target must make a
-          <strong>Constitution</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. The target must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -876,8 +844,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        EGMpcDJJR9WMrcxv:
           type: attack
           activation:
             type: action
@@ -892,10 +859,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -912,7 +880,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -938,14 +907,21 @@ items:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: EGMpcDJJR9WMrcxv
+        hcLz9GILmf8UvyVF:
           type: save
           activation:
-            type: action
+            type: special
             value: 1
-            condition: ''
+            condition: When a creature is hit by this attack.
             override: false
           consumption:
             targets: []
@@ -955,13 +931,26 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The target must succeed on a [[/save]] saving throw or become
+              poisoned for 1 hour. If the saving throw fails by 5 or more, the
+              target falls unconscious for the same duration, or until it takes
+              damage or another creature uses an action to shake it awake.</p>
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: 6WbfnxuaqYYI3UDt
+              onSave: false
+              level:
+                min: null
+                max: null
+            - _id: JDRYANXUoIBF9EQr
+              level: {}
+              onSave: false
           range:
             value: '5'
             units: ft
@@ -975,10 +964,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -988,40 +978,185 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '11'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: hcLz9GILmf8UvyVF
+          name: Poison Save
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: sting
       mastery: ''
-    effects: []
+    effects:
+      - name: Pseudodragon Poison
+        img: icons/skills/toxins/symbol-poison-drop-skull-green.webp
+        origin: Compendium.dnd5e.monsters.Actor.fkCNtbvPOMd7mipF.Item.MKFXRWP55I1bVlyD
+        transfer: false
+        _id: 6WbfnxuaqYYI3UDt
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: hours
+          expiry: turnStart
+          expired: false
+        description: <p>You are &amp;reference[poisoned apply=false] for 1 hour.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781551192889
+          modifiedTime: 1781551305141
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!fkCNtbvPOMd7mipF.MKFXRWP55I1bVlyD.6WbfnxuaqYYI3UDt
+      - name: Potent Pseudodragon Poison
+        img: icons/skills/toxins/symbol-poison-drop-skull-green.webp
+        origin: Compendium.dnd5e.monsters.Actor.fkCNtbvPOMd7mipF.Item.MKFXRWP55I1bVlyD
+        transfer: false
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: hours
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[poisoned apply=false] for 1 hour. You are
+          also &amp;reference[unconscious apply=false] for the same duration, or
+          until you take damage or another creature uses an action to shake you
+          awake.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses:
+                - unconscious
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781551235305
+          modifiedTime: 1781551309024
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _id: JDRYANXUoIBF9EQr
+        _key: >-
+          !actors.items.effects!fkCNtbvPOMd7mipF.MKFXRWP55I1bVlyD.JDRYANXUoIBF9EQr
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448399049
+      systemVersion: 6.0.0
+      createdTime: 1781551046837
+      modifiedTime: 1781551290939
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!fkCNtbvPOMd7mipF.MKFXRWP55I1bVlyD'
+  - _id: l942VLThscFdstX8
+    name: Magic Resistance
+    type: feat
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 300000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.Hm4o2FgPZsdbXjLq.Item.Et4wxxXo9aoxv3C8
+      duplicateSource: Item.gUYGrA0WHbwQ26NK
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781550953038
+      modifiedTime: 1781550954041
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!fkCNtbvPOMd7mipF.l942VLThscFdstX8'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1030,7 +1165,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171246273

--- a/packs/_source/monsters/dragon/pseudodragon.yml
+++ b/packs/_source/monsters/dragon/pseudodragon.yml
@@ -766,10 +766,11 @@ items:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
-          succeed on a [[/save]] saving throw or become poisoned for 1 hour. If
-          the saving throw fails by 5 or more, the target falls unconscious for
-          the same duration, or until it takes damage or another creature uses
-          an action to shake it awake.</p>
+          succeed on a [[/save]] saving throw or become &amp;reference[poisoned]
+          for [[lookup @labels.duration activity=hcLz9GILmf8UvyVF]]. If the
+          saving throw fails by 5 or more, the target falls
+          &amp;reference[unconscious] for the same duration, or until it takes
+          damage or another creature uses an action to shake it awake.</p>
         chat: >-
           <p>The [[lookup @name]]{monster} attacks with its [[lookup
           @item.name]]. The target must make a Constitution saving throw.</p>
@@ -938,8 +939,8 @@ items:
               damage or another creature uses an action to shake it awake.</p>
           duration:
             concentration: false
-            value: ''
-            units: inst
+            value: '1'
+            units: hour
             special: ''
             override: false
           effects:
@@ -949,8 +950,10 @@ items:
                 min: null
                 max: null
             - _id: JDRYANXUoIBF9EQr
-              level: {}
               onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '5'
             units: ft
@@ -1100,7 +1103,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781551046837
-      modifiedTime: 1781551290939
+      modifiedTime: 1781632112380
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!fkCNtbvPOMd7mipF.MKFXRWP55I1bVlyD'

--- a/packs/_source/monsters/dragon/red-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/red-dragon-wyrmling.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,15 +480,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: iGge3BzjEfpSeaxP
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Red Dragon Wyrmling attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -554,7 +554,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -563,8 +563,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        nFpt5ocCfFlizRSb:
           type: attack
           activation:
             type: action
@@ -579,10 +578,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -599,7 +599,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -612,36 +613,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: nFpt5ocCfFlizRSb
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -651,28 +663,30 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107554242
+      systemVersion: 6.0.0
+      createdTime: 1781557463330
+      modifiedTime: 1781557476529
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!zgWkII3VoE4AHCND.iGge3BzjEfpSeaxP'
   - _id: KVIjYSLZoYmdFwzS
     name: Fire Breath
     type: feat
-    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
+    img: icons/magic/fire/flame-burning-earth-orange.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales fire in a 15-foot cone. Each creature in that
-          area must make a [[/save]] saving throw, taking [[/damage average]]
-          damage on a failed save, or half as much damage on a successful
-          one.</p>
+          <p>The [[lookup @name lowercase]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=dN04D22jj4eo1ERu]]. Each
+          creature in that area must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
         chat: >-
-          <p>The dragon exhales fire in a 15-foot cone. Each creature in that
-          area must make a <strong>Dexterity</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=dN04D22jj4eo1ERu]]. Each
+          creature in that area must make a Dexterity saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -688,13 +702,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        dN04D22jj4eo1ERu:
           type: save
           activation:
             type: action
@@ -704,21 +717,20 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -735,9 +747,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -749,24 +762,37 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 7
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 7
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
-              calculation: ''
+              calculation: con
               formula: '13'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: dN04D22jj4eo1ERu
+          name: Exhale Fire
       enchant: {}
       prerequisites:
         level: null
@@ -780,11 +806,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.bGSW8IuWURWiWtxr
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450195293
+      systemVersion: 6.0.0
+      createdTime: 1781557374433
+      modifiedTime: 1781557720286
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!zgWkII3VoE4AHCND.KVIjYSLZoYmdFwzS'
@@ -796,7 +822,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171267898

--- a/packs/_source/monsters/dragon/silver-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/silver-dragon-wyrmling.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,15 +480,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: x7uPzThV97uQxTun
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Silver Dragon Wyrmling attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -554,7 +554,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -563,8 +563,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        Q798hjNASV9jIVet:
           type: attack
           activation:
             type: action
@@ -579,10 +578,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -599,7 +599,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -612,24 +613,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: Q798hjNASV9jIVet
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -639,11 +653,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107551117
+      systemVersion: 6.0.0
+      createdTime: 1781560079754
+      modifiedTime: 1781560094172
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!J1QVPd8POvcPaqx4.x7uPzThV97uQxTun'
@@ -654,18 +668,21 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Cold Breath.</strong> The dragon exhales an icy
-          blast in a 90-foot cone. Each creature in that area must make a
-          [[/save activity=U5F5qe2Hu0r0yHmk]] saving throw, taking [[/damage
-          average activity=U5F5qe2Hu0r0yHmk]] damage on a failed save, or half
-          as much damage on a successful one.</p><p><strong>Paralyzing
-          Breath.</strong> The dragon exhales paralyzing gas in a 90- foot cone.
-          Each creature in that area must succeed on a [[/save
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Cold Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales an icy blast in a [[lookup
+          @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
+          creature in that area must make a [[/save activity=U5F5qe2Hu0r0yHmk]]
+          saving throw, taking [[/damage average activity=U5F5qe2Hu0r0yHmk]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Paralyzing Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales paralyzing gas in a [[lookup
+          @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
+          creature in that area must succeed on a [[/save
           activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for 1 minute.
           A creature can repeat the saving throw at the end of each of its
           turns, ending the effect on itself on a success.</p>
-        chat: <p>The dragon breathes in!</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -681,7 +698,7 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -704,6 +721,13 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales an icy blast in
+              a [[lookup @labels.description.labels activity=9gMvqjbgKK42uyzr]].
+              Each creature in that area must make a [[/save
+              activity=U5F5qe2Hu0r0yHmk]] saving throw, taking [[/damage average
+              activity=U5F5qe2Hu0r0yHmk]] damage on a failed save, or half as
+              much damage on a successful one.</p>
           duration:
             concentration: false
             value: ''
@@ -720,13 +744,13 @@ items:
               count: ''
               contiguous: false
               type: cone
-              size: '90'
+              size: '15'
               width: ''
               height: ''
               units: ft
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -750,13 +774,19 @@ items:
             ability:
               - con
             dc:
-              calculation: ''
+              calculation: con
               formula: '13'
+            bonus: ''
           sort: 0
           _id: U5F5qe2Hu0r0yHmk
           name: Cold Breath
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
         9gMvqjbgKK42uyzr:
           type: save
           activation:
@@ -775,13 +805,26 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales paralyzing gas
+              in a [[lookup @labels.description.template
+              activity=9gMvqjbgKK42uyzr]]. Each creature in that area must
+              succeed on a [[/save activity=9gMvqjbgKK42uyzr]] saving throw or
+              be paralyzed for 1 minute. A creature can repeat the saving throw
+              at the end of each of its turns, ending the effect on itself on a
+              success.</p>
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: yYbmtst3L1jGwwbF
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             units: self
             special: ''
@@ -791,13 +834,13 @@ items:
               count: ''
               contiguous: false
               type: cone
-              size: '90'
+              size: '15'
               width: ''
               height: ''
               units: ft
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -807,19 +850,25 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability:
               - con
             dc:
-              calculation: ''
+              calculation: con
               formula: '13'
+            bonus: ''
           sort: 0
           _id: 9gMvqjbgKK42uyzr
           name: Paralyzing Breath
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
       enchant: {}
       prerequisites:
         level: null
@@ -828,24 +877,61 @@ items:
       advancement: []
       cover: null
       crewed: false
-    effects: []
+    effects:
+      - name: Paralyzing Breath
+        img: icons/magic/control/debuff-chains-shackles-movement-purple.webp
+        origin: Compendium.dnd5e.monsters.Actor.J1QVPd8POvcPaqx4.Item.ENcwNUKxDAqH6V9l
+        transfer: false
+        _id: yYbmtst3L1jGwwbF
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[paralyzed apply=false] for 1 minute. You can
+          repeat the saving throw at the end of each of your turns, ending the
+          effect on yourself.</p>
+        tint: '#ffffff'
+        statuses:
+          - paralyzed
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781560256483
+          modifiedTime: 1781560304663
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!J1QVPd8POvcPaqx4.ENcwNUKxDAqH6V9l.yYbmtst3L1jGwwbF
     folder: null
     sort: 600000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
+      systemVersion: 6.0.0
       createdTime: 1745452711596
-      modifiedTime: 1745452766762
+      modifiedTime: 1781560477018
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!J1QVPd8POvcPaqx4.ENcwNUKxDAqH6V9l'
@@ -857,7 +943,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171220307

--- a/packs/_source/monsters/dragon/silver-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/silver-dragon-wyrmling.yml
@@ -679,9 +679,10 @@ items:
           lowercase]]{monster} exhales paralyzing gas in a [[lookup
           @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
           creature in that area must succeed on a [[/save
-          activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for 1 minute.
-          A creature can repeat the saving throw at the end of each of its
-          turns, ending the effect on itself on a success.</p>
+          activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for [[lookup
+          @labels.duration activity=9gMvqjbgKK42uyzr]]. A creature can repeat
+          the saving throw at the end of each of its turns, ending the effect on
+          itself on a success.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -810,9 +811,10 @@ items:
               in a [[lookup @labels.description.template
               activity=9gMvqjbgKK42uyzr]]. Each creature in that area must
               succeed on a [[/save activity=9gMvqjbgKK42uyzr]] saving throw or
-              be paralyzed for 1 minute. A creature can repeat the saving throw
-              at the end of each of its turns, ending the effect on itself on a
-              success.</p>
+              be paralyzed for [[lookup @labels.duration
+              activity=9gMvqjbgKK42uyzr]]. A creature can repeat the saving
+              throw at the end of each of its turns, ending the effect on itself
+              on a success.</p>
           duration:
             concentration: false
             value: '1'
@@ -931,7 +933,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1745452711596
-      modifiedTime: 1781560477018
+      modifiedTime: 1781631628525
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!J1QVPd8POvcPaqx4.ENcwNUKxDAqH6V9l'

--- a/packs/_source/monsters/dragon/silver-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/silver-dragon-wyrmling.yml
@@ -879,7 +879,7 @@ items:
       crewed: false
     effects:
       - name: Paralyzing Breath
-        img: icons/magic/control/debuff-chains-shackles-movement-purple.webp
+        img: icons/magic/unholy/energy-smoke-pink.webp
         origin: Compendium.dnd5e.monsters.Actor.J1QVPd8POvcPaqx4.Item.ENcwNUKxDAqH6V9l
         transfer: false
         _id: yYbmtst3L1jGwwbF
@@ -912,7 +912,7 @@ items:
           systemId: dnd5e
           systemVersion: 6.0.0
           createdTime: 1781560256483
-          modifiedTime: 1781560304663
+          modifiedTime: 1781630992702
           lastModifiedBy: dnd5ebuilder0000
           compendiumSource: null
           duplicateSource: null

--- a/packs/_source/monsters/dragon/white-dragon-wyrmling.yml
+++ b/packs/_source/monsters/dragon/white-dragon-wyrmling.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,15 +480,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: 5fAK2gZdIiYxLNzK
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The White Dragon Wyrmling attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -554,7 +554,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -563,8 +563,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        EBlF7BNUIfnwABmF:
           type: attack
           activation:
             type: action
@@ -579,10 +578,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -599,7 +599,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -612,36 +613,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 4
                 bonus: ''
                 types:
                   - cold
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: EBlF7BNUIfnwABmF
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -651,29 +663,30 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107554041
+      systemVersion: 6.0.0
+      createdTime: 1781557686283
+      modifiedTime: 1781557700815
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!vc2TAgIuq4yInjbf.5fAK2gZdIiYxLNzK'
   - _id: 8ZXdgzpI6WytT63w
     name: Cold Breath
     type: feat
-    img: icons/creatures/abilities/dragon-ice-breath-blue.webp
+    img: icons/magic/water/projectile-ice-orb-white.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales an icy blast of hail in a 15-foot cone. Each
-          creature in that area must make a [[/save]] saving throw, taking
-          [[/damage average]] damage on a failed save, or half as much damage on
-          a successful one.</p>
+          <p>The [[lookup @name lowercase]]{monster} exhales an icy blast of
+          hail in a [[lookup @labels.description.template
+          activity=UF4fJlhyYiLM7XeM]]. Each creature in that area must make a
+          [[/save]] saving throw, taking [[/damage average]] damage on a failed
+          save, or half as much damage on a successful one.</p>
         chat: >-
-          <p>The dragon exhales an icy blast of hail in a 15-foot cone. Each
-          creature in that area must make a <strong>Constitution</strong> saving
-          throw.</p>
+          <p>The [[lookup @name]]{monster} exhales an icy blast of hail in a
+          [[lookup @labels.description.template activity=UF4fJlhyYiLM7XeM]].
+          Each creature in that area must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -694,8 +707,7 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        UF4fJlhyYiLM7XeM:
           type: save
           activation:
             type: action
@@ -705,17 +717,16 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -736,9 +747,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -750,24 +762,37 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 5
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 5
                 denomination: 8
                 bonus: ''
                 types:
                   - cold
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
-              calculation: ''
+              calculation: con
               formula: '12'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: UF4fJlhyYiLM7XeM
+          name: Exhale Ice
       enchant: {}
       prerequisites:
         level: null
@@ -781,11 +806,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.iHOaiOqwUWIfCljJ
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450516684
+      systemVersion: 6.0.0
+      createdTime: 1781557607256
+      modifiedTime: 1781557677475
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!vc2TAgIuq4yInjbf.8ZXdgzpI6WytT63w'
@@ -797,7 +822,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171265352

--- a/packs/_source/monsters/dragon/wyvern.yml
+++ b/packs/_source/monsters/dragon/wyvern.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,6 +478,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: vnO8N4pro9PVOOQn
     name: Multiattack
@@ -489,10 +487,10 @@ items:
     system:
       description:
         value: >-
-          <p>The wyvern makes two attacks: one with its [[/item
-          .j1LTHxGLXWdnEbwq]]{bite} and one with its [[/item
-          .HzLuzqlmtBSeSS4Q]]{stinger}. While flying, it can use its [[/item
-          .Wa8BU72wRqyBCqkI]]{claws} in place of one other attack.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two attacks: one with
+          its [[/item .j1LTHxGLXWdnEbwq]]{Bite} and one with its [[/item
+          .HzLuzqlmtBSeSS4Q]]{Stinger}. While flying, it can use its [[/item
+          .Wa8BU72wRqyBCqkI]]{Claws} in place of one other attack.</p>
         chat: ''
       source:
         custom: ''
@@ -506,13 +504,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        Sf49M02Twr7ydotr:
           type: utility
           activation:
             type: action
@@ -527,15 +524,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -546,7 +544,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -563,7 +562,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: Sf49M02Twr7ydotr
       enchant: {}
       prerequisites:
         level: null
@@ -577,22 +584,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448292278
+      systemVersion: 6.0.0
+      createdTime: 1781550616830
+      modifiedTime: 1781550650863
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!7198siHjPJf8g0cG.vnO8N4pro9PVOOQn'
   - _id: j1LTHxGLXWdnEbwq
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Wyvern attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -665,8 +674,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        Lijuep4fa4UsSRNT:
           type: attack
           activation:
             type: action
@@ -681,10 +689,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -701,7 +710,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -714,24 +724,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: Lijuep4fa4UsSRNT
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -741,22 +764,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448291327
+      systemVersion: 6.0.0
+      createdTime: 1781550654474
+      modifiedTime: 1781550670700
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!7198siHjPJf8g0cG.j1LTHxGLXWdnEbwq'
   - _id: Wa8BU72wRqyBCqkI
     name: Claws
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-hooked-barbed.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Wyvern attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -818,9 +843,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - fin
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -829,8 +853,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        IV9aQWUvM8NMLnMJ:
           type: attack
           activation:
             type: action
@@ -845,10 +868,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -865,7 +889,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -878,24 +903,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: IV9aQWUvM8NMLnMJ
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -905,28 +943,28 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448291327
+      systemVersion: 6.0.0
+      createdTime: 1781550724181
+      modifiedTime: 1781550751329
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!7198siHjPJf8g0cG.Wa8BU72wRqyBCqkI'
   - _id: HzLuzqlmtBSeSS4Q
     name: Stinger
     type: weapon
-    img: icons/creatures/abilities/fang-tooth-venomous.webp
+    img: icons/creatures/abilities/stinger-poison-green.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
           make a [[/save]] saving throw, taking [[/damage average
-          activity=dnd5eactivity100]] damage on a failed save, or half as much
+          activity=5R4V2td9o9mrejmz]] damage on a failed save, or half as much
           damage on a successful one.</p>
         chat: >-
-          <p>The Wyvern attacks with its Stinger. The target must make a
-          <strong>Constitution</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. The target must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -950,7 +988,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -988,10 +1026,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - fin
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1000,8 +1036,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        wCU69sKMe2hPwIDA:
           type: attack
           activation:
             type: action
@@ -1016,69 +1051,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-          duration:
-            concentration: false
             value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '10'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: str
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts: []
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
           duration:
             concentration: false
             value: ''
@@ -1099,10 +1072,90 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          attack:
+            ability: ''
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: ''
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: wCU69sKMe2hPwIDA
+          name: ''
+        5R4V2td9o9mrejmz:
+          type: save
+          activation:
+            type: special
+            value: 1
+            condition: When a creature is hit by this attack.
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The target must make a [[/save]] saving throw, taking [[/damage
+              average activity=5R4V2td9o9mrejmz]] damage on a failed save, or
+              half as much damage on a successful one.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '10'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1118,19 +1171,33 @@ items:
                   enabled: false
                   formula: ''
                 number: 7
-                denomination: '6'
+                denomination: 6
                 bonus: ''
                 types:
                   - poison
+                scaling:
+                  number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '15'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 200000
+          name: Poison Save
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 5R4V2td9o9mrejmz
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1141,19 +1208,15 @@ items:
     sort: 400000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448335175
+      systemVersion: 6.0.0
+      createdTime: 1781550763370
+      modifiedTime: 1781550842585
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!7198siHjPJf8g0cG.HzLuzqlmtBSeSS4Q'
@@ -1165,7 +1228,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171205449

--- a/packs/_source/monsters/dragon/wyvern.yml
+++ b/packs/_source/monsters/dragon/wyvern.yml
@@ -488,9 +488,9 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes two attacks: one with
-          its [[/item .j1LTHxGLXWdnEbwq]]{Bite} and one with its [[/item
-          .HzLuzqlmtBSeSS4Q]]{Stinger}. While flying, it can use its [[/item
-          .Wa8BU72wRqyBCqkI]]{Claws} in place of one other attack.</p>
+          its [[/item .j1LTHxGLXWdnEbwq]]{bite} and one with its [[/item
+          .HzLuzqlmtBSeSS4Q]]{stinger}. While flying, it can use its [[/item
+          .Wa8BU72wRqyBCqkI]]{claws} in place of one other attack.</p>
         chat: ''
       source:
         custom: ''
@@ -588,7 +588,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781550616830
-      modifiedTime: 1781550650863
+      modifiedTime: 1783371925500
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!7198siHjPJf8g0cG.vnO8N4pro9PVOOQn'

--- a/packs/_source/monsters/dragon/young-black-dragon.yml
+++ b/packs/_source/monsters/dragon/young-black-dragon.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,366 +481,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
-  - _id: 963t1Gp9Nsy3UY9D
-    name: Acid Breath
-    type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon exhales acid in a 30-foot line that is 5 feet wide. Each
-          creature in that line must make a [[/save]] saving throw, taking
-          [[/damage average]] damage on a failed save, or half as much damage on
-          a successful one.</p>
-        chat: >-
-          <p>The dragon exhales acid in a 30-foot line that is 5 feet wide. Each
-          creature in that line must make a <strong>Dexterity</strong> saving
-          throw.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: line
-              size: '30'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - number: 11
-                denomination: 8
-                bonus: ''
-                types:
-                  - acid
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          save:
-            ability: dex
-            dc:
-              calculation: ''
-              formula: '14'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: acid-breath
-    effects: []
-    folder: null
-    sort: 400000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.zjcGly9P3Gn9MXt7
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448913385
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!bcapsJdIhY5WktpT.963t1Gp9Nsy3UY9D'
-  - _id: KRrrjifJpxjJ0zKy
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!bcapsJdIhY5WktpT.KRrrjifJpxjJ0zKy'
-  - _id: kuTDtAq2QL2Tmr4h
-    name: Bite
-    type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
-    system:
-      description:
-        value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Black Dragon attacks with its Bite.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: null
-        long: null
-        units: ft
-        reach: 10
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 2
-          denomination: 10
-          bonus: ''
-          types:
-            - piercing
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: attack
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '10'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: str
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts:
-              - number: 1
-                denomination: 8
-                bonus: ''
-                types:
-                  - acid
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      identifier: bite
-    effects: []
-    folder: null
-    sort: 100000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448887696
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!bcapsJdIhY5WktpT.kuTDtAq2QL2Tmr4h'
   - _id: gy0FMKec2tea9YI1
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Black Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -915,8 +564,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        G6gbdmw4q4bRCIbS:
           type: attack
           activation:
             type: action
@@ -931,10 +579,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -951,7 +600,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -964,24 +614,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: G6gbdmw4q4bRCIbS
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -991,11 +654,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448887696
+      systemVersion: 6.0.0
+      createdTime: 1781551891571
+      modifiedTime: 1781551908237
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!bcapsJdIhY5WktpT.gy0FMKec2tea9YI1'
@@ -1006,9 +669,9 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon makes three attacks: one with its [[/item
-          .kuTDtAq2QL2Tmr4h]]{bite} and two with its [[/item
-          .gy0FMKec2tea9YI1]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .TMquJwGqWpgp9SJd]]{Bite} and two with its [[/item
+          .gy0FMKec2tea9YI1]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -1022,13 +685,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        s9Tg5ZrZAk3EJOLT:
           type: utility
           activation:
             type: action
@@ -1043,15 +705,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1062,7 +725,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1079,7 +743,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: s9Tg5ZrZAk3EJOLT
       enchant: {}
       prerequisites:
         level: null
@@ -1093,14 +765,402 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745448888523
+      systemVersion: 6.0.0
+      createdTime: 1781551815972
+      modifiedTime: 1781551872013
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!bcapsJdIhY5WktpT.ApR7vtoU4ec7UulE'
+  - _id: 6N9Y6JGPD6C1N4yL
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781551802287
+      modifiedTime: 1781551802287
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!bcapsJdIhY5WktpT.6N9Y6JGPD6C1N4yL'
+  - _id: RV4M3hdgqPgUlKip
+    name: Acid Breath
+    type: feat
+    img: icons/magic/acid/projectile-faceted-glob.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} exhales acid in a [[lookup
+          @labels.description.template activity=KkzK6MGHKa5GCAwQ]]. Each
+          creature in that line must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} exhales acid in a [[lookup
+          @labels.description.template activity=KkzK6MGHKa5GCAwQ]]. Each
+          creature in that line must make a Dexterity saving throw.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        KkzK6MGHKa5GCAwQ:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: line
+              size: '30'
+              width: '5'
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 11
+                denomination: 8
+                bonus: ''
+                types:
+                  - acid
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: ''
+              formula: '14'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: KkzK6MGHKa5GCAwQ
+          name: Exhale Acid
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: acid-breath
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 400000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.IZMbiAHqQpzPo0CX.Item.ABS9Om2RejM5wrRF
+      duplicateSource: Item.bZemtIxYyd8U6Udb
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781551834632
+      modifiedTime: 1781556506985
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!bcapsJdIhY5WktpT.RV4M3hdgqPgUlKip'
+  - _id: TMquJwGqWpgp9SJd
+    name: Bite
+    type: weapon
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
+    system:
+      description:
+        value: <p>[[/attack extended]]. [[/damage extended]].</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      quantity: 1
+      weight:
+        value: 0
+        units: lb
+      price:
+        value: 0
+        denomination: gp
+      attunement: ''
+      rarity: ''
+      identified: true
+      cover: null
+      range:
+        value: null
+        long: null
+        units: ft
+        reach: 10
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      damage:
+        versatile:
+          number: null
+          denomination: null
+          bonus: ''
+          types: []
+          custom:
+            enabled: false
+            formula: ''
+          scaling:
+            mode: ''
+            number: null
+            formula: ''
+        base:
+          number: 2
+          denomination: 10
+          bonus: ''
+          types:
+            - piercing
+          custom:
+            enabled: false
+            formula: ''
+          scaling:
+            mode: ''
+            number: null
+            formula: ''
+      armor:
+        value: 10
+      hp:
+        value: 0
+        max: 0
+        dt: null
+        conditions: ''
+      properties: []
+      proficient: null
+      unidentified:
+        description: ''
+      type:
+        value: natural
+        baseItem: ''
+      container: null
+      activities:
+        qepPwTFb858W2XhE:
+          type: attack
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          attack:
+            ability: ''
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: ''
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: 8
+                bonus: ''
+                types:
+                  - acid
+                scaling:
+                  number: 1
+          sort: 100000
+          name: ''
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: qepPwTFb858W2XhE
+      ammunition: {}
+      identifier: bite
+      mastery: ''
+      crew:
+        value: []
+      attuned: false
+      equipped: true
+    effects: []
+    folder: null
+    sort: 100391
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.IZMbiAHqQpzPo0CX.Item.dmLvn6VGNA20rMvC
+      duplicateSource: Item.2s73wYXXCgvmkfD0
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781551838383
+      modifiedTime: 1781551857552
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!bcapsJdIhY5WktpT.TMquJwGqWpgp9SJd'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1109,7 +1169,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171241522

--- a/packs/_source/monsters/dragon/young-black-dragon.yml
+++ b/packs/_source/monsters/dragon/young-black-dragon.yml
@@ -670,8 +670,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
-          with its [[/item .TMquJwGqWpgp9SJd]]{Bite} and two with its [[/item
-          .gy0FMKec2tea9YI1]]{Claws}.</p>
+          with its [[/item .TMquJwGqWpgp9SJd]]{bite} and two with its [[/item
+          .gy0FMKec2tea9YI1]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -769,7 +769,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781551815972
-      modifiedTime: 1781551872013
+      modifiedTime: 1783370751057
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!bcapsJdIhY5WktpT.ApR7vtoU4ec7UulE'

--- a/packs/_source/monsters/dragon/young-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/young-blue-dragon.yml
@@ -854,8 +854,8 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon makes three attacks: one with its [[/item
-          .42AGHJQzJZfUYxF9]]{bite} and two with its [[/item
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .42AGHJQzJZfUYxF9]]{bite} and two with its [[/item
           .YSVencwrBzRdfm62]]{claws}.</p>
         chat: ''
       source:
@@ -870,13 +870,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        rwbidIpOUtznNF33:
           type: utility
           activation:
             type: action
@@ -891,15 +890,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -910,7 +910,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -927,7 +928,16 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          behaviors: []
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: rwbidIpOUtznNF33
       enchant: {}
       prerequisites:
         level: null
@@ -943,9 +953,9 @@ items:
       duplicateSource: null
       coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449294437
+      systemVersion: 6.0.0
+      createdTime: 1783370694463
+      modifiedTime: 1783370703571
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!mNijwXPMhwR7yYfc.dGVHjuCt6WhGx0sX'
@@ -956,9 +966,9 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon exhales lightning in a [[lookup
-          @labels.description.template activity=GSQtl90Opu6WzZk4]]. Each
-          creature in that line must make a [[/save]] saving throw, taking
+          <p>The [[lookup @name lowercase]]{monster} exhales lightning in a
+          [[lookup @labels.description.template activity=GSQtl90Opu6WzZk4]].
+          Each creature in that line must make a [[/save]] saving throw, taking
           [[/damage average]] damage on a failed save, or half as much damage on
           a successful one.</p>
         chat: >-
@@ -980,7 +990,7 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -1092,7 +1102,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781561979470
-      modifiedTime: 1781562128743
+      modifiedTime: 1783370720229
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!mNijwXPMhwR7yYfc.dDDGb8PVdU0irZz8'

--- a/packs/_source/monsters/dragon/young-blue-dragon.yml
+++ b/packs/_source/monsters/dragon/young-blue-dragon.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,15 +481,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: 42AGHJQzJZfUYxF9
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Blue Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -555,7 +555,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -564,8 +564,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        cYV8ujqP4bkhYX6u:
           type: attack
           activation:
             type: action
@@ -580,10 +579,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -600,7 +600,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -613,36 +614,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 10
                 bonus: ''
                 types:
                   - lightning
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: cYV8ujqP4bkhYX6u
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -652,22 +664,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449293676
+      systemVersion: 6.0.0
+      createdTime: 1781562162570
+      modifiedTime: 1781562174626
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!mNijwXPMhwR7yYfc.42AGHJQzJZfUYxF9'
   - _id: YSVencwrBzRdfm62
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Blue Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -730,7 +744,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -739,8 +753,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bUrcp6X5enDY8LzR:
           type: attack
           activation:
             type: action
@@ -755,10 +768,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -775,7 +789,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -801,11 +816,20 @@ items:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: bUrcp6X5enDY8LzR
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -815,144 +839,14 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449293676
+      systemVersion: 6.0.0
+      createdTime: 1781562140257
+      modifiedTime: 1781562148528
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!mNijwXPMhwR7yYfc.YSVencwrBzRdfm62'
-  - _id: 7XDStiwr5cRAODjk
-    name: Lightning Breath
-    type: feat
-    img: icons/magic/lightning/bolt-strike-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon exhales lightning in an 60-foot line that is 5 feet
-          wide. Each creature in that line must make a [[/save]] saving throw,
-          taking [[/damage average]] damage on a failed save, or half as much
-          damage on a successful one.</p>
-        chat: >-
-          <p>The dragon exhales lightning in a 60-foot line that is 5 feet wide.
-          Each creature in that line must make a <strong>Dexterity</strong>
-          saving throw.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: line
-              size: '60'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - number: 10
-                denomination: 10
-                bonus: ''
-                types:
-                  - lightning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          save:
-            ability: dex
-            dc:
-              calculation: ''
-              formula: '16'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: lightning-breath
-    effects: []
-    folder: null
-    sort: 400000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.LVnd9fq9cQj7rR0Q
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449312945
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!mNijwXPMhwR7yYfc.7XDStiwr5cRAODjk'
   - _id: dGVHjuCt6WhGx0sX
     name: Multiattack
     type: feat
@@ -1047,7 +941,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -1055,6 +949,153 @@ items:
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!mNijwXPMhwR7yYfc.dGVHjuCt6WhGx0sX'
+  - _id: dDDGb8PVdU0irZz8
+    name: Lightning Breath
+    type: feat
+    img: icons/magic/lightning/bolt-beam-strike-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The dragon exhales lightning in a [[lookup
+          @labels.description.template activity=GSQtl90Opu6WzZk4]]. Each
+          creature in that line must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} exhales lightning in a [[lookup
+          @labels.description.template activity=GSQtl90Opu6WzZk4]]. Each
+          creature in that line must make a Dexterity saving throw.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: ''
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        GSQtl90Opu6WzZk4:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: line
+              size: '60'
+              width: '5'
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 10
+                denomination: 10
+                bonus: ''
+                types:
+                  - lightning
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '12'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: GSQtl90Opu6WzZk4
+          name: Exhale Lightning
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: lightning-breath
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.LVnd9fq9cQj7rR0Q
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781561979470
+      modifiedTime: 1781562128743
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!mNijwXPMhwR7yYfc.dDDGb8PVdU0irZz8'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1063,7 +1104,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171254636

--- a/packs/_source/monsters/dragon/young-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/young-brass-dragon.yml
@@ -971,9 +971,9 @@ items:
           @labels.description.template activity=O02zuaLvAqtmgutQ]]. Each
           creature in that area must succeed on a [[/save
           activity=O02zuaLvAqtmgutQ]] saving throw or fall
-          &amp;Reference[unconscious] for 5 minutes. This effect ends for a
-          creature if the creature takes damage or someone uses an action to
-          wake it.</p>
+          &amp;Reference[unconscious] for [[lookup @labels.duration
+          activity=O02zuaLvAqtmgutQ]]. This effect ends for a creature if the
+          creature takes damage or someone uses an action to wake it.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -1111,9 +1111,10 @@ items:
               [[lookup @labels.description.template activity=O02zuaLvAqtmgutQ]].
               Each creature in that area must succeed on a [[/save
               activity=O02zuaLvAqtmgutQ]] saving throw or fall
-              &amp;Reference[unconscious] for 5 minutes. This effect ends for a
-              creature if the creature takes damage or someone uses an action to
-              wake it.</p>
+              &amp;Reference[unconscious] for [[lookup @labels.duration
+              activity=O02zuaLvAqtmgutQ]]. This effect ends for a creature if
+              the creature takes damage or someone uses an action to wake
+              it.</p>
           duration:
             concentration: false
             value: '5'
@@ -1237,7 +1238,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781562219369
-      modifiedTime: 1781622880843
+      modifiedTime: 1781631786130
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!FzvZ6xl3U9GoL9ju.K9vktdgJkPWfYjwa'

--- a/packs/_source/monsters/dragon/young-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/young-brass-dragon.yml
@@ -849,8 +849,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
-          with its [[/item .dYJy66Ftt58qpTUi]]{Bite} and two with its [[/item
-          .YHom7FFObzrKEBLQ]]{Claws}.</p>
+          with its [[/item .dYJy66Ftt58qpTUi]]{bite} and two with its [[/item
+          .YHom7FFObzrKEBLQ]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -948,7 +948,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781562401846
-      modifiedTime: 1781620918419
+      modifiedTime: 1783370668048
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!FzvZ6xl3U9GoL9ju.oyNvUJRyGRVF22t8'

--- a/packs/_source/monsters/dragon/young-brass-dragon.yml
+++ b/packs/_source/monsters/dragon/young-brass-dragon.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,15 +481,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: dYJy66Ftt58qpTUi
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Brass Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -555,7 +555,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -564,8 +564,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        CJfLU5RwQsSvSlt1:
           type: attack
           activation:
             type: action
@@ -580,10 +579,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -600,7 +600,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -613,24 +614,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: CJfLU5RwQsSvSlt1
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -640,221 +654,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451010621
+      systemVersion: 6.0.0
+      createdTime: 1781562337440
+      modifiedTime: 1781562349607
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!FzvZ6xl3U9GoL9ju.dYJy66Ftt58qpTUi'
-  - _id: h8ocFdixa3iZVj0m
-    name: Breath Weapons
-    type: feat
-    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Fire Breath.</strong> The dragon exhales fire
-          in a 40-foot line that is 5 feet wide. Each creature in that line must
-          make a [[/save activity=Es6C2unaFSW7LHd3]] saving throw, taking
-          [[/damage average activity=Es6C2unaFSW7LHd3]] damage on a failed save,
-          or half as much damage on a successful one.</p><p><strong>Sleep
-          Breath.</strong> The dragon exhales sleep gas in a 30-foot cone. Each
-          creature in that area must succeed on a [[/save
-          activity=6xecSNeczVQ2Wtcg]] saving throw or fall
-          &amp;Reference[unconscious] for 5 minutes. This effect ends for a
-          creature if the creature takes damage or someone uses an action to
-          wake it.</p>
-        chat: <p>The dragon breathes in!</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        Es6C2unaFSW7LHd3:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: Breath weapon must be charged
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: line
-              size: '40'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 12
-                denomination: '6'
-                bonus: ''
-                types:
-                  - fire
-          save:
-            ability:
-              - dex
-            dc:
-              calculation: ''
-              formula: '14'
-          sort: 0
-          _id: Es6C2unaFSW7LHd3
-          name: Fire Breath
-          img: ''
-          appliedEffects: []
-        6xecSNeczVQ2Wtcg:
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: Breath Weapon must be charged
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: self
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '30'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts: []
-          save:
-            ability:
-              - con
-            dc:
-              calculation: ''
-              formula: '14'
-          sort: 0
-          _id: 6xecSNeczVQ2Wtcg
-          name: Sleep Breath
-          img: ''
-          appliedEffects: []
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: breath-weapons
-    effects: []
-    folder: null
-    sort: 400000
-    ownership:
-      default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451239220
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!FzvZ6xl3U9GoL9ju.h8ocFdixa3iZVj0m'
   - _id: YHom7FFObzrKEBLQ
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Brass Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -917,7 +734,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -926,8 +743,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bYNQf8JH8hyuEm9B:
           type: attack
           activation:
             type: action
@@ -942,10 +758,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -962,7 +779,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -975,24 +793,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bYNQf8JH8hyuEm9B
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -1002,11 +833,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451010621
+      systemVersion: 6.0.0
+      createdTime: 1781562364357
+      modifiedTime: 1781562376519
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!FzvZ6xl3U9GoL9ju.YHom7FFObzrKEBLQ'
@@ -1017,9 +848,9 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon makes three attacks: one with its [[/item
-          .dYJy66Ftt58qpTUi]]{bite} and two with its [[/item
-          .YHom7FFObzrKEBLQ]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .dYJy66Ftt58qpTUi]]{Bite} and two with its [[/item
+          .YHom7FFObzrKEBLQ]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -1033,13 +864,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        lyyHQyxxDV8CoMrC:
           type: utility
           activation:
             type: action
@@ -1054,15 +884,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1073,7 +904,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1090,7 +922,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 200000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: lyyHQyxxDV8CoMrC
       enchant: {}
       prerequisites:
         level: null
@@ -1104,14 +944,303 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451011333
+      systemVersion: 6.0.0
+      createdTime: 1781562401846
+      modifiedTime: 1781620918419
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!FzvZ6xl3U9GoL9ju.oyNvUJRyGRVF22t8'
+  - _id: K9vktdgJkPWfYjwa
+    name: Breath Weapons
+    type: feat
+    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Fire Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales fire in an [[lookup
+          @labels.description.template activity=NBdXGRF1vahbq4p8]]. Each
+          creature in that line must make a [[/save activity=NBdXGRF1vahbq4p8]]
+          saving throw, taking [[/damage average activity=NBdXGRF1vahbq4p8]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Sleep Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales sleep gas in a [[lookup
+          @labels.description.template activity=O02zuaLvAqtmgutQ]]. Each
+          creature in that area must succeed on a [[/save
+          activity=O02zuaLvAqtmgutQ]] saving throw or fall
+          &amp;Reference[unconscious] for 5 minutes. This effect ends for a
+          creature if the creature takes damage or someone uses an action to
+          wake it.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        NBdXGRF1vahbq4p8:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales fire in an
+              [[lookup @labels.description.template activity=NBdXGRF1vahbq4p8]].
+              Each creature in that line must make a [[/save
+              activity=NBdXGRF1vahbq4p8]] saving throw, taking [[/damage average
+              activity=NBdXGRF1vahbq4p8]] damage on a failed save, or half as
+              much damage on a successful one.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: line
+              size: '40'
+              width: '5'
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 12
+                denomination: 6
+                bonus: ''
+                types:
+                  - fire
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: NBdXGRF1vahbq4p8
+          name: Fire Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+        O02zuaLvAqtmgutQ:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales sleep gas in a
+              [[lookup @labels.description.template activity=O02zuaLvAqtmgutQ]].
+              Each creature in that area must succeed on a [[/save
+              activity=O02zuaLvAqtmgutQ]] saving throw or fall
+              &amp;Reference[unconscious] for 5 minutes. This effect ends for a
+              creature if the creature takes damage or someone uses an action to
+              wake it.</p>
+          duration:
+            concentration: false
+            value: '5'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: P1rGrKiV7x2OMiN0
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '30'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - con
+            dc:
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
+          sort: 0
+          _id: O02zuaLvAqtmgutQ
+          name: Sleep Breath
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: breath-weapons
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Sleep Breath
+        img: icons/magic/control/sleep-bubble-purple.webp
+        origin: Compendium.dnd5e.monsters.Actor.azCbLQt5LAYwTI7U.Item.JmVLjWM4G6OOQxl4
+        transfer: false
+        _id: P1rGrKiV7x2OMiN0
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 5
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[unconcious apply=false] for 5 minutes. This
+          effect ends for you when you take damage or when someone uses and
+          action to wake you.</p>
+        tint: '#ffffff'
+        statuses:
+          - unconscious
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781562219369
+          modifiedTime: 1781621257264
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!FzvZ6xl3U9GoL9ju.K9vktdgJkPWfYjwa.P1rGrKiV7x2OMiN0
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781562219369
+      modifiedTime: 1781622880843
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!FzvZ6xl3U9GoL9ju.K9vktdgJkPWfYjwa'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1120,7 +1249,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171216952

--- a/packs/_source/monsters/dragon/young-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/young-bronze-dragon.yml
@@ -849,8 +849,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
-          with its [[/item .22lf3TLPObmD4s6h]]{Bite} and two with its [[/item
-          .LGFPSpA0pvVpj3cF]]{Claws}.</p>
+          with its [[/item .22lf3TLPObmD4s6h]]{bite} and two with its [[/item
+          .LGFPSpA0pvVpj3cF]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -948,7 +948,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781562510901
-      modifiedTime: 1781562515736
+      modifiedTime: 1783370659306
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!NmQLj0zv4FmfuSan.xDjzXK9dbD2EV8hi'

--- a/packs/_source/monsters/dragon/young-bronze-dragon.yml
+++ b/packs/_source/monsters/dragon/young-bronze-dragon.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,61 +481,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
-  - _id: E7PndURmnBqGibjl
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!NmQLj0zv4FmfuSan.E7PndURmnBqGibjl'
   - _id: 22lf3TLPObmD4s6h
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Bronze Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -610,8 +564,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        AuLEdCWLl2j0BHNQ:
           type: attack
           activation:
             type: action
@@ -626,10 +579,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -646,7 +600,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -659,24 +614,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: AuLEdCWLl2j0BHNQ
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -686,22 +654,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451326129
+      systemVersion: 6.0.0
+      createdTime: 1781562434326
+      modifiedTime: 1781562444771
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!NmQLj0zv4FmfuSan.22lf3TLPObmD4s6h'
   - _id: LGFPSpA0pvVpj3cF
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Bronze Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -764,7 +734,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -773,8 +743,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        0DeqrW42tQIOZ0yn:
           type: attack
           activation:
             type: action
@@ -789,10 +758,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -809,7 +779,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -822,24 +793,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 0DeqrW42tQIOZ0yn
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -849,11 +833,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451326129
+      systemVersion: 6.0.0
+      createdTime: 1781562456819
+      modifiedTime: 1781562467762
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!NmQLj0zv4FmfuSan.LGFPSpA0pvVpj3cF'
@@ -864,9 +848,9 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon makes three attacks: one with its [[/item
-          .22lf3TLPObmD4s6h]]{bite} and two with its [[/item
-          .LGFPSpA0pvVpj3cF]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .22lf3TLPObmD4s6h]]{Bite} and two with its [[/item
+          .LGFPSpA0pvVpj3cF]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -880,13 +864,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        87jtImB92yNmS3oz:
           type: utility
           activation:
             type: action
@@ -901,15 +884,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -920,7 +904,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -937,7 +922,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 87jtImB92yNmS3oz
       enchant: {}
       prerequisites:
         level: null
@@ -951,32 +944,36 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451326826
+      systemVersion: 6.0.0
+      createdTime: 1781562510901
+      modifiedTime: 1781562515736
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!NmQLj0zv4FmfuSan.xDjzXK9dbD2EV8hi'
-  - _id: cbov06rPLGnlIvFi
+  - _id: nRygf5tL7Jm91beK
     name: Breath Weapons
     type: feat
     img: icons/creatures/abilities/dragon-ice-breath-blue.webp
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Lightning Breath.</strong> The dragon exhales
-          lightning in a 120-foot line that is 10 feet wide. Each creature in
-          that line must make a [[/save activity=w2CftR6CLr5PZ7zY]] saving
-          throw, taking [[/damage average activity=w2CftR6CLr5PZ7zY]] damage on
-          a failed save, or half as much damage on a successful
-          one.</p><p><strong>Repulsion Breath.</strong> The dragon exhales
-          repulsion energy in a 30-foot cone. Each creature in that area must
-          succeed on a [[/save activity=YElWYv6C5UfhAu48]] saving throw. On a
-          failed save, the creature is pushed 60 feet away from the dragon.</p>
-        chat: <p>The dragon breathes in!</p>
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Lightning Breath.</strong> The [[lookup
+          @name lowercase]]{monster} exhales lightning in a [[lookup
+          @labels.description.template activity=w2CftR6CLr5PZ7zY]]. Each
+          creature in that line must make a [[/save activity=w2CftR6CLr5PZ7zY]]
+          saving throw, taking [[/damage average activity=w2CftR6CLr5PZ7zY]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Repulsion Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales repulsion energy in a [[lookup
+          @labels.description.template activity=YElWYv6C5UfhAu48]]. Each
+          creature in that area must succeed on a [[/save
+          activity=YElWYv6C5UfhAu48]] saving throw. On a failed save, the
+          creature is pushed 60 feet away from the [[lookup @name
+          lowercase]]{monster}.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -992,7 +989,7 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -1009,12 +1006,20 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales lightning in a
+              [[lookup @labels.description.template activity=w2CftR6CLr5PZ7zY]].
+              Each creature in that line must make a [[/save
+              activity=w2CftR6CLr5PZ7zY]] saving throw, taking [[/damage average
+              activity=w2CftR6CLr5PZ7zY]] damage on a failed save, or half as
+              much damage on a successful one.</p>
           duration:
             concentration: false
             value: ''
@@ -1031,13 +1036,14 @@ items:
               count: ''
               contiguous: false
               type: line
-              size: '120'
-              width: ''
+              size: '60'
+              width: '5'
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1053,21 +1059,33 @@ items:
                   enabled: false
                   formula: ''
                 number: 10
-                denomination: '10'
+                denomination: 10
                 bonus: ''
                 types:
                   - lightning
+                scaling:
+                  number: 1
           save:
             ability:
               - dex
             dc:
-              calculation: ''
-              formula: '15'
+              calculation: con
+              formula: '12'
+            bonus: ''
+            visible: true
           sort: 0
           _id: w2CftR6CLr5PZ7zY
           name: Lightning Breath
           img: ''
-          appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
         YElWYv6C5UfhAu48:
           type: save
           activation:
@@ -1080,12 +1098,20 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales repulsion
+              energy in a [[lookup @labels.description.template
+              activity=YElWYv6C5UfhAu48]]. Each creature in that area must
+              succeed on a [[/save activity=YElWYv6C5UfhAu48]] saving throw. On
+              a failed save, the creature is pushed 60 feet away from the
+              [[lookup @name lowercase]]{monster}.</p>
           duration:
             concentration: false
             value: ''
@@ -1106,9 +1132,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1118,25 +1145,36 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability:
               - str
             dc:
-              calculation: ''
-              formula: '15'
+              calculation: con
+              formula: '12'
+            bonus: ''
+            visible: true
           sort: 0
           _id: YElWYv6C5UfhAu48
           name: Repulsion Breath
           img: ''
-          appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
       enchant: {}
       prerequisites:
         level: null
         repeatable: false
+        items: []
       identifier: breath-weapons
-      advancement: []
+      advancement: {}
       cover: null
       crewed: false
     effects: []
@@ -1144,22 +1182,71 @@ items:
     sort: 600000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: 1745451477671
-      modifiedTime: 1745451490966
+      systemVersion: 6.0.0
+      createdTime: 1781562489216
+      modifiedTime: 1781562636144
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!NmQLj0zv4FmfuSan.cbov06rPLGnlIvFi'
+    _key: '!actors.items!NmQLj0zv4FmfuSan.nRygf5tL7Jm91beK'
+  - _id: z1P0RbYFfEJX8DNL
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781562663365
+      modifiedTime: 1781562663365
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!NmQLj0zv4FmfuSan.z1P0RbYFfEJX8DNL'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1168,7 +1255,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171227229

--- a/packs/_source/monsters/dragon/young-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/young-copper-dragon.yml
@@ -974,8 +974,9 @@ items:
           creature can't use reactions, its speed is halved, and it can't make
           more than one attack on its turn. In addition, the creature can use
           either an action or a bonus action on its turn, but not both. These
-          effects last for 1 minute. The creature can repeat the saving throw at
-          the end of each of its turns, ending the effect on itself with a
+          effects last for [[lookup @labels.duration
+          activity=CkPMajPOZWWj3gl0]]. The creature can repeat the saving throw
+          at the end of each of its turns, ending the effect on itself with a
           successful save.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
@@ -1117,9 +1118,10 @@ items:
               creature can't use reactions, its speed is halved, and it can't
               make more than one attack on its turn. In addition, the creature
               can use either an action or a bonus action on its turn, but not
-              both. These effects last for 1 minute. The creature can repeat the
-              saving throw at the end of each of its turns, ending the effect on
-              itself with a successful save.</p>
+              both. These effects last for [[lookup @labels.duration
+              activity=CkPMajPOZWWj3gl0]]. The creature can repeat the saving
+              throw at the end of each of its turns, ending the effect on itself
+              with a successful save.</p>
           duration:
             concentration: false
             value: '1'
@@ -1271,7 +1273,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781562726004
-      modifiedTime: 1781562875217
+      modifiedTime: 1781631688290
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qW8cBwg7ghCA4Cw6.3oecwwSby4Of0PrD'

--- a/packs/_source/monsters/dragon/young-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/young-copper-dragon.yml
@@ -849,8 +849,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
-          with its [[/item .Km7rUn5tu44KuVbz]]{Bite} and two with its [[/item
-          .DlxAB4bcOmBIn0UG]]{Claws}.</p>
+          with its [[/item .Km7rUn5tu44KuVbz]]{bite} and two with its [[/item
+          .DlxAB4bcOmBIn0UG]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -948,7 +948,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781562793412
-      modifiedTime: 1781562797997
+      modifiedTime: 1783370646935
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qW8cBwg7ghCA4Cw6.kk9fXkx19bCD5Qqv'

--- a/packs/_source/monsters/dragon/young-copper-dragon.yml
+++ b/packs/_source/monsters/dragon/young-copper-dragon.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,15 +481,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: Km7rUn5tu44KuVbz
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Copper Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -555,7 +555,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -564,8 +564,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        JiWopTmontrQr61u:
           type: attack
           activation:
             type: action
@@ -580,10 +579,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -600,7 +600,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -613,24 +614,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: JiWopTmontrQr61u
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -640,22 +654,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451773338
+      systemVersion: 6.0.0
+      createdTime: 1781562755786
+      modifiedTime: 1781562769364
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qW8cBwg7ghCA4Cw6.Km7rUn5tu44KuVbz'
   - _id: DlxAB4bcOmBIn0UG
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Copper Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -718,17 +734,16 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: simpleM
+        value: natural
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        vsIDDMQkwnjUq0B8:
           type: attack
           activation:
             type: action
@@ -743,10 +758,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -763,7 +779,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -776,24 +793,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: vsIDDMQkwnjUq0B8
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -803,11 +833,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451773338
+      systemVersion: 6.0.0
+      createdTime: 1781562732143
+      modifiedTime: 1781562747287
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qW8cBwg7ghCA4Cw6.DlxAB4bcOmBIn0UG'
@@ -818,9 +848,9 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon makes three attacks: one with its [[/item
-          .Km7rUn5tu44KuVbz]]{bite} and two with its [[/item
-          .DlxAB4bcOmBIn0UG]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .Km7rUn5tu44KuVbz]]{Bite} and two with its [[/item
+          .DlxAB4bcOmBIn0UG]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -834,13 +864,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        nsX2sbie8RvuGmqP:
           type: utility
           activation:
             type: action
@@ -855,15 +884,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -874,7 +904,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -891,7 +922,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: nsX2sbie8RvuGmqP
       enchant: {}
       prerequisites:
         level: null
@@ -905,28 +944,31 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745451774011
+      systemVersion: 6.0.0
+      createdTime: 1781562793412
+      modifiedTime: 1781562797997
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qW8cBwg7ghCA4Cw6.kk9fXkx19bCD5Qqv'
-  - _id: QIwTmsNVErWEqzFN
+  - _id: 3oecwwSby4Of0PrD
     name: Breath Weapons
     type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
+    img: icons/magic/acid/projectile-faceted-glob.webp
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Acid Breath.</strong> The dragon exhales acid
-          in an 90-foot line that is 10 feet wide. Each creature in that line
-          must make a [[/save activity=zTWpuajI6meBb52D]] saving throw, taking
-          [[/damage average activity=zTWpuajI6meBb52D]] damage on a failed save,
-          or half as much damage on a successful one.</p><p><strong>Slowing
-          Breath.</strong> The dragon exhales gas in a 90-foot cone. Each
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Acid Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales acid in an [[lookup
+          @labels.description.template activity=zTWpuajI6meBb52D]]. Each
+          creature in that line must make a [[/save activity=zTWpuajI6meBb52D]]
+          saving throw, taking [[/damage average activity=zTWpuajI6meBb52D]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Slowing Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales gas in a [[lookup
+          @labels.description.template activity=zTWpuajI6meBb52D]]. Each
           creature in that area must succeed on a [[/save
           activity=CkPMajPOZWWj3gl0]] saving throw. On a failed save, the
           creature can't use reactions, its speed is halved, and it can't make
@@ -935,7 +977,7 @@ items:
           effects last for 1 minute. The creature can repeat the saving throw at
           the end of each of its turns, ending the effect on itself with a
           successful save.</p>
-        chat: <p>The dragon breathes in!</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -951,7 +993,7 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -968,12 +1010,20 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales acid in an
+              [[lookup @labels.description.template activity=zTWpuajI6meBb52D]].
+              Each creature in that line must make a [[/save
+              activity=zTWpuajI6meBb52D]] saving throw, taking [[/damage average
+              activity=zTWpuajI6meBb52D]] damage on a failed save, or half as
+              much damage on a successful one.</p>
           duration:
             concentration: false
             value: ''
@@ -990,13 +1040,14 @@ items:
               count: ''
               contiguous: false
               type: line
-              size: '90'
-              width: ''
+              size: '40'
+              width: '5'
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1012,21 +1063,33 @@ items:
                   enabled: false
                   formula: ''
                 number: 9
-                denomination: '8'
+                denomination: 8
                 bonus: ''
                 types:
                   - acid
+                scaling:
+                  number: 1
           save:
             ability:
               - dex
             dc:
-              calculation: ''
-              formula: '14'
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
           sort: 0
           _id: zTWpuajI6meBb52D
           name: Acid Breath
           img: ''
-          appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
         CkPMajPOZWWj3gl0:
           type: save
           activation:
@@ -1039,19 +1102,36 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=zTWpuajI6meBb52D]].
+              Each creature in that area must succeed on a [[/save
+              activity=CkPMajPOZWWj3gl0]] saving throw. On a failed save, the
+              creature can't use reactions, its speed is halved, and it can't
+              make more than one attack on its turn. In addition, the creature
+              can use either an action or a bonus action on its turn, but not
+              both. These effects last for 1 minute. The creature can repeat the
+              saving throw at the end of each of its turns, ending the effect on
+              itself with a successful save.</p>
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: 5E6iveIba4rYeUbc
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             units: self
             special: ''
@@ -1061,13 +1141,14 @@ items:
               count: ''
               contiguous: false
               type: cone
-              size: '90'
+              size: '30'
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1077,48 +1158,123 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability:
               - con
             dc:
-              calculation: ''
-              formula: '14'
+              calculation: con
+              formula: '11'
+            bonus: ''
+            visible: true
           sort: 0
           _id: CkPMajPOZWWj3gl0
           name: Slowing Breath
           img: ''
-          appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
       enchant: {}
       prerequisites:
         level: null
         repeatable: false
+        items: []
       identifier: breath-weapons
-      advancement: []
+      advancement: {}
       cover: null
       crewed: false
-    effects: []
+    effects:
+      - name: Slowed
+        img: icons/skills/movement/arrow-down-pink.webp
+        origin: Compendium.dnd5e.monsters.Actor.AyvniEKtyroOe83p.Item.XuuhDCc4RQcZOXUL
+        transfer: false
+        _id: 5E6iveIba4rYeUbc
+        type: base
+        system:
+          changes:
+            - key: system.attributes.movement.burrow
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.climb
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.fly
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.swim
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+            - key: system.attributes.movement.walk
+              type: multiply
+              value: 0.5
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are slowed. While slowed, you can't use reactions, your speed
+          is halved, and you can't make more than one attack on your turn. In
+          addition, you can use either an action or a bonus action on your turn,
+          but not both.</p><p>These effects last for 1 minute. You can repeat
+          the saving throw at the end of each of your turns, ending the effect
+          on yourself with a succesful save.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781562726004
+          modifiedTime: 1781562726004
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!qW8cBwg7ghCA4Cw6.3oecwwSby4Of0PrD.5E6iveIba4rYeUbc
     folder: null
     sort: 550000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: 1745451912657
-      modifiedTime: 1745451929580
+      systemVersion: 6.0.0
+      createdTime: 1781562726004
+      modifiedTime: 1781562875217
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!qW8cBwg7ghCA4Cw6.QIwTmsNVErWEqzFN'
+    _key: '!actors.items!qW8cBwg7ghCA4Cw6.3oecwwSby4Of0PrD'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1127,7 +1283,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171259652

--- a/packs/_source/monsters/dragon/young-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/young-gold-dragon.yml
@@ -848,8 +848,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
-          with its [[/item .IiZoBYBEjE5gGjeD]]{Bite} and two with its [[/item
-          .qRuJSlOzJITBzcjv]]{Claws}.</p>
+          with its [[/item .IiZoBYBEjE5gGjeD]]{bite} and two with its [[/item
+          .qRuJSlOzJITBzcjv]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -947,7 +947,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781563245537
-      modifiedTime: 1781563250358
+      modifiedTime: 1783370636529
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!QSytPah5WKoFJ1zt.VmQbXjALjJwKhT91'

--- a/packs/_source/monsters/dragon/young-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/young-gold-dragon.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,61 +481,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
-  - _id: At4ZIy9ucx4umj5Y
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!QSytPah5WKoFJ1zt.At4ZIy9ucx4umj5Y'
   - _id: IiZoBYBEjE5gGjeD
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Gold Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -601,7 +555,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -610,8 +564,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        WhrzWLxscqPrnwdY:
           type: attack
           activation:
             type: action
@@ -626,10 +579,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -646,7 +600,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -659,24 +614,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: WhrzWLxscqPrnwdY
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -686,22 +654,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452195289
+      systemVersion: 6.0.0
+      createdTime: 1781563210167
+      modifiedTime: 1781563222788
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!QSytPah5WKoFJ1zt.IiZoBYBEjE5gGjeD'
   - _id: qRuJSlOzJITBzcjv
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Gold Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -764,7 +734,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -773,8 +743,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        Kpwot7I6EO9GPGQN:
           type: attack
           activation:
             type: action
@@ -789,15 +758,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -808,7 +778,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -821,24 +792,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: Kpwot7I6EO9GPGQN
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -848,11 +832,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452195289
+      systemVersion: 6.0.0
+      createdTime: 1781563187433
+      modifiedTime: 1781563227289
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!QSytPah5WKoFJ1zt.qRuJSlOzJITBzcjv'
@@ -863,9 +847,9 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon makes three attacks: one with its [[/item
-          .IiZoBYBEjE5gGjeD]]{bite} and two with its [[/item
-          .qRuJSlOzJITBzcjv]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .IiZoBYBEjE5gGjeD]]{Bite} and two with its [[/item
+          .qRuJSlOzJITBzcjv]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -879,13 +863,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4xKQrXiiM6miXOa7:
           type: utility
           activation:
             type: action
@@ -900,15 +883,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -919,7 +903,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -936,7 +921,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 4xKQrXiiM6miXOa7
       enchant: {}
       prerequisites:
         level: null
@@ -950,34 +943,37 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452196016
+      systemVersion: 6.0.0
+      createdTime: 1781563245537
+      modifiedTime: 1781563250358
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!QSytPah5WKoFJ1zt.VmQbXjALjJwKhT91'
-  - _id: mgNFoCeNcwVLej7g
+  - _id: VnIBkSFvqaQrq10M
     name: Breath Weapons
     type: feat
     img: icons/creatures/abilities/dragon-fire-breath-orange.webp
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Fire Breath.</strong> The dragon exhales fire
-          in a 90-foot cone. Each creature in that area must make a [[/save
-          activity=o8fOmWWIqCYwGu3C]] saving throw, taking [[/damage average
-          activity=o8fOmWWIqCYwGu3C]] damage on a failed save, or half as much
-          damage on a successful one.</p><p><strong>Weakening Breath.</strong>
-          The dragon exhales gas in a 90-foot cone. Each creature in that area
-          must succeed on a [[/save activity=J4QhEMZOdsyIy2D6]] saving throw or
-          have disadvantage on Strength-based attack rolls, Strength checks, and
-          Strength saving throws for 1 minute. A creature can repeat the saving
-          throw at the end of each of its turns, ending the effect on itself on
-          a success.</p>
-        chat: <p>The dragon breathes in!</p>
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Fire Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=o8fOmWWIqCYwGu3C]]. Each
+          creature in that area must make a [[/save activity=o8fOmWWIqCYwGu3C]]
+          saving throw, taking [[/damage average activity=o8fOmWWIqCYwGu3C]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Weakening Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales gas in a [[lookup
+          @labels.description.template activity=J4QhEMZOdsyIy2D6]]. Each
+          creature in that area must succeed on a [[/save
+          activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+          Strength-based attack rolls, Strength checks, and Strength saving
+          throws for 1 minute. A creature can repeat the saving throw at the end
+          of each of its turns, ending the effect on itself on a success.</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -986,11 +982,14 @@ items:
         rules: '2014'
         revision: 1
       uses:
-        max: ''
-        recovery: []
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -1007,12 +1006,22 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=J4QhEMZOdsyIy2D6]].
+              Each creature in that area must succeed on a [[/save
+              activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+              Strength-based attack rolls, Strength checks, and Strength saving
+              throws for 1 minute. A creature can repeat the saving throw at the
+              end of each of its turns, ending the effect on itself on a
+              success.</p>
           duration:
             concentration: false
             value: ''
@@ -1029,13 +1038,14 @@ items:
               count: ''
               contiguous: false
               type: cone
-              size: '90'
+              size: '30'
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1051,21 +1061,33 @@ items:
                   enabled: false
                   formula: ''
                 number: 10
-                denomination: '10'
+                denomination: 10
                 bonus: ''
                 types:
                   - fire
+                scaling:
+                  number: 1
           save:
             ability:
               - dex
             dc:
-              calculation: ''
-              formula: '17'
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
           sort: 0
           _id: o8fOmWWIqCYwGu3C
           name: Fire Breath
           img: ''
-          appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
         J4QhEMZOdsyIy2D6:
           type: save
           activation:
@@ -1078,19 +1100,26 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: a5q0M5lHMSOhKxFi
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             units: self
             special: ''
@@ -1100,13 +1129,14 @@ items:
               count: ''
               contiguous: false
               type: cone
-              size: '90'
+              size: '30'
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1116,48 +1146,159 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability:
               - str
             dc:
-              calculation: ''
-              formula: '17'
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
           sort: 0
           _id: J4QhEMZOdsyIy2D6
           name: Weakening Breath
           img: ''
-          appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          flags: {}
       enchant: {}
       prerequisites:
         level: null
         repeatable: false
+        items: []
       identifier: breath-weapons
-      advancement: []
+      advancement: {}
       cover: null
       crewed: false
-    effects: []
+    effects:
+      - name: Weakened
+        img: icons/magic/death/hand-withered-gray.webp
+        origin: Compendium.dnd5e.monsters.Actor.naSoHU9KbkgeNIwB.Item.5vCVx0zwz1FKIvTX
+        transfer: false
+        _id: a5q0M5lHMSOhKxFi
+        type: base
+        system:
+          changes:
+            - key: system.abilities.str.save.roll.mode
+              type: add
+              value: -1
+              phase: initial
+              priority: null
+            - key: system.abilities.str.check.roll.mode
+              type: add
+              value: -1
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are weakened. While weakened, you have disadavntage on
+          Strength-based attack rolls, Strength checks, and Strength saving
+          throws for 1 minute. You can repeat the saving throw at the end of
+          each of your turns, ending the effect on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781563090577
+          modifiedTime: 1781563090577
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!QSytPah5WKoFJ1zt.VnIBkSFvqaQrq10M.a5q0M5lHMSOhKxFi
     folder: null
     sort: 600000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: 1745452318985
-      modifiedTime: 1745452350424
+      systemVersion: 6.0.0
+      createdTime: 1781563090577
+      modifiedTime: 1781630360812
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!QSytPah5WKoFJ1zt.mgNFoCeNcwVLej7g'
+    _key: '!actors.items!QSytPah5WKoFJ1zt.VnIBkSFvqaQrq10M'
+  - _id: A02zFTe8hrM8vUXI
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781563091837
+      modifiedTime: 1781563091837
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!QSytPah5WKoFJ1zt.A02zFTe8hrM8vUXI'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1166,7 +1307,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171230445

--- a/packs/_source/monsters/dragon/young-gold-dragon.yml
+++ b/packs/_source/monsters/dragon/young-gold-dragon.yml
@@ -971,8 +971,9 @@ items:
           creature in that area must succeed on a [[/save
           activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
           Strength-based attack rolls, Strength checks, and Strength saving
-          throws for 1 minute. A creature can repeat the saving throw at the end
-          of each of its turns, ending the effect on itself on a success.</p>
+          throws for [[lookup @labels.duration activity=J4QhEMZOdsyIy2D6]]. A
+          creature can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -1107,7 +1108,15 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-            value: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales gas in a
+              [[lookup @labels.description.template activity=J4QhEMZOdsyIy2D6]].
+              Each creature in that area must succeed on a [[/save
+              activity=J4QhEMZOdsyIy2D6]] saving throw or have disadvantage on
+              Strength-based attack rolls, Strength checks, and Strength saving
+              throws for [[lookup @labels.duration activity=J4QhEMZOdsyIy2D6]].
+              A creature can repeat the saving throw at the end of each of its
+              turns, ending the effect on itself on a success.</p>
           duration:
             concentration: false
             value: '1'
@@ -1242,7 +1251,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781563090577
-      modifiedTime: 1781630360812
+      modifiedTime: 1781631530803
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!QSytPah5WKoFJ1zt.VnIBkSFvqaQrq10M'

--- a/packs/_source/monsters/dragon/young-green-dragon.yml
+++ b/packs/_source/monsters/dragon/young-green-dragon.yml
@@ -860,8 +860,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
-          with its [[/item .0Ob35HZxhSF7p2ys]]{Bite} and two with its [[/item
-          .WvvHslcDhMq7MD1s]]{Claws}.</p>
+          with its [[/item .0Ob35HZxhSF7p2ys]]{bite} and two with its [[/item
+          .WvvHslcDhMq7MD1s]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -959,7 +959,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781561554091
-      modifiedTime: 1781561560818
+      modifiedTime: 1783370626758
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!85ahD1jEo9B3POaQ.Ux1Gv0S29JzRaD27'

--- a/packs/_source/monsters/dragon/young-green-dragon.yml
+++ b/packs/_source/monsters/dragon/young-green-dragon.yml
@@ -448,9 +448,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -465,7 +462,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -485,61 +482,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
-  - _id: 6VIuuNCntP3W9Tki
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The dragon can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!85ahD1jEo9B3POaQ.6VIuuNCntP3W9Tki'
   - _id: 0Ob35HZxhSF7p2ys
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Green Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -602,7 +556,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -611,8 +565,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        7WNtVvJm9KV0p9gL:
           type: attack
           activation:
             type: action
@@ -627,10 +580,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -647,7 +601,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -660,36 +615,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 6
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: 7WNtVvJm9KV0p9gL
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -699,22 +665,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449676167
+      systemVersion: 6.0.0
+      createdTime: 1781561118796
+      modifiedTime: 1781561414869
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!85ahD1jEo9B3POaQ.0Ob35HZxhSF7p2ys'
   - _id: WvvHslcDhMq7MD1s
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Green Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -777,7 +745,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -786,8 +754,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        i6qPvLGaTR36AbC8:
           type: attack
           activation:
             type: action
@@ -802,10 +769,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -822,7 +790,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -835,24 +804,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          name: ''
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: i6qPvLGaTR36AbC8
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -862,11 +844,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449676167
+      systemVersion: 6.0.0
+      createdTime: 1781561097683
+      modifiedTime: 1781561112417
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!85ahD1jEo9B3POaQ.WvvHslcDhMq7MD1s'
@@ -877,9 +859,9 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon makes three attacks: one with its [[/item
-          .0Ob35HZxhSF7p2ys]]{bite} and two with its [[/item
-          .WvvHslcDhMq7MD1s]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .0Ob35HZxhSF7p2ys]]{Bite} and two with its [[/item
+          .WvvHslcDhMq7MD1s]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -893,13 +875,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        B2JwbGjAMD8ESKOO:
           type: utility
           activation:
             type: action
@@ -914,15 +895,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -933,7 +915,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -950,7 +933,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: B2JwbGjAMD8ESKOO
       enchant: {}
       prerequisites:
         level: null
@@ -964,29 +955,83 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449676950
+      systemVersion: 6.0.0
+      createdTime: 1781561554091
+      modifiedTime: 1781561560818
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!85ahD1jEo9B3POaQ.Ux1Gv0S29JzRaD27'
-  - _id: PIXokIK4tYPwua2G
-    name: Poison Breath
+  - _id: FhV1rSsYQlrAK7el
+    name: Amphibious
     type: feat
-    img: icons/magic/acid/projectile-smoke-glowing.webp
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales poisonous gas in a 30-foot cone. Each creature
-          in that area must make a [[/save]] saving throw, taking [[/damage
-          average]] damage on a failed save, or half as much damage on a
-          successful one.</p>
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 125000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781561082750
+      modifiedTime: 1781561082750
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!85ahD1jEo9B3POaQ.FhV1rSsYQlrAK7el'
+  - _id: y0ah5CNeERfDAyP9
+    name: Poison Breath
+    type: feat
+    img: icons/skills/toxins/cauldron-bubbles-overflow-green.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} exhales poisonous gas in a
+          [[lookup @labels.description.template activity=MiNhGAqISi8NVtZa]].
+          Each creature in that area must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
         chat: >-
-          <p>The dragon exhales poisonous gas in a 30-foot cone. Each creature
-          in that area must make a <strong>Constitution</strong> saving
-          throw.</p>
+          <p>The [[lookup @name]]{monster} exhales poisonous gas in a [[lookup
+          @labels.description.template activity=MiNhGAqISi8NVtZa]]. Each
+          creature in that area must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1002,13 +1047,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        MiNhGAqISi8NVtZa:
           type: save
           activation:
             type: action
@@ -1018,17 +1062,16 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1049,9 +1092,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1063,45 +1107,62 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 12
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 12
                 denomination: 6
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
-              calculation: ''
-              formula: '14'
-          sort: 0
+              calculation: con
+              formula: '11'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: MiNhGAqISi8NVtZa
+          name: Exhale Poison
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: poison-breath
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
-    sort: 400000
+    sort: 500000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.JAEclghgOT24pQD9
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745449857373
+      systemVersion: 6.0.0
+      createdTime: 1781561089486
+      modifiedTime: 1781605188483
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!85ahD1jEo9B3POaQ.PIXokIK4tYPwua2G'
+    _key: '!actors.items!85ahD1jEo9B3POaQ.y0ah5CNeERfDAyP9'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1110,7 +1171,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171206621

--- a/packs/_source/monsters/dragon/young-red-dragon.yml
+++ b/packs/_source/monsters/dragon/young-red-dragon.yml
@@ -859,8 +859,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
-          with its [[/item .KuuOPjJ1YeTtjGbN]]{Bite} and two with its [[/item
-          .3UHmbpT3v3FTlplI]]{Claws}.</p>
+          with its [[/item .KuuOPjJ1YeTtjGbN]]{bite} and two with its [[/item
+          .3UHmbpT3v3FTlplI]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -958,7 +958,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781561051218
-      modifiedTime: 1781561056405
+      modifiedTime: 1783370552360
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qrasJNDC7SGj7xzG.uwDyoGhbCR8NoRmc'

--- a/packs/_source/monsters/dragon/young-red-dragon.yml
+++ b/packs/_source/monsters/dragon/young-red-dragon.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,15 +481,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: KuuOPjJ1YeTtjGbN
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Red Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -555,7 +555,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -564,8 +564,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        66qCN3IZ3JJ7OJxh:
           type: attack
           activation:
             type: action
@@ -580,10 +579,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: The dragon snaps its mighty jaws shut!
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -600,7 +600,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -613,36 +614,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 66qCN3IZ3JJ7OJxh
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -652,22 +664,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450147719
+      systemVersion: 6.0.0
+      createdTime: 1781561012795
+      modifiedTime: 1781561024943
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qrasJNDC7SGj7xzG.KuuOPjJ1YeTtjGbN'
   - _id: 3UHmbpT3v3FTlplI
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Red Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -730,7 +744,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -739,8 +753,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        3GxyaefD36zKjUua:
           type: attack
           activation:
             type: action
@@ -755,10 +768,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -775,7 +789,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -788,24 +803,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: 3GxyaefD36zKjUua
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -815,143 +843,14 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450147719
+      systemVersion: 6.0.0
+      createdTime: 1781560964636
+      modifiedTime: 1781561007991
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qrasJNDC7SGj7xzG.3UHmbpT3v3FTlplI'
-  - _id: nWjLJm6ErLvCUvun
-    name: Fire Breath
-    type: feat
-    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon exhales fire in a 30-foot cone. Each creature in that
-          area must make a [[/save]] saving throw, taking [[/damage average]]
-          damage on a failed save, or half as much damage on a successful
-          one.</p>
-        chat: >-
-          <p>The dragon exhales fire in a 30-foot cone. Each creature in that
-          area must make a <strong>Dexterity</strong> saving throw.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: '1'
-        recovery:
-          - period: recharge
-            formula: '5'
-            type: recoverAll
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: cone
-              size: '30'
-              width: ''
-              height: ''
-              units: ft
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - number: 16
-                denomination: 6
-                bonus: ''
-                types:
-                  - fire
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          save:
-            ability: dex
-            dc:
-              calculation: ''
-              formula: '17'
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: fire-breath
-    effects: []
-    folder: null
-    sort: 400000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.bGSW8IuWURWiWtxr
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450167422
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!qrasJNDC7SGj7xzG.nWjLJm6ErLvCUvun'
   - _id: uwDyoGhbCR8NoRmc
     name: Multiattack
     type: feat
@@ -959,9 +858,9 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon makes three attacks: one with its [[/item
-          .KuuOPjJ1YeTtjGbN]]{bite} and two with its [[/item
-          .3UHmbpT3v3FTlplI]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .KuuOPjJ1YeTtjGbN]]{Bite} and two with its [[/item
+          .3UHmbpT3v3FTlplI]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -975,13 +874,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        7meHWXwVbWIP7lwk:
           type: utility
           activation:
             type: action
@@ -996,15 +894,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1015,7 +914,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1032,7 +932,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 7meHWXwVbWIP7lwk
       enchant: {}
       prerequisites:
         level: null
@@ -1046,14 +954,161 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450148563
+      systemVersion: 6.0.0
+      createdTime: 1781561051218
+      modifiedTime: 1781561056405
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qrasJNDC7SGj7xzG.uwDyoGhbCR8NoRmc'
+  - _id: zapwzE9ylLBsufXf
+    name: Fire Breath
+    type: feat
+    img: icons/magic/fire/flame-burning-earth-orange.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=dN04D22jj4eo1ERu]]. Each
+          creature in that area must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=dN04D22jj4eo1ERu]]. Each
+          creature in that area must make a Dexterity saving throw.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: '1'
+        recovery:
+          - period: recharge
+            formula: '5'
+            type: recoverAll
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        dN04D22jj4eo1ERu:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: cone
+              size: '30'
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 16
+                denomination: 6
+                bonus: ''
+                types:
+                  - fire
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: con
+              formula: '13'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: dN04D22jj4eo1ERu
+          name: Exhale Fire
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: fire-breath
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 500000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.bGSW8IuWURWiWtxr
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781560864549
+      modifiedTime: 1781560881697
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!qrasJNDC7SGj7xzG.zapwzE9ylLBsufXf'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1062,7 +1117,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171260887

--- a/packs/_source/monsters/dragon/young-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/young-silver-dragon.yml
@@ -849,8 +849,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
-          with its [[/item .qsfDO6B4wLP1UeKS]]{Bite} and two with its [[/item
-          .GvAgPChKDJLm64Za]]{Claws}.</p>
+          with its [[/item .qsfDO6B4wLP1UeKS]]{bite} and two with its [[/item
+          .GvAgPChKDJLm64Za]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -948,7 +948,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781560830776
-      modifiedTime: 1781560835818
+      modifiedTime: 1783370543808
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!eykRfV85DQJoCkmc.dAoWnethMNHwPNDJ'

--- a/packs/_source/monsters/dragon/young-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/young-silver-dragon.yml
@@ -970,9 +970,10 @@ items:
           lowercase]]{monster} exhales paralyzing gas in a [[lookup
           @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
           creature in that area must succeed on a [[/save
-          activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for 1 minute.
-          A creature can repeat the saving throw at the end of each of its
-          turns, ending the effect on itself on a success.</p>
+          activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for [[lookup
+          @labels.duration activity=9gMvqjbgKK42uyzr]]. A creature can repeat
+          the saving throw at the end of each of its turns, ending the effect on
+          itself on a success.</p>
         chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
@@ -1110,9 +1111,10 @@ items:
               in a [[lookup @labels.description.template
               activity=9gMvqjbgKK42uyzr]]. Each creature in that area must
               succeed on a [[/save activity=9gMvqjbgKK42uyzr]] saving throw or
-              be paralyzed for 1 minute. A creature can repeat the saving throw
-              at the end of each of its turns, ending the effect on itself on a
-              success.</p>
+              be paralyzed for [[lookup @labels.duration
+              activity=9gMvqjbgKK42uyzr]]. A creature can repeat the saving
+              throw at the end of each of its turns, ending the effect on itself
+              on a success.</p>
           duration:
             concentration: false
             value: '1'
@@ -1237,7 +1239,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781560712557
-      modifiedTime: 1781560751938
+      modifiedTime: 1781631606956
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!eykRfV85DQJoCkmc.zwKc0TIAiEv0BNvl'

--- a/packs/_source/monsters/dragon/young-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/young-silver-dragon.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,15 +481,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: qsfDO6B4wLP1UeKS
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Silver Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -555,7 +555,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -564,8 +564,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        Z7O5AnW2r5H85zqG:
           type: attack
           activation:
             type: action
@@ -580,10 +579,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -600,7 +600,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -613,24 +614,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: Z7O5AnW2r5H85zqG
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -640,22 +654,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452626313
+      systemVersion: 6.0.0
+      createdTime: 1781560762949
+      modifiedTime: 1781560776596
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!eykRfV85DQJoCkmc.qsfDO6B4wLP1UeKS'
   - _id: GvAgPChKDJLm64Za
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young Silver Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -718,7 +734,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -727,8 +743,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        csbsHiKVzWcpNrsf:
           type: attack
           activation:
             type: action
@@ -743,10 +758,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -763,7 +779,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -776,24 +793,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: csbsHiKVzWcpNrsf
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -803,11 +833,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452626313
+      systemVersion: 6.0.0
+      createdTime: 1781560782251
+      modifiedTime: 1781560809942
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!eykRfV85DQJoCkmc.GvAgPChKDJLm64Za'
@@ -818,9 +848,9 @@ items:
     system:
       description:
         value: >-
-          <p>The dragon makes three attacks: one with its [[/item
-          .qsfDO6B4wLP1UeKS]]{bite} and two with its [[/item
-          .GvAgPChKDJLm64Za]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .qsfDO6B4wLP1UeKS]]{Bite} and two with its [[/item
+          .GvAgPChKDJLm64Za]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -834,13 +864,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        MBsNRvtgAFlXMt6v:
           type: utility
           activation:
             type: action
@@ -855,15 +884,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -874,7 +904,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -891,7 +922,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: MBsNRvtgAFlXMt6v
       enchant: {}
       prerequisites:
         level: null
@@ -905,33 +944,36 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745452626996
+      systemVersion: 6.0.0
+      createdTime: 1781560830776
+      modifiedTime: 1781560835818
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!eykRfV85DQJoCkmc.dAoWnethMNHwPNDJ'
-  - _id: 7pHG1bhYOsbPVvSI
+  - _id: zwKc0TIAiEv0BNvl
     name: Breath Weapons
     type: feat
     img: icons/creatures/abilities/dragon-ice-breath-blue.webp
     system:
       description:
         value: >-
-          <p>The dragon uses one of the following breath
-          weapons.</p><p><strong>Cold Breath.</strong> The dragon exhales an icy
-          blast in a 90-foot cone. Each creature in that area must make a
-          [[/save activity=U5F5qe2Hu0r0yHmk]] saving throw, taking [[/damage
-          average activity=U5F5qe2Hu0r0yHmk]] damage on a failed save, or half
-          as much damage on a successful one.</p><p><strong>Paralyzing
-          Breath.</strong> The dragon exhales paralyzing gas in a 90- foot cone.
-          Each creature in that area must succeed on a [[/save
+          <p>The [[lookup @name lowercase]]{monster} uses one of the following
+          breath weapons.</p><p><strong>Cold Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales an icy blast in a [[lookup
+          @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
+          creature in that area must make a [[/save activity=U5F5qe2Hu0r0yHmk]]
+          saving throw, taking [[/damage average activity=U5F5qe2Hu0r0yHmk]]
+          damage on a failed save, or half as much damage on a successful
+          one.</p><p><strong>Paralyzing Breath.</strong> The [[lookup @name
+          lowercase]]{monster} exhales paralyzing gas in a [[lookup
+          @labels.description.template activity=9gMvqjbgKK42uyzr]]. Each
+          creature in that area must succeed on a [[/save
           activity=9gMvqjbgKK42uyzr]] saving throw or be paralyzed for 1 minute.
           A creature can repeat the saving throw at the end of each of its
           turns, ending the effect on itself on a success.</p>
-        chat: <p>The dragon breathes in!</p>
+        chat: <p>The [[lookup @name]]{monster} breathes in!</p>
       source:
         custom: ''
         book: ''
@@ -947,7 +989,7 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
@@ -964,12 +1006,20 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales an icy blast in
+              a [[lookup @labels.description.labels activity=9gMvqjbgKK42uyzr]].
+              Each creature in that area must make a [[/save
+              activity=U5F5qe2Hu0r0yHmk]] saving throw, taking [[/damage average
+              activity=U5F5qe2Hu0r0yHmk]] damage on a failed save, or half as
+              much damage on a successful one.</p>
           duration:
             concentration: false
             value: ''
@@ -986,13 +1036,14 @@ items:
               count: ''
               contiguous: false
               type: cone
-              size: '90'
+              size: '30'
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1008,21 +1059,33 @@ items:
                   enabled: false
                   formula: ''
                 number: 12
-                denomination: '8'
+                denomination: 8
                 bonus: ''
                 types:
                   - cold
+                scaling:
+                  number: 1
           save:
             ability:
               - con
             dc:
-              calculation: ''
-              formula: '17'
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
           sort: 0
           _id: U5F5qe2Hu0r0yHmk
           name: Cold Breath
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
         9gMvqjbgKK42uyzr:
           type: save
           activation:
@@ -1035,19 +1098,33 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The [[lookup @name lowercase]]{monster} exhales paralyzing gas
+              in a [[lookup @labels.description.template
+              activity=9gMvqjbgKK42uyzr]]. Each creature in that area must
+              succeed on a [[/save activity=9gMvqjbgKK42uyzr]] saving throw or
+              be paralyzed for 1 minute. A creature can repeat the saving throw
+              at the end of each of its turns, ending the effect on itself on a
+              success.</p>
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: yYbmtst3L1jGwwbF
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             units: self
             special: ''
@@ -1057,13 +1134,14 @@ items:
               count: ''
               contiguous: false
               type: cone
-              size: '90'
+              size: '30'
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1073,48 +1151,96 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability:
               - con
             dc:
-              calculation: ''
-              formula: '17'
+              calculation: con
+              formula: '13'
+            bonus: ''
+            visible: true
           sort: 0
           _id: 9gMvqjbgKK42uyzr
           name: Paralyzing Breath
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
       enchant: {}
       prerequisites:
         level: null
         repeatable: false
+        items: []
       identifier: breath-weapons
-      advancement: []
+      advancement: {}
       cover: null
       crewed: false
-    effects: []
+    effects:
+      - name: Paralyzing Breath
+        img: icons/magic/control/debuff-chains-shackles-movement-purple.webp
+        origin: Compendium.dnd5e.monsters.Actor.J1QVPd8POvcPaqx4.Item.ENcwNUKxDAqH6V9l
+        transfer: false
+        _id: yYbmtst3L1jGwwbF
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[paralyzed apply=false] for 1 minute. You can
+          repeat the saving throw at the end of each of your turns, ending the
+          effect on yourself.</p>
+        tint: '#ffffff'
+        statuses:
+          - paralyzed
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781560712557
+          modifiedTime: 1781560712557
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!eykRfV85DQJoCkmc.zwKc0TIAiEv0BNvl.yYbmtst3L1jGwwbF
     folder: null
     sort: 600000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.KcUjvqIXZI3APp5a
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: 1745452710803
-      modifiedTime: 1745452749664
+      systemVersion: 6.0.0
+      createdTime: 1781560712557
+      modifiedTime: 1781560751938
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!eykRfV85DQJoCkmc.7pHG1bhYOsbPVvSI'
+    _key: '!actors.items!eykRfV85DQJoCkmc.zwKc0TIAiEv0BNvl'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1123,7 +1249,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171245718

--- a/packs/_source/monsters/dragon/young-silver-dragon.yml
+++ b/packs/_source/monsters/dragon/young-silver-dragon.yml
@@ -1185,7 +1185,7 @@ items:
       crewed: false
     effects:
       - name: Paralyzing Breath
-        img: icons/magic/control/debuff-chains-shackles-movement-purple.webp
+        img: icons/magic/unholy/energy-smoke-pink.webp
         origin: Compendium.dnd5e.monsters.Actor.J1QVPd8POvcPaqx4.Item.ENcwNUKxDAqH6V9l
         transfer: false
         _id: yYbmtst3L1jGwwbF
@@ -1218,7 +1218,7 @@ items:
           systemId: dnd5e
           systemVersion: 6.0.0
           createdTime: 1781560712557
-          modifiedTime: 1781560712557
+          modifiedTime: 1781630903202
           lastModifiedBy: dnd5ebuilder0000
           compendiumSource: null
           duplicateSource: null

--- a/packs/_source/monsters/dragon/young-white-dragon.yml
+++ b/packs/_source/monsters/dragon/young-white-dragon.yml
@@ -72,6 +72,11 @@ system:
       walk: 40
       units: ft
       hover: false
+      bonus: ''
+      ignoredDifficultTerrain:
+        - snow
+        - ice
+      special: ''
     attunement:
       max: 3
     senses:
@@ -447,9 +452,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +466,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,15 +486,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: qFfEF7lLt2kH3RbA
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young White Dragon attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -564,8 +569,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        s4JjRKyIFDyrVmAf:
           type: attack
           activation:
             type: action
@@ -580,10 +584,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: The dragon opens its wide mouth to bite its foe.
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -600,7 +605,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -613,36 +619,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 8
                 bonus: ''
                 types:
                   - cold
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: s4JjRKyIFDyrVmAf
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -652,22 +669,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450474492
+      systemVersion: 6.0.0
+      createdTime: 1781561692448
+      modifiedTime: 1781561734771
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!u1UQfHutP5eEKkjM.qFfEF7lLt2kH3RbA'
   - _id: d9xXEIYNNQjIMGF8
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Young White Dragon attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -730,7 +749,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -739,8 +758,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        P91sIZ6siXFHfptW:
           type: attack
           activation:
             type: action
@@ -755,10 +773,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: The dragon strikes with one of its claws.
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -775,7 +794,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -788,24 +808,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          name: ''
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: P91sIZ6siXFHfptW
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -815,28 +848,192 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450474492
+      systemVersion: 6.0.0
+      createdTime: 1781561664192
+      modifiedTime: 1781561801202
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!u1UQfHutP5eEKkjM.d9xXEIYNNQjIMGF8'
-  - _id: 78LbjdfWaZcAqVE7
-    name: Cold Breath
+  - _id: g2nJbBJ06mRtxEy0
+    name: Ice Walk
     type: feat
-    img: icons/creatures/abilities/dragon-ice-breath-blue.webp
+    img: icons/magic/water/water-iceberg-bubbles.webp
     system:
       description:
         value: >-
-          <p>The dragon exhales an icy blast in a 30-foot cone. Each creature in
-          that area must make a [[/save]] saving throw, taking [[/damage
-          average]] damage on a failed save, or half as much damage on a
-          successful one.</p>
+          <p>The [[lookup @name lowercase]]{monster} can move across and climb
+          icy surfaces without needing to make an ability check. Additionally,
+          &amp;reference[difficult terrain] composed of ice or snow doesn't cost
+          it extra movement.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+      identifier: ice-walk
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.YKC7pwYkJSKn1vuw
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781561865846
+      modifiedTime: 1781561897490
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!u1UQfHutP5eEKkjM.g2nJbBJ06mRtxEy0'
+  - _id: lRFwKaRqhFY4xNhJ
+    name: Multiattack
+    type: feat
+    img: icons/skills/melee/blade-tips-triple-steel.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .qFfEF7lLt2kH3RbA]]{Bite} and two with its [[/item
+          .d9xXEIYNNQjIMGF8]]{Claws}.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        KkUtYb3bVzTbjjUV:
+          type: utility
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: KkUtYb3bVzTbjjUV
+      enchant: {}
+      prerequisites:
+        level: null
+      identifier: multiattack
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781561942999
+      modifiedTime: 1781561952981
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!u1UQfHutP5eEKkjM.lRFwKaRqhFY4xNhJ'
+  - _id: K38ku0AFxbQfZwXL
+    name: Cold Breath
+    type: feat
+    img: icons/magic/water/projectile-ice-orb-white.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} exhales an icy blast of
+          hail in a [[lookup @labels.description.template
+          activity=UF4fJlhyYiLM7XeM]]. Each creature in that area must make a
+          [[/save]] saving throw, taking [[/damage average]] damage on a failed
+          save, or half as much damage on a successful one.</p>
         chat: >-
-          <p>The dragon exhales an icy blast in a 30-foot cone. Each creature in
-          that area must make a <strong>Constitution</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} exhales an icy blast of hail in a
+          [[lookup @labels.description.template activity=UF4fJlhyYiLM7XeM]].
+          Each creature in that area must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -857,8 +1054,7 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        UF4fJlhyYiLM7XeM:
           type: save
           activation:
             type: action
@@ -876,7 +1072,8 @@ items:
               max: ''
             spellSlot: true
           description:
-            chatFlavor: The dragon exhales its deadly breath attack.
+            chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -897,9 +1094,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -922,184 +1120,51 @@ items:
                 scaling:
                   number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
-              calculation: ''
-              formula: '15'
-          sort: 0
-          name: ''
+              calculation: con
+              formula: '12'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: UF4fJlhyYiLM7XeM
+          name: Exhale Ice
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: cold-breath
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
-    sort: 400000
+    sort: 500000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.iHOaiOqwUWIfCljJ
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450494994
+      systemVersion: 6.0.0
+      createdTime: 1781561603524
+      modifiedTime: 1781561647223
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!u1UQfHutP5eEKkjM.78LbjdfWaZcAqVE7'
-  - _id: g2nJbBJ06mRtxEy0
-    name: Ice Walk
-    type: feat
-    img: icons/magic/water/water-iceberg-bubbles.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon can move across and climb icy surfaces without needing
-          to make an ability check. Additionally, difficult terrain composed of
-          ice or snow doesn't cost it extra movement.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: ice-walk
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.YKC7pwYkJSKn1vuw
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!u1UQfHutP5eEKkjM.g2nJbBJ06mRtxEy0'
-  - _id: lRFwKaRqhFY4xNhJ
-    name: Multiattack
-    type: feat
-    img: icons/skills/melee/blade-tips-triple-steel.webp
-    system:
-      description:
-        value: >-
-          <p>The dragon makes three attacks: one with its [[/item
-          .qFfEF7lLt2kH3RbA]]{bite} and two with its [[/item
-          .d9xXEIYNNQjIMGF8]]{claws}.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: multiattack
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745450475181
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!u1UQfHutP5eEKkjM.lRFwKaRqhFY4xNhJ'
+    _key: '!actors.items!u1UQfHutP5eEKkjM.K38ku0AFxbQfZwXL'
 effects: []
 folder: PNekSR74iAZ5dJwZ
 sort: 0
@@ -1108,11 +1173,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.4.0
+  systemVersion: 6.0.0
   createdTime: 1726171264487
-  modifiedTime: 1745450499055
+  modifiedTime: 1781561886414
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!u1UQfHutP5eEKkjM'

--- a/packs/_source/monsters/dragon/young-white-dragon.yml
+++ b/packs/_source/monsters/dragon/young-white-dragon.yml
@@ -915,8 +915,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
-          with its [[/item .qFfEF7lLt2kH3RbA]]{Bite} and two with its [[/item
-          .d9xXEIYNNQjIMGF8]]{Claws}.</p>
+          with its [[/item .qFfEF7lLt2kH3RbA]]{bite} and two with its [[/item
+          .d9xXEIYNNQjIMGF8]]{claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -1014,7 +1014,7 @@ items:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1781561942999
-      modifiedTime: 1781561952981
+      modifiedTime: 1783370531011
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!u1UQfHutP5eEKkjM.lRFwKaRqhFY4xNhJ'


### PR DESCRIPTION
This one was a mess, a lot of the dragons had incorrect breath weapon ranges (mainly metallic dragons). Had to bring out the 5.1 SRD to correct them (metallic wyrmlings had breath ranges of 90 feet as an example). Amazed that none of this was reported, but all 43 dragon creatures have been updated,

Related #6712