### PR TITLE
[#7154] Add `originatingMessage` to effectFlags

### DIFF
--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -217,7 +217,6 @@ export default class EffectApplicationElement extends ChatTrayElement {
       flags: {
         dnd5e: {
           dependentOn: concentration?.uuid,
-          originatingMessage: this.chatMessage.id,
           scaling: this.chatMessage.system.scaling,
           spellLevel: this.chatMessage.system.level
         }
@@ -226,6 +225,7 @@ export default class EffectApplicationElement extends ChatTrayElement {
         origin: {
           [activity ? "activity" : "item"]: activity ? activity.uuid : item?.uuid,
           effect: concentration?.uuid,
+          message: this.chatMessage.uuid,
           profile: activity
             ? activity.effects?.find(e => (e.uuid === effect.uuid) || (e._id === effect.id))?._id : undefined
         }

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -217,6 +217,7 @@ export default class EffectApplicationElement extends ChatTrayElement {
       flags: {
         dnd5e: {
           dependentOn: concentration?.uuid,
+          originatingMessage: this.chatMessage.id,
           scaling: this.chatMessage.system.scaling,
           spellLevel: this.chatMessage.system.level
         }

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -22,6 +22,7 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
         behavior: new DocumentUUIDField({ required: false, type: "RegionBehavior" }),
         effect: new DocumentUUIDField({ relative: true, required: false, type: "ActiveEffect" }),
         item: new DocumentUUIDField({ relative: true, required: false, type: "Item" }),
+        message: new DocumentUUIDField({ required: false, type: "ChatMessage" }),
         profile: new DocumentIdField({ readonly: false, required: false })
       })
     };

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -169,6 +169,7 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
       system: {
         origin: {
           activity: this.uuid,
+          message: chatMessage?.uuid,
           profile: profileId
         }
       },


### PR DESCRIPTION
Closes #7154 
Not sure if we should be passing the full message document or just the ID.

There might be a need to clean up the usage of `originatingMessage` across the codebase to ensure it consistently refers to the same thing.