### PR TITLE
5.1 SRD Update: Monsters - Fiends

### DIFF
--- a/packs/_source/monsters/fiend/balor.yml
+++ b/packs/_source/monsters/fiend/balor.yml
@@ -457,9 +457,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -474,7 +471,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -494,19 +491,21 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
   - _id: nzkZgDrDq0RwWUao
     name: Death Throes
     type: feat
-    img: icons/magic/fire/explosion-fireball-large-red-orange.webp
+    img: icons/magic/fire/flame-burning-skull-orange.webp
     system:
       description:
         value: >-
-          <p>When the balor dies, it explodes, and each creature within 30 feet
-          of it must make a [[/save]] saving throw, taking [[/damage average]]
-          damage on a failed save, or half as much damage on a successful
-          one.</p><p>The explosion ignites flammable objects in that area that
-          aren't being worn or carried, and it destroys the balor's weapons.</p>
+          <p>When the [[lookup @name lowercase]]{monster} dies, it explodes, and
+          each creature within 30 feet of it must make a [[/save]] saving throw,
+          taking [[/damage average]] damage on a failed save, or half as much
+          damage on a successful one.</p><p>The explosion ignites flammable
+          objects in that area that aren't being worn or carried, and it
+          destroys the [[lookup @name lowercase]]{monster}'s weapons.</p>
         chat: >-
           <p>When the balor dies, it explodes, and each creature within 30 feet
           of it must make a <strong>Dexterity</strong> saving throw. The
@@ -529,13 +528,12 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bft8Mf1FKyyIxwb8:
           type: save
           activation:
-            type: ''
+            type: special
             value: null
-            condition: Upon death
+            condition: When the [[lookup @name lowercase]]{monster} dies.
             override: false
           consumption:
             targets: []
@@ -545,6 +543,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -553,9 +552,10 @@ items:
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
+            value: '30'
           target:
             template:
               count: ''
@@ -565,9 +565,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -587,15 +588,29 @@ items:
                 bonus: ''
                 types:
                   - fire
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '20'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Explode
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bft8Mf1FKyyIxwb8
       enchant: {}
       prerequisites:
         level: null
@@ -605,34 +620,33 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EmlE1a0rhucK2UT1
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956196138
+      systemVersion: 6.0.0
+      createdTime: 1781696561266
+      modifiedTime: 1781696677965
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!uZ8NrRenwYZ4qNf6.nzkZgDrDq0RwWUao'
   - _id: FWSzSLqeIDq7meXC
     name: Fire Aura
     type: feat
-    img: icons/magic/air/fog-gas-smoke-swirling-orange.webp
+    img: icons/magic/fire/barrier-wall-explosion-orange.webp
     system:
       description:
         value: >-
-          <p>At the start of each of the balor's turns, each creature within 5
-          feet of it takes [[/damage average]] damage, and flammable objects in
-          the aura that aren't being worn or carried ignite.</p><p>A creature
-          that touches the balor or hits it with a melee attack while within 5
-          feet of it takes [[/damage average]] damage.</p>
+          <p>At the start of each of the [[lookup @name lowercase]]{monster}'s
+          turns, each creature within [[lookup @labels.description.range
+          activity=t0DzL3PUekMarxZX]] of it takes [[/damage average]] damage,
+          and flammable objects in the aura that aren't being worn or carried
+          ignite.</p><p>A creature that touches the [[lookup @name
+          lowercase]]{monster} or hits it with a melee attack while within
+          [[lookup @labels.description.range activity=QoYDB21VZPDbFEuo]] of it
+          takes [[/damage average activity=QoYDB21VZPDbFEuo]] damage.</p>
         chat: >-
           <p>At the start of each of the balor's turns, each creature within 5
           feet of it takes <em>fire damage</em>, and flammable objects in the
@@ -656,11 +670,10 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        t0DzL3PUekMarxZX:
           type: damage
           activation:
-            type: ''
+            type: turnStart
             value: null
             condition: ''
             override: false
@@ -672,18 +685,25 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>At the start of each of the [[lookup @name
+              lowercase]]{monster}'s turns, each creature within [[lookup
+              @labels.description.range activity=t0DzL3PUekMarxZX]] of it takes
+              [[/damage average activity=t0DzL3PUekMarxZX]] damage, and
+              flammable objects in the aura that aren't being worn or carried
+              ignite.</p>
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: self
+            units: ft
             special: ''
             override: false
-            value: ''
+            value: '5'
           target:
             template:
               count: ''
@@ -693,6 +713,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: true
             affects:
               count: ''
               type: creature
@@ -717,10 +738,91 @@ items:
                 bonus: ''
                 types:
                   - fire
-          sort: 0
-          name: ''
+                scaling:
+                  number: 1
+          sort: 100000
+          name: Start of Turn Damage
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: t0DzL3PUekMarxZX
+        QoYDB21VZPDbFEuo:
+          type: damage
+          name: Contact Damage
+          _id: QoYDB21VZPDbFEuo
+          img: ''
+          sort: 200000
+          activation:
+            type: special
+            override: false
+            condition: >-
+              When a creature touches the [[lookup @name lowercase]]{monster} or
+              hits it with a melee attack while within 5 feet of it.
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: ft
+            override: false
+            special: ''
+            value: '5'
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: creature
+              count: '1'
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          damage:
+            critical:
+              allow: false
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
+                denomination: 6
+                bonus: ''
+                types:
+                  - fire
+                scaling:
+                  number: 1
       enchant: {}
       prerequisites:
         level: null
@@ -730,116 +832,18 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.LJTY3nl1cp9go4eT
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956232743
+      systemVersion: 6.0.0
+      createdTime: 1781696370591
+      modifiedTime: 1781696548754
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!uZ8NrRenwYZ4qNf6.FWSzSLqeIDq7meXC'
-  - _id: 0Y2ThqWytMPb9RlR
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The balor has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!uZ8NrRenwYZ4qNf6.0Y2ThqWytMPb9RlR'
-  - _id: 5TGqX6bI8BdLEvTk
-    name: Magic Weapons
-    type: feat
-    img: icons/weapons/swords/sword-runed-glowing.webp
-    system:
-      description:
-        value: <p>The balor's weapon attacks are magical.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-weapons
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nahRRxck9R5GVVFS
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!uZ8NrRenwYZ4qNf6.5TGqX6bI8BdLEvTk'
   - _id: qzphlErr2D2mRpxT
     name: Multiattack
     type: feat
@@ -847,9 +851,9 @@ items:
     system:
       description:
         value: >-
-          <p>The balor makes two attacks: one with its [[/item
-          .6ZAh5TkiXwQMUfDB]]{longsword} and one with its [[/item
-          .1oGgJQB1ItqyKoZ5]]{whip}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two attacks: one with
+          its [[/item .6ZAh5TkiXwQMUfDB]]{Longsword} and one with its [[/item
+          .1oGgJQB1ItqyKoZ5]]{Whip}.</p>
         chat: ''
       source:
         custom: ''
@@ -863,13 +867,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4JUia83JB2jZzcbw:
           type: utility
           activation:
             type: action
@@ -884,15 +887,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -903,7 +907,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -920,7 +925,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 4JUia83JB2jZzcbw
       enchant: {}
       prerequisites:
         level: null
@@ -934,24 +947,25 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273657585
+      systemVersion: 6.0.0
+      createdTime: 1781696706579
+      modifiedTime: 1781696727479
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!uZ8NrRenwYZ4qNf6.qzphlErr2D2mRpxT'
   - _id: mw93amZDA4ctKqvQ
     name: Teleport
     type: feat
-    img: icons/magic/symbols/runes-star-pentagon-magenta.webp
+    img: icons/magic/symbols/ring-circle-smoke-blue.webp
     system:
       description:
         value: >-
-          <p>The balor magically teleports, along with any equipment it is
-          wearing or carrying, up to 120 feet to an unoccupied space it can
-          see.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically teleports, along
+          with any equipment it is wearing or carrying, up to [[lookup
+          @labels.description.range activity=dnd5eactivity000]] to an unoccupied
+          space it can see.</p>
         chat: ''
       source:
         custom: ''
@@ -965,10 +979,11 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
@@ -1024,6 +1039,14 @@ items:
             prompt: false
             visible: false
           sort: 0
+          name: ''
+          img: ''
+          visibility:
+            requireMagic: true
+            level:
+              min: null
+              max: null
+            identifier: ''
       enchant: {}
       prerequisites:
         level: null
@@ -1037,25 +1060,27 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.PPzVD90vab60FqCt
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1747956115054
+      systemVersion: 6.0.0
+      createdTime: 1781696947422
+      modifiedTime: 1781696993751
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!uZ8NrRenwYZ4qNf6.mw93amZDA4ctKqvQ'
   - _id: 6ZAh5TkiXwQMUfDB
     name: Longsword
     type: weapon
-    img: icons/weapons/swords/greatsword-crossguard-steel.webp
+    img: icons/weapons/swords/greatsword-crossguard-flanged-red.webp
     system:
       description:
         value: >-
-          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the balor
-          scores a critical hit, it rolls damage dice three times, instead of
-          twice.</p>
-        chat: <p>The Balor attacks with its Longsword.</p>
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the [[lookup
+          @name lowercase]]{monster} scores a critical hit, it rolls damage dice
+          three times, instead of twice.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1179,35 +1204,40 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
-              bonus: ''
+              bonus: 3d8[slashing] + 3d8[lightning]
             includeBase: true
             parts:
-              - number: 3
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
                 denomination: 8
                 bonus: ''
                 types:
                   - lightning
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           sort: 0
+          name: ''
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: longsword
       mastery: ''
     effects: []
@@ -1219,11 +1249,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.10ZP2Bu3vnCuYMIB
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378666907
+      systemVersion: 6.0.0
+      createdTime: 1781696733476
+      modifiedTime: 1781696840828
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!uZ8NrRenwYZ4qNf6.6ZAh5TkiXwQMUfDB'
@@ -1236,10 +1266,10 @@ items:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]]. The target must succeed
           on a [[/save]] saving throw or be pulled up to 25 feet toward the
-          balor.</p>
+          [[lookup @name lowercase]]{monster}.</p>
         chat: >-
-          <p>The Balor attacks with its Whip. The target must make a
-          <strong>Strength</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. The target must make a Strength saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1305,7 +1335,7 @@ items:
         - fin
         - mgc
         - rch
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1314,8 +1344,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        YGM2eLITR0pDcdb6:
           type: attack
           activation:
             type: action
@@ -1330,10 +1359,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1350,7 +1380,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1363,39 +1394,48 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 3
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: YGM2eLITR0pDcdb6
+          name: ''
+        LEKd2jRukXVvtSPG:
           type: save
           activation:
-            type: action
+            type: special
             value: 1
-            condition: ''
+            condition: When a creautre is hit by this attack.
             override: false
           consumption:
             targets: []
@@ -1405,10 +1445,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1425,10 +1466,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1438,17 +1480,32 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: str
+            ability:
+              - str
             dc:
               calculation: ''
               formula: '20'
-          sort: 0
+            bonus: ''
+            visible: true
+          sort: 200000
+          name: Pull Save
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: LEKd2jRukXVvtSPG
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: whip
       mastery: ''
     effects: []
@@ -1456,22 +1513,124 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.items.QKTyxoO0YDnAsbYe
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378671284
+      systemVersion: 6.0.0
+      createdTime: 1781696862198
+      modifiedTime: 1781696933532
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!uZ8NrRenwYZ4qNf6.1oGgJQB1ItqyKoZ5'
+  - _id: z6qrm9EZiEH500K2
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 100000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781696687224
+      modifiedTime: 1781696688274
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!uZ8NrRenwYZ4qNf6.z6qrm9EZiEH500K2'
+  - _id: VLlNW1PkgzpXgBKr
+    name: Magic Weapons
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster}'s weapon attacks are
+          magical.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-weapons
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/weapons/swords/sword-runed-glowing.webp
+    effects: []
+    folder: null
+    sort: 200000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781696695915
+      modifiedTime: 1781696696638
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.nahRRxck9R5GVVFS
+    _key: '!actors.items!uZ8NrRenwYZ4qNf6.VLlNW1PkgzpXgBKr'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1480,7 +1639,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171264697

--- a/packs/_source/monsters/fiend/balor.yml
+++ b/packs/_source/monsters/fiend/balor.yml
@@ -852,8 +852,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes two attacks: one with
-          its [[/item .6ZAh5TkiXwQMUfDB]]{Longsword} and one with its [[/item
-          .1oGgJQB1ItqyKoZ5]]{Whip}.</p>
+          its [[/item .6ZAh5TkiXwQMUfDB]]{longsword} and one with its [[/item
+          .1oGgJQB1ItqyKoZ5]]{whip}.</p>
         chat: ''
       source:
         custom: ''
@@ -1435,7 +1435,7 @@ items:
           activation:
             type: special
             value: 1
-            condition: When a creautre is hit by this attack.
+            condition: When a creature is hit by this attack.
             override: false
           consumption:
             targets: []

--- a/packs/_source/monsters/fiend/barbed-devil.yml
+++ b/packs/_source/monsters/fiend/barbed-devil.yml
@@ -630,8 +630,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three melee attacks:
-          one with its [[/item .mlWql992zSZ6hvl6]]{Tail} and two with its
-          [[/item .pya9jchjLkwMedEr]]{Claws}. Alternatively, it can use [[/item
+          one with its [[/item .mlWql992zSZ6hvl6]]{tail} and two with its
+          [[/item .pya9jchjLkwMedEr]]{claws}. Alternatively, it can use [[/item
           .syCZDlwGoyT1GvJv]]{Hurl Flame} twice.</p>
         chat: ''
       source:

--- a/packs/_source/monsters/fiend/barbed-devil.yml
+++ b/packs/_source/monsters/fiend/barbed-devil.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,16 +492,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: 8QaMc1baRrSlLFXN
     name: Barbed Hide
     type: feat
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/commodities/bones/teeth-pointed-gray.webp
     system:
       description:
         value: >-
-          <p>At the start of each of its turns, the barbed devil deals [[/damage
-          average]] damage to any creature grappling it.</p>
+          <p>At the start of each of its turns, the [[lookup @name
+          lowercase]]{monster} deals [[/damage average]] damage to any creature
+          &amp;reference[grappling] it.</p>
         chat: ''
       source:
         custom: ''
@@ -518,19 +517,20 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties:
         - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        OaFWjyHQ90ZsI8EU:
           type: damage
           activation:
-            type: ''
+            type: turnStart
             value: null
-            condition: ''
+            condition: >-
+              When the [[lookup @name lowercase]]{monster} starts its turn while
+              a creature is &reference[grappling] it.
             override: false
           consumption:
             targets: []
@@ -540,15 +540,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: touch
             special: ''
             override: false
           target:
@@ -559,10 +560,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -582,130 +584,44 @@ items:
                 number: 1
                 denomination: 10
                 bonus: ''
-                types: []
-          sort: 0
-          name: ''
+                types:
+                  - piercing
+                scaling:
+                  number: 1
+          sort: 100000
+          name: Grapple Damage
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: OaFWjyHQ90ZsI8EU
       enchant: {}
       prerequisites:
         level: null
       identifier: barbed-hide
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.QMGBV7OSnXqWLdhr
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956256210
+      systemVersion: 6.0.0
+      createdTime: 1781637070230
+      modifiedTime: 1781637814938
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!sLdpiuaZF8lujJQy.8QaMc1baRrSlLFXN'
-  - _id: wPHhtm2eyM9LKpT4
-    name: Devil's Sight
-    type: feat
-    img: icons/magic/perception/eye-slit-pink.webp
-    system:
-      description:
-        value: <p>Magical darkness doesn't impede the devil's Darkvision.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: devils-sight
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!sLdpiuaZF8lujJQy.wPHhtm2eyM9LKpT4'
-  - _id: f3ItDDfd5L4WMGlf
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The devil has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!sLdpiuaZF8lujJQy.f3ItDDfd5L4WMGlf'
   - _id: JbDDt9MNYFyEbHsm
     name: Multiattack
     type: feat
@@ -713,9 +629,9 @@ items:
     system:
       description:
         value: >-
-          <p>The devil makes three melee attacks: one with its [[/item
-          .mlWql992zSZ6hvl6]]{tail} and two with its [[/item
-          .pya9jchjLkwMedEr]]{claws}. Alternatively, it can use [[/item
+          <p>The [[lookup @name lowercase]]{monster} makes three melee attacks:
+          one with its [[/item .mlWql992zSZ6hvl6]]{Tail} and two with its
+          [[/item .pya9jchjLkwMedEr]]{Claws}. Alternatively, it can use [[/item
           .syCZDlwGoyT1GvJv]]{Hurl Flame} twice.</p>
         chat: ''
       source:
@@ -730,13 +646,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        DDs76OVAnNDTRhNd:
           type: utility
           activation:
             type: action
@@ -751,15 +666,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -770,7 +686,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -787,7 +704,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: DDs76OVAnNDTRhNd
       enchant: {}
       prerequisites:
         level: null
@@ -801,22 +726,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273657458
+      systemVersion: 6.0.0
+      createdTime: 1781637784867
+      modifiedTime: 1781637794000
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!sLdpiuaZF8lujJQy.JbDDt9MNYFyEbHsm'
   - _id: pya9jchjLkwMedEr
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-glowing-purple.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Barbed Devil attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -878,10 +805,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - fin
-        - mgc
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -890,8 +815,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        96mLCHGSPTGKAPKh:
           type: attack
           activation:
             type: action
@@ -906,10 +830,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -926,7 +851,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -939,23 +865,35 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 96mLCHGSPTGKAPKh
+          name: ''
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: claw
       mastery: ''
     effects: []
@@ -967,22 +905,24 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378654655
+      systemVersion: 6.0.0
+      createdTime: 1781637712946
+      modifiedTime: 1781637740121
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!sLdpiuaZF8lujJQy.pya9jchjLkwMedEr'
   - _id: mlWql992zSZ6hvl6
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Barbed Devil attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1044,8 +984,7 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - mgc
+      properties: []
       proficient: 1
       unidentified:
         description: ''
@@ -1055,8 +994,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        mrhmnhWiwOepbuib:
           type: attack
           activation:
             type: action
@@ -1071,10 +1009,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1091,7 +1030,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1104,23 +1044,35 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: mrhmnhWiwOepbuib
+          name: ''
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: tail
       mastery: ''
     effects: []
@@ -1132,18 +1084,18 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378658660
+      systemVersion: 6.0.0
+      createdTime: 1781637266035
+      modifiedTime: 1781637762075
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!sLdpiuaZF8lujJQy.mlWql992zSZ6hvl6'
   - _id: syCZDlwGoyT1GvJv
     name: Hurl Flame
     type: weapon
-    img: icons/magic/fire/blast-jet-stream-splash.webp
+    img: icons/magic/fire/projectile-fireball-orange-yellow.webp
     system:
       description:
         value: >-
@@ -1151,9 +1103,9 @@ items:
           flammable object that isn't being worn or carried, it also catches
           fire.</p>
         chat: >-
-          <p>The Barbed Devil attacks with its Hurl Flame. If the target is a
-          flammable object that isn't being worn or carried, it also catches
-          fire.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. If the target is a flammable object that isn't being
+          worn or carried, it also catches fire.</p>
       source:
         custom: ''
         book: ''
@@ -1216,18 +1168,17 @@ items:
         dt: null
         conditions: ''
       properties:
-        - thr
-      proficient: 1
+        - mgc
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: martialR
+        value: natural
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        OYxhOrPcIbUdBQSV:
           type: attack
           activation:
             type: action
@@ -1242,6 +1193,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1262,7 +1214,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1288,10 +1241,19 @@ items:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: OYxhOrPcIbUdBQSV
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1302,22 +1264,124 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745175668889
+      systemVersion: 6.0.0
+      createdTime: 1781637171200
+      modifiedTime: 1781637756913
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!sLdpiuaZF8lujJQy.syCZDlwGoyT1GvJv'
+  - _id: DWuLaCrJVsysrgNB
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 400000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781637041091
+      modifiedTime: 1781637814938
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!sLdpiuaZF8lujJQy.DWuLaCrJVsysrgNB'
+  - _id: Mr0XAAdAlLKQU5on
+    name: Devil Sight
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>Magical &amp;reference[darkness] doesn't impede the [[lookup @name
+          lowercase]]{monster}'s &amp;reference[Darkvision].</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: devil-sight
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/creatures/eyes/lizard-single-slit-pink.webp
+    effects: []
+    folder: null
+    sort: 300000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781637813036
+      modifiedTime: 1781637814938
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.UjbgbOnd6ltjagZm
+    _key: '!actors.items!sLdpiuaZF8lujJQy.Mr0XAAdAlLKQU5on'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1326,7 +1390,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171262244

--- a/packs/_source/monsters/fiend/bearded-devil.yml
+++ b/packs/_source/monsters/fiend/bearded-devil.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,110 +492,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
-  - _id: xt4Cm1tg8Xfodhdt
-    name: Devil's Sight
-    type: feat
-    img: icons/magic/perception/eye-slit-pink.webp
-    system:
-      description:
-        value: <p>Magical darkness doesn't impede the devil's Darkvision.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: devils-sight
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!9ggQBmAKXraOtz7S.xt4Cm1tg8Xfodhdt'
-  - _id: u1abloZz4RhCI9rk
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The devil has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!9ggQBmAKXraOtz7S.u1abloZz4RhCI9rk'
   - _id: PIggvpkBTTCDGOHp
     name: Steadfast
     type: feat
-    img: icons/magic/defensive/illusion-evasion-echo-purple.webp
+    img: icons/environment/people/charge.webp
     system:
       description:
         value: >-
-          <p>The devil can't be frightened while it can see an allied creature
-          within 30 feet of it.</p>
+          <p>The [[lookup @name lowercase]]{monster} can't be
+          &amp;reference[frightened apply=false] while it can see an allied
+          creature within 30 feet of it.</p>
         chat: ''
       source:
         custom: ''
@@ -612,10 +517,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -623,38 +529,39 @@ items:
       identifier: steadfast
     effects: []
     folder: null
-    sort: 0
+    sort: 600000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.4N7S29kDROQ932pG
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956271839
+      systemVersion: 6.0.0
+      createdTime: 1781637848584
+      modifiedTime: 1781637904167
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!9ggQBmAKXraOtz7S.PIggvpkBTTCDGOHp'
   - _id: ndwCjJFBLTujojCl
     name: Beard
     type: weapon
-    img: icons/creatures/tentacles/tentacles-thing-green.webp
+    img: icons/commodities/biological/stinger-insect-brown.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
           succeed on a [[/save]] saving throw or be &amp;Reference[poisoned] for
-          1 minute. While poisoned in this way, the target can't regain hit
-          points. The target can repeat the saving throw at the end of each of
-          its turns, ending the effect on itself on a success.</p>
-        chat: >-
-          <p>The Bearded Devil attacks with its Beard. The target must make a
-          <strong>Constitution</strong> saving throw. The target can repeat the
-          saving throw at the end of each of its turns, ending the effect on
+          [[lookup @labels.duration activity=otXVZOYTWnkMPkxs]]. While poisoned
+          in this way, the target can't regain hit points. The target can repeat
+          the saving throw at the end of each of its turns, ending the effect on
           itself on a success.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. The target must make a Constitution saving throw. The
+          target can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success.</p>
       source:
         custom: ''
         book: ''
@@ -717,7 +624,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -726,8 +633,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        mUG3YzXgashryiUW:
           type: attack
           activation:
             type: action
@@ -742,6 +648,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -762,7 +669,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -781,24 +689,32 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: mUG3YzXgashryiUW
+        otXVZOYTWnkMPkxs:
           type: save
           activation:
-            type: action
+            type: special
             value: 1
-            condition: ''
+            condition: When a creature is hit by this attack.
             override: false
           consumption:
             targets: []
@@ -808,13 +724,25 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The target must succeed on a [[/save]] saving throw or be
+              &amp;Reference[poisoned] for [[lookup @labels.duration
+              activity=otXVZOYTWnkMPkxs]]. While poisoned in this way, the
+              target can't regain hit points. The target can repeat the saving
+              throw at the end of each of its turns, ending the effect on itself
+              on a success.</p>
           duration:
             concentration: false
-            value: ''
-            units: ''
+            value: '1'
+            units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: HUohD8uvaVqJpz1Q
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '5'
             units: ft
@@ -828,7 +756,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -841,37 +770,95 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '12'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: otXVZOYTWnkMPkxs
+          name: Poison Save
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: beard
       mastery: ''
-    effects: []
+    effects:
+      - name: Bearded Devil Poison
+        img: icons/skills/toxins/symbol-poison-drop-skull-green.webp
+        origin: Compendium.dnd5e.monsters.Actor.9ggQBmAKXraOtz7S.Item.ndwCjJFBLTujojCl
+        transfer: false
+        _id: HUohD8uvaVqJpz1Q
+        type: base
+        system:
+          changes:
+            - key: system.traits.di.value
+              type: add
+              value: healing
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[poisoned apply=false] for 1 minute. While
+          poisoned in this way, you can't regain hit points.</p><p>You can
+          repeat the saving throw at the end of each of your turnds, ending the
+          effect on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781638013026
+          modifiedTime: 1781638122396
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!9ggQBmAKXraOtz7S.ndwCjJFBLTujojCl.HUohD8uvaVqJpz1Q
     folder: null
     sort: 100000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956294859
+      systemVersion: 6.0.0
+      createdTime: 1781637929044
+      modifiedTime: 1781638129870
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!9ggQBmAKXraOtz7S.ndwCjJFBLTujojCl'
@@ -885,16 +872,17 @@ items:
           <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
           a creature other than an undead or a construct, it must succeed on a
           [[/save]] saving throw or lose 5 (1d10) hit points at the start of
-          each of its turns due to an infernal wound.</p><p>Each time the devil
-          hits the wounded target with this attack, the damage dealt by the
-          wound increases by 5 (1d10). Any creature can take an action to stanch
-          the wound with a successful DC 12 Wisdom (Medicine) check. The wound
-          also closes if the target receives magical healing.</p>
+          each of its turns due to an infernal wound.</p><p>Each time the
+          [[lookup @name lowercase]]{monster} hits the wounded target with this
+          attack, the damage dealt by the wound increases by 5 (1d10). Any
+          creature can take an action to stanch the wound with a successful
+          [[/check 12 wis med]] check. The wound also closes if the target
+          receives magical healing.</p>
         chat: >-
-          <p>The Bearded Devil attacks with its Glaive. If the target is a
-          creature other than an undead or a construct, it must make a
-          <strong>Constitution</strong> saving throw. Any creature can take an
-          action to stanch the wound with a successful Wisdom (Medicine)
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. If the target is a creature other than an undead or a
+          construct, it must make a Constitution saving throw. Any creature can
+          take an action to stanch the wound with a successful Wisdom (Medicine)
           check.</p>
       source:
         custom: ''
@@ -961,7 +949,7 @@ items:
         - hvy
         - rch
         - two
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -970,8 +958,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        TU1j8fVk8TBXzMhl:
           type: attack
           activation:
             type: action
@@ -986,10 +973,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1006,7 +994,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1019,27 +1008,38 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: TU1j8fVk8TBXzMhl
+          name: ''
+        KofC2z7Z0no9xTeX:
           type: save
           activation:
-            type: action
+            type: special
             value: 1
-            condition: ''
+            condition: When a creature is hit by this attack.
             override: false
           consumption:
             targets: []
@@ -1049,13 +1049,24 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>If the target is a creature other than an undead or a
+              construct, it must succeed on a [[/save]] saving throw or lose 5
+              (1d10) hit points at the start of each of its turns due to an
+              @UUID[Compendium.dnd5e.monsters.Actor.9ggQBmAKXraOtz7S.Item.RgZ4lGrNf9AaIyrG.ActiveEffect.jv3cUKchLC6CUW7D]{Infernal
+              Wound}.</p>
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: jv3cUKchLC6CUW7D
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '10'
             units: ft
@@ -1069,10 +1080,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1082,37 +1094,161 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '12'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: KofC2z7Z0no9xTeX
+          name: Infernal Wound Save
+        BnnkX7yeweayZAKB:
+          type: damage
+          name: Infernal Wound Damage
+          _id: BnnkX7yeweayZAKB
+          img: ''
+          sort: 300000
+          activation:
+            type: special
+            override: false
+            condition: >-
+              When a creature with an
+              @UUID[Compendium.dnd5e.monsters.Actor.9ggQBmAKXraOtz7S.Item.RgZ4lGrNf9AaIyrG.ActiveEffect.jv3cUKchLC6CUW7D]{Infernal
+              Wound} starts their turn.
+          consumption:
+            scaling:
+              allowed: true
+              max: ''
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: spec
+            override: true
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: creature
+              count: '1'
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          damage:
+            critical:
+              allow: false
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
+                denomination: 10
+                bonus: ''
+                types: []
+                scaling:
+                  mode: whole
+                  number: 1
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: glaive
       mastery: ''
-    effects: []
+    effects:
+      - name: Infernal Wound
+        img: icons/creatures/abilities/mouth-teeth-fire-orange.webp
+        origin: Compendium.dnd5e.monsters.Actor.9ggQBmAKXraOtz7S.Item.RgZ4lGrNf9AaIyrG
+        transfer: false
+        _id: jv3cUKchLC6CUW7D
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You have been inflicted with an infernal wounds. You lose [[/damage
+          1d10 average]] hit points for each infernal wound you have at the
+          start of each of your turns.</p><p>Any creature can take an action to
+          staunch the wound with a successful [[/check 12 wis med]] check. The
+          wound also closes if you receive magical healing.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781638261503
+          modifiedTime: 1781639085667
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!9ggQBmAKXraOtz7S.RgZ4lGrNf9AaIyrG.jv3cUKchLC6CUW7D
     folder: null
     sort: 300000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.items.rOG1OM2ihgPjOvFW
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956326618
+      systemVersion: 6.0.0
+      createdTime: 1781638238981
+      modifiedTime: 1781639746369
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!9ggQBmAKXraOtz7S.RgZ4lGrNf9AaIyrG'
@@ -1123,9 +1259,9 @@ items:
     system:
       description:
         value: >-
-          <p>The devil makes two attacks: one with its [[/item
-          .ndwCjJFBLTujojCl]]{beard} and one with its [[/item
-          .RgZ4lGrNf9AaIyrG]]{glaive}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two attacks: one with
+          its [[/item .ndwCjJFBLTujojCl]]{Beard} and one with its [[/item
+          .RgZ4lGrNf9AaIyrG]]{Glaive}.</p>
         chat: ''
       source:
         custom: ''
@@ -1139,13 +1275,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        Ite5b0vqY7eiF7xB:
           type: utility
           activation:
             type: action
@@ -1160,15 +1295,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1179,7 +1315,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1196,7 +1333,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: Ite5b0vqY7eiF7xB
       enchant: {}
       prerequisites:
         level: null
@@ -1210,14 +1355,120 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956274923
+      systemVersion: 6.0.0
+      createdTime: 1781638191216
+      modifiedTime: 1781638196119
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!9ggQBmAKXraOtz7S.iRRniNGmcgkUi4oH'
+  - _id: DrCGu7cY5WhWioFT
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 500000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781637836919
+      modifiedTime: 1781637848584
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!9ggQBmAKXraOtz7S.DrCGu7cY5WhWioFT'
+  - _id: jfFJ5cnUOGIrUTY4
+    name: Devil Sight
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>Magical &amp;reference[darkness] doesn't impede the [[lookup @name
+          lowercase]]{monster}'s &amp;reference[Darkvision].</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: devil-sight
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/creatures/eyes/lizard-single-slit-pink.webp
+    effects: []
+    folder: null
+    sort: 400000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781637840651
+      modifiedTime: 1781637848584
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.UjbgbOnd6ltjagZm
+    _key: '!actors.items!9ggQBmAKXraOtz7S.jfFJ5cnUOGIrUTY4'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1226,7 +1477,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171209435

--- a/packs/_source/monsters/fiend/bearded-devil.yml
+++ b/packs/_source/monsters/fiend/bearded-devil.yml
@@ -1260,8 +1260,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes two attacks: one with
-          its [[/item .ndwCjJFBLTujojCl]]{Beard} and one with its [[/item
-          .RgZ4lGrNf9AaIyrG]]{Glaive}.</p>
+          its [[/item .ndwCjJFBLTujojCl]]{beard} and one with its [[/item
+          .RgZ4lGrNf9AaIyrG]]{glaive}.</p>
         chat: ''
       source:
         custom: ''

--- a/packs/_source/monsters/fiend/bone-devil.yml
+++ b/packs/_source/monsters/fiend/bone-devil.yml
@@ -999,8 +999,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: two
-          with its [[/item .KjxsSFx9xv2HLtMX]]{Claws} and one with its [[/item
-          .iFHGL8wlqBtZAdHr]]{Sting}.</p>
+          with its [[/item .KjxsSFx9xv2HLtMX]]{claws} and one with its [[/item
+          .iFHGL8wlqBtZAdHr]]{sting}.</p>
         chat: ''
       source:
         custom: ''

--- a/packs/_source/monsters/fiend/bone-devil.yml
+++ b/packs/_source/monsters/fiend/bone-devil.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,15 +492,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: KjxsSFx9xv2HLtMX
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/commodities/claws/claw-lizard-white-black.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Bone Devil attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -527,7 +527,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -565,10 +565,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - fin
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -577,8 +575,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        x8jHFZXZ6uSo3gSo:
           type: attack
           activation:
             type: action
@@ -593,10 +590,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -613,7 +611,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -626,24 +625,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: x8jHFZXZ6uSo3gSo
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -653,18 +665,18 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956347839
+      systemVersion: 6.0.0
+      createdTime: 1781639132971
+      modifiedTime: 1781639157827
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!AnseLn7HwuP97grf.KjxsSFx9xv2HLtMX'
   - _id: iFHGL8wlqBtZAdHr
     name: Sting
     type: weapon
-    img: icons/creatures/abilities/fang-tooth-venomous.webp
+    img: icons/creatures/abilities/stinger-poison-green.webp
     system:
       description:
         value: >-
@@ -673,10 +685,10 @@ items:
           for 1 minute. The target can repeat the saving throw at the end of
           each of its turns, ending the effect on itself on a success .</p>
         chat: >-
-          <p>The Bone Devil attacks with its Sting. the target must make a
-          <strong>Constitution</strong> saving throw. The target can repeat the
-          saving throw at the end of each of its turns, ending the effect on
-          itself on a success .</p>
+          <p>The Bone Devil attacks with its Sting. The target must make a
+          Constitution saving throw. The target can repeat the saving throw at
+          the end of each of its turns, ending the effect on itself on a
+          success.</p>
       source:
         custom: ''
         book: ''
@@ -700,7 +712,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -738,10 +750,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - fin
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -750,8 +760,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        SbiE2YyVwGiMRhp9:
           type: attack
           activation:
             type: action
@@ -766,10 +775,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -786,7 +796,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -799,39 +810,48 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 5
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 5
                 denomination: 6
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: SbiE2YyVwGiMRhp9
+          name: ''
+        b7w4pKSTyul1TqDh:
           type: save
           activation:
-            type: action
+            type: special
             value: 1
-            condition: ''
+            condition: When a creature is hit by this attack.
             override: false
           consumption:
             targets: []
@@ -841,13 +861,23 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The target must succeed on a [[/save]] saving throw or become
+              &amp;Reference[poisoned] for 1 minute. The target can repeat the
+              saving throw at the end of each of its turns, ending the effect on
+              itself on a success.</p>
           duration:
             concentration: false
-            value: ''
-            units: ''
+            value: '1'
+            units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: lf9nh0D3xPK0k8b2
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '10'
             units: ft
@@ -861,10 +891,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -874,134 +905,92 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '14'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: b7w4pKSTyul1TqDh
+          name: Poison Save
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: sting
       mastery: ''
-    effects: []
+    effects:
+      - name: Bone Devil Poison
+        img: icons/skills/toxins/symbol-poison-drop-skull-green.webp
+        origin: Compendium.dnd5e.monsters.Actor.AnseLn7HwuP97grf.Item.iFHGL8wlqBtZAdHr
+        transfer: false
+        _id: lf9nh0D3xPK0k8b2
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[poisoned apply=false] for 1 minute. You can
+          repeat the saving throw at the end of each of your turns, ending the
+          effect on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781639599703
+          modifiedTime: 1781639673333
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!AnseLn7HwuP97grf.iFHGL8wlqBtZAdHr.lf9nh0D3xPK0k8b2
     folder: null
     sort: 300000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956381241
+      systemVersion: 6.0.0
+      createdTime: 1781639182837
+      modifiedTime: 1781639689696
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!AnseLn7HwuP97grf.iFHGL8wlqBtZAdHr'
-  - _id: aj4Bg2H8CNydNhMB
-    name: Devil Sight
-    type: feat
-    img: icons/magic/perception/eye-slit-pink.webp
-    system:
-      description:
-        value: <p>Magical darkness doesn't impede the devil's Darkvision.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: devil-sight
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.UjbgbOnd6ltjagZm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!AnseLn7HwuP97grf.aj4Bg2H8CNydNhMB'
-  - _id: hQXiIJrlHh2rb2k9
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The devil has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!AnseLn7HwuP97grf.hQXiIJrlHh2rb2k9'
   - _id: sC1dqjfFZKnDmhec
     name: Multiattack
     type: feat
@@ -1009,9 +998,9 @@ items:
     system:
       description:
         value: >-
-          <p>The devil makes three attacks: two with its [[/item
-          .KjxsSFx9xv2HLtMX]]{claws} and one with its [[/item
-          .iFHGL8wlqBtZAdHr]]{sting}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: two
+          with its [[/item .KjxsSFx9xv2HLtMX]]{Claws} and one with its [[/item
+          .iFHGL8wlqBtZAdHr]]{Sting}.</p>
         chat: ''
       source:
         custom: ''
@@ -1025,13 +1014,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        B79oa2h11iad80wQ:
           type: utility
           activation:
             type: action
@@ -1046,15 +1034,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1065,7 +1054,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1082,7 +1072,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: B79oa2h11iad80wQ
       enchant: {}
       prerequisites:
         level: null
@@ -1096,14 +1094,120 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956348705
+      systemVersion: 6.0.0
+      createdTime: 1781639725216
+      modifiedTime: 1781639730413
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!AnseLn7HwuP97grf.sC1dqjfFZKnDmhec'
+  - _id: XTbjimpPqg4YV2QD
+    name: Devil Sight
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>Magical &amp;reference[darkness] doesn't impede the [[lookup @name
+          lowercase]]{monster}'s &amp;reference[Darkvision].</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: devil-sight
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/creatures/eyes/lizard-single-slit-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781638157114
+      modifiedTime: 1781638157114
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.UjbgbOnd6ltjagZm
+    _key: '!actors.items!AnseLn7HwuP97grf.XTbjimpPqg4YV2QD'
+  - _id: MAYv8xZJTlYFAK8s
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781638161180
+      modifiedTime: 1781638161181
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!AnseLn7HwuP97grf.MAYv8xZJTlYFAK8s'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1112,7 +1216,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171210131

--- a/packs/_source/monsters/fiend/chain-devil.yml
+++ b/packs/_source/monsters/fiend/chain-devil.yml
@@ -940,7 +940,7 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes two attacks with its
-          [[/item .9SWi4zPVGsMD5l2Y]]{Chains}.</p>
+          [[/item .9SWi4zPVGsMD5l2Y]]{chains}.</p>
         chat: ''
       source:
         custom: ''

--- a/packs/_source/monsters/fiend/chain-devil.yml
+++ b/packs/_source/monsters/fiend/chain-devil.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,6 +492,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: 9SWi4zPVGsMD5l2Y
     name: Chain
@@ -504,14 +502,16 @@ items:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
-          grappled (escape DC 14) if the devil isn't already grappling a
-          creature. Until this grapple ends, the target is restrained and takes
-          [[/damage activity=7GprfdQsWbexe4iC average]] damage at the start of
+          &amp;reference[grappled] (escape DC 14) if the [[lookup @name
+          lowercase]]{monster} isn't already grappling a creature. Until this
+          grapple ends, the target is &amp;reference[restrained] and takes
+          [[/damage activity=D2oyIMFCCxoTivHb average]] damage at the start of
           each of its turns.</p>
         chat: >-
-          <p>The Chain Devil attacks with its Chain. The target is grappled if
-          the devil isn't already grappling a creature. Until this grapple ends,
-          the target is restrained.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. The target is &amp;reference[grappled] if the [[lookup
+          @name]]{monster} isn't already grappling a creature. Until this
+          grapple ends, the target is &amp;reference[restrained].</p>
       source:
         custom: ''
         book: ''
@@ -584,8 +584,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        ha55OpmlvLYr0Sul:
           type: attack
           activation:
             type: action
@@ -600,13 +599,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
             units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: 87lmQ6FGjFrf8rs4
+              level: {}
           range:
             value: '10'
             units: ft
@@ -620,7 +622,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -639,25 +642,35 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
-        7GprfdQsWbexe4iC:
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: ha55OpmlvLYr0Sul
+        D2oyIMFCCxoTivHb:
           type: damage
-          _id: 7GprfdQsWbexe4iC
-          sort: 0
+          sort: 200000
           activation:
-            type: action
+            type: special
             override: false
-            condition: ''
+            condition: >-
+              When a creature &reference[grappled apply=false] by this attack
+              start their turn.
           consumption:
             scaling:
               allowed: false
@@ -665,6 +678,11 @@ items:
             targets: []
           description:
             chatFlavor: ''
+            value: >-
+              <p>Until this grapple ends, the target is
+              &amp;reference[restrained] and takes [[/damage
+              activity=7GprfdQsWbexe4iC average]] damage at the start of each of
+              its turns.</p>
           duration:
             units: inst
             concentration: false
@@ -678,9 +696,12 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
-              type: ''
+              type: creature
+              count: '1'
+              special: ''
             override: false
             prompt: true
           uses:
@@ -699,51 +720,104 @@ items:
                 bonus: ''
                 types:
                   - piercing
-          name: ''
+                scaling:
+                  number: 1
+          name: Start of Turn Grapple Damage
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: D2oyIMFCCxoTivHb
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: chain
       mastery: ''
-    effects: []
+    effects:
+      - name: Grappled by Chains
+        img: icons/tools/fasteners/chain-steel-grey.webp
+        origin: Compendium.dnd5e.monsters.Actor.KtM6IV9I5l1MWUDk.Item.9SWi4zPVGsMD5l2Y
+        transfer: false
+        _id: 87lmQ6FGjFrf8rs4
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are &amp;reference[grappled apply=false] (escape DC 14). While
+          grappled in this way, you are &amp;reference[restrained apply=false]
+          and take [[/damage average 2d6 piercing average]] damage at the start
+          of each of your turns..</p>
+        tint: '#ffffff'
+        statuses:
+          - grappled
+          - restrained
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781801924151
+          modifiedTime: 1781802094710
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!KtM6IV9I5l1MWUDk.9SWi4zPVGsMD5l2Y.87lmQ6FGjFrf8rs4
     folder: null
     sort: 250000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956450484
+      systemVersion: 6.0.0
+      createdTime: 1781801655036
+      modifiedTime: 1781802082629
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KtM6IV9I5l1MWUDk.9SWi4zPVGsMD5l2Y'
   - _id: c8fbl1Kc5O3GNTus
     name: Unnerving Mask
     type: feat
-    img: icons/magic/life/heart-shadow-red.webp
+    img: icons/magic/control/fear-fright-white.webp
     system:
       description:
         value: >-
-          <p>When a creature the devil can see starts its turn within 30 feet of
-          the devil, the devil can create the illusion that it looks like one of
-          the creature's departed loved ones or bitter enemies. If the creature
-          can see the devil, it must succeed on a [[/save]] saving throw or be
-          Frightened until the end of its turn.</p>
+          <p>When a creature the [[lookup @name lowercase]]{monster} can see
+          starts its turn within 30 feet of the [[lookup @name
+          lowercase]]{monster}, the [[lookup @name lowercase]]{monster} can
+          create the illusion that it looks like one of the creature's departed
+          loved ones or bitter enemies. If the creature can see the [[lookup
+          @name lowercase]]{monster}, it must succeed on a [[/save]] saving
+          throw or be &amp;reference[Frightened apply=false] until the end of
+          its turn.</p>
         chat: >-
-          <p>The devil can create the illusion that it looks like one of the
-          creature's departed loved ones or bitter enemies. make a
-          <strong>Wisdom</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} can create the illusion that it looks
+          like one of the creature's departed loved ones or bitter enemies. make
+          a Wisdom saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -761,13 +835,15 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+        CuPUw2NAEVtPEAV8:
           type: save
           activation:
             type: reaction
             value: 1
-            condition: ''
+            condition: >-
+              When a creature the [[lookup @name lowercase]]{monster} can see
+              starts its turn within range of the [[lookup @name
+              lowercase]]{monster}.
             override: false
           consumption:
             targets: []
@@ -777,10 +853,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -797,7 +874,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -818,10 +896,21 @@ items:
             dc:
               calculation: ''
               formula: '14'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Create Illusion
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: CuPUw2NAEVtPEAV8
       enchant: {}
       prerequisites:
         level: null
@@ -831,116 +920,18 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.uEYSTOkpfr0OkKrD
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956490723
+      systemVersion: 6.0.0
+      createdTime: 1781697198176
+      modifiedTime: 1781697295835
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KtM6IV9I5l1MWUDk.c8fbl1Kc5O3GNTus'
-  - _id: FkvVIJjzEPFMgvsc
-    name: Devil's Sight
-    type: feat
-    img: icons/magic/perception/eye-slit-pink.webp
-    system:
-      description:
-        value: <p>Magical darkness doesn't impede the devil's Darkvision.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: devils-sight
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!KtM6IV9I5l1MWUDk.FkvVIJjzEPFMgvsc'
-  - _id: ZZ4l35Sr34AL2Ett
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The creature has advantage on saving throws against spells and
-          other magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!KtM6IV9I5l1MWUDk.ZZ4l35Sr34AL2Ett'
   - _id: AGKUD82KJZaMKVRt
     name: Multiattack
     type: feat
@@ -948,8 +939,8 @@ items:
     system:
       description:
         value: >-
-          <p>The devil makes two attacks with its [[/item
-          .9SWi4zPVGsMD5l2Y]]{chains}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two attacks with its
+          [[/item .9SWi4zPVGsMD5l2Y]]{Chains}.</p>
         chat: ''
       source:
         custom: ''
@@ -963,13 +954,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        DgK56NtcBHrVGRRI:
           type: utility
           activation:
             type: action
@@ -984,15 +974,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1003,7 +994,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1020,7 +1012,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 200000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: DgK56NtcBHrVGRRI
       enchant: {}
       prerequisites:
         level: null
@@ -1034,11 +1034,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956387297
+      systemVersion: 6.0.0
+      createdTime: 1781802252252
+      modifiedTime: 1781803040020
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KtM6IV9I5l1MWUDk.AGKUD82KJZaMKVRt'
@@ -1049,20 +1049,27 @@ items:
     system:
       description:
         value: >-
-          <p>Up to four chains the devil can see within 60 feet of it magically
-          sprout razor-edged barbs and animate under the devil's control,
-          provided that the chains aren't being worn or carried.</p><p>Each
-          animated chain is an object with AC 20, 20 hit points, resistance to
-          <em>piercing damage</em>, and immunity to psychic and thunder damage.
-          When the devil uses Multiattack on its turn, it can use each animated
-          chain to make one additional chain attack. An animated chain can
-          grapple one creature of its own but can't make attacks while
-          grappling. An animated chain reverts to its inanimate state if reduced
-          to 0 hit points or if the devil is incapacitated or dies.</p>
+          <p>Up to four chains the [[lookup @name lowercase]]{monster} can see
+          within [[lookup @labels.description.range activity=kRPVij49Rpa8sFnz]]
+          of it magically sprout razor-edged barbs and animate under the
+          [[lookup @name lowercase]]{monster}'s control, provided that the
+          chains aren't being worn or carried.</p><p>Each animated chain is an
+          object with AC 20, 20 hit points, resistance to <em>piercing
+          damage</em>, and immunity to psychic and thunder damage. When the
+          [[lookup @name lowercase]]{monster} uses
+          @UUID[Compendium.dnd5e.monsters.Actor.KtM6IV9I5l1MWUDk.Item.AGKUD82KJZaMKVRt]{Multiattack}
+          on its turn, it can use each animated chain to make one additional
+          @UUID[Compendium.dnd5e.monsters.Actor.KtM6IV9I5l1MWUDk.Item.9SWi4zPVGsMD5l2Y]{Chain}
+          attack. An animated chain can grapple one creature of its own but
+          can't make attacks while grappling. An animated chain reverts to its
+          inanimate state if reduced to 0 hit points or if the [[lookup @name
+          lowercase]]{monster} is &amp;reference[incapacitated apply=false] or
+          dies.</p>
         chat: >-
-          <p>Up to four chains the devil can see within 60 feet of it magically
-          sprout razor-edged barbs and animate under the devil's control,
-          provided that the chains aren't being worn or carried.</p>
+          <p>Up to four chains the [[lookup @name]]{monster} can see within 60
+          feet of it magically sprout razor-edged barbs and animate under the
+          [[lookup @name]]{monster}'s control, provided that the chains aren't
+          being worn or carried.</p>
       source:
         custom: ''
         book: ''
@@ -1077,13 +1084,13 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        kRPVij49Rpa8sFnz:
           type: utility
           activation:
             type: action
@@ -1093,24 +1100,25 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
             units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: wVrlw8BsY4R0lWxu
+              level: {}
           range:
             value: '60'
             units: ft
@@ -1124,7 +1132,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '4'
               type: object
@@ -1141,12 +1150,84 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: kRPVij49Rpa8sFnz
+          name: Animate Chains
       enchant: {}
       prerequisites:
         level: null
       identifier: animate-chains
-    effects: []
+    effects:
+      - name: Animated Chain
+        img: icons/equipment/neck/necklace-simple-hook-stone.webp
+        origin: Compendium.dnd5e.monsters.Actor.KtM6IV9I5l1MWUDk.Item.B9KJpn20n0tG4xit
+        transfer: false
+        _id: wVrlw8BsY4R0lWxu
+        type: base
+        system:
+          changes:
+            - key: flags.world.chain-multiattack-1
+              type: override
+              value: The @name can make an additional
+              phase: initial
+              priority: null
+            - key: flags.world.chain-multiattack-2
+              type: override
+              value: Chain attacks, using its Animated Chains.
+              phase: initial
+              priority: null
+            - key: flags.world.animated-chain-count
+              type: add
+              value: 1
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You have animated a chain. The chain is an object with AC 20, 20
+          Hit Points, resistance to piercing damage, and immunity to psychic and
+          thunder damage.</p><p>When you use Multiattack on your turn, you can
+          use each animated chain to make one additional Chain attack. An
+          animated Chain can &amp;reference[grapple] one creature on its own but
+          can't make attacks while grappling.</p><p>An animated chain reverts to
+          its inanimate state if reduced to 0 hit points or if you are
+          &amp;reference[incapacitated apply=false] or die.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781802273914
+          modifiedTime: 1781802995798
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!KtM6IV9I5l1MWUDk.B9KJpn20n0tG4xit.wVrlw8BsY4R0lWxu
     folder: null
     sort: 300000
     ownership:
@@ -1155,14 +1236,120 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.6ej6jlwh8ryDEzlB
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.2.0
-      createdTime: null
-      modifiedTime: 1747956387297
+      systemVersion: 6.0.0
+      createdTime: 1781802156330
+      modifiedTime: 1781802273937
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KtM6IV9I5l1MWUDk.B9KJpn20n0tG4xit'
+  - _id: 0dnRBTCLiRB6hXRE
+    name: Devil Sight
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>Magical &amp;reference[darkness] doesn't impede the [[lookup @name
+          lowercase]]{monster}'s &amp;reference[Darkvision].</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: devil-sight
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/creatures/eyes/lizard-single-slit-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781697165263
+      modifiedTime: 1781697165263
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.UjbgbOnd6ltjagZm
+    _key: '!actors.items!KtM6IV9I5l1MWUDk.0dnRBTCLiRB6hXRE'
+  - _id: xhP680WoDGbC2RlS
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781697172507
+      modifiedTime: 1781697172507
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!KtM6IV9I5l1MWUDk.xhP680WoDGbC2RlS'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1171,7 +1358,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171223453

--- a/packs/_source/monsters/fiend/dretch.yml
+++ b/packs/_source/monsters/fiend/dretch.yml
@@ -450,9 +450,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -467,7 +464,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -487,6 +484,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: Ex0UN9pj0w7p4D9F
     name: Multiattack
@@ -582,7 +580,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -593,11 +591,13 @@ items:
   - _id: 2So9DIMKKgeGHVru
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Dretch attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -660,7 +660,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -669,8 +669,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        o1neeolx8p8YS6Xq:
           type: attack
           activation:
             type: action
@@ -685,10 +684,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -705,7 +705,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -724,18 +725,31 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: o1neeolx8p8YS6Xq
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -745,22 +759,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107553039
+      systemVersion: 6.0.0
+      createdTime: 1781666608027
+      modifiedTime: 1781666622256
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!kz2fW9xb5CcvXLX4.2So9DIMKKgeGHVru'
   - _id: 5fa9Rdzy2YYpkAgS
     name: Claws
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-glowing-orange.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Dretch attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -823,7 +839,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -832,8 +848,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        KlF5M94TQaJQnqxZ:
           type: attack
           activation:
             type: action
@@ -848,10 +863,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -868,7 +884,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -887,18 +904,31 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: KlF5M94TQaJQnqxZ
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -908,34 +938,37 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107553039
+      systemVersion: 6.0.0
+      createdTime: 1781666548069
+      modifiedTime: 1781666600430
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!kz2fW9xb5CcvXLX4.5fa9Rdzy2YYpkAgS'
   - _id: JVbj7KABKYi3Z8U3
     name: Fetid Cloud
     type: feat
-    img: icons/magic/acid/projectile-glowing-bubbles.webp
+    img: icons/magic/acid/orb-bubble-smoke-drip.webp
     system:
       description:
         value: >-
-          <p>A 10-foot radius of disgusting green gas extends out from the
-          dretch. The gas spreads around corners, and its area is lightly
-          obscured. It lasts for 1 minute or until a strong wind disperses
-          it.</p><p>Any creature that starts its turn in that area must succeed
-          on a [[/save]] saving throw or be &amp;Reference[poisoned] until the
-          start of its next turn. While poisoned in this way, the target can
-          take either an action or a bonus action on its turn, not both, and
-          can't take reactions. 1 use per day.</p>
+          <p>A [[lookup @labels.description.template activity=UmjK0kfobgLTjdOu]]
+          of disgusting green gas extends out from the [[lookup @name
+          lowercase]]{monster}. The gas spreads around corners, and its area is
+          &amp;reference[lightly obscured]. It lasts for [[lookup
+          @labels.duration activity=UmjK0kfobgLTjdOu]] or until a strong wind
+          disperses it.</p><p>Any creature that starts its turn in that area
+          must succeed on a [[/save]] saving throw or be
+          &amp;Reference[poisoned] until the start of its next turn. While
+          poisoned in this way, the target can take either an action or a bonus
+          action on its turn, not both, and can't take reactions.</p>
         chat: >-
-          <p>A 10-foot radius of disgusting green gas extends out from the
-          dretch. The gas spreads around corners, and its area is lightly
-          obscured. Any creature that starts its turn in that area must make a
-          <strong>Constitution</strong> saving throw.</p>
+          <p>A [[lookup @labels.description.template activity=UmjK0kfobgLTjdOu]]
+          of disgusting green gas extends out from the [[lookup
+          @name]]{monster}. The gas spreads around corners, and its area is
+          &amp;reference[lightly obscured]. Any creature that starts its turn in
+          that area must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -950,40 +983,48 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        ZwNb6VN8YJEZdHV1:
           type: save
           activation:
-            type: action
+            type: special
             value: 1
-            condition: ''
+            condition: When a creature starts its turn in the area.
             override: false
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>Any creature that starts its turn in that area must succeed on
+              a [[/save]] saving throw or be &amp;Reference[poisoned] until the
+              start of its next turn. While poisoned in this way, the target can
+              take either an action or a bonus action on its turn, not both, and
+              can't take reactions.</p>
           duration:
             concentration: false
             value: '1'
-            units: minute
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: XzGwAeU1HCPp89tA
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             units: self
             special: ''
@@ -997,9 +1038,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1009,19 +1051,142 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: con
+            ability:
+              - con
             dc:
-              calculation: ''
+              calculation: con
               formula: '11'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 300000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: ZwNb6VN8YJEZdHV1
+          name: Poison Save
+        UmjK0kfobgLTjdOu:
+          type: utility
+          name: Exude Gas
+          _id: UmjK0kfobgLTjdOu
+          img: ''
+          sort: 200000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: minute
+            concentration: false
+            override: false
+            value: '1'
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+            value: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: radius
+              size: '10'
+              count: ''
+            affects:
+              choice: false
+              type: creature
+              count: ''
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
       enchant: {}
       prerequisites:
         level: null
       identifier: fetid-cloud
-    effects: []
+    effects:
+      - name: Fetid Gas Poisoning
+        img: icons/magic/acid/orb-bubble-smoke-drip.webp
+        origin: Compendium.dnd5e.monsters.Actor.kz2fW9xb5CcvXLX4.Item.JVbj7KABKYi3Z8U3
+        transfer: false
+        _id: XzGwAeU1HCPp89tA
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: rounds
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[poisoned apply=false] until the start of
+          your next turn. While poisoned in this way, you can take either an
+          action or a bonus action on your turn, not both, and you can't take
+          reactions.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781666362960
+          modifiedTime: 1781666435698
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!kz2fW9xb5CcvXLX4.JVbj7KABKYi3Z8U3.XzGwAeU1HCPp89tA
     folder: null
     sort: 0
     ownership:
@@ -1030,11 +1195,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.XwcFK21aM2BThgSk
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956514689
+      systemVersion: 6.0.0
+      createdTime: 1781664598196
+      modifiedTime: 1781667498151
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!kz2fW9xb5CcvXLX4.JVbj7KABKYi3Z8U3'
@@ -1046,7 +1211,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171253121

--- a/packs/_source/monsters/fiend/erinyes.yml
+++ b/packs/_source/monsters/fiend/erinyes.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,6 +492,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: BeB04w7ftFRDaMQ6
     name: Hellish Weapons
@@ -503,8 +501,9 @@ items:
     system:
       description:
         value: >-
-          <p>The erinyes's weapon attacks are magical and deal an extra 13 (3d8)
-          poison damage on a hit (included in the attacks).</p>
+          <p>The [[lookup @name lowercase]]{monster}'s weapon attacks are
+          magical and deal an extra 13 (3d8) poison damage on a hit (included in
+          the attacks).</p>
         chat: >-
           <p>The erinyes's weapon attacks are magical and deal extra <em>poison
           damage</em> on a hit (included in the attacks).</p>
@@ -520,10 +519,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -538,24 +538,26 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.uqoqQJ9NpMCPra6P
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956534789
+      systemVersion: 6.0.0
+      createdTime: 1781666654540
+      modifiedTime: 1781666682819
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!3o2rQBqpzjIHmrBW.BeB04w7ftFRDaMQ6'
   - _id: dvoOA7jzBnq2Lxza
     name: Longsword
     type: weapon
-    img: icons/weapons/swords/greatsword-crossguard-steel.webp
+    img: icons/weapons/swords/greatsword-crossguard-flanged-red.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]], or [[/damage average
           attackMode=twoHanded]] damage if used with two hands.</p>
-        chat: <p>The Erinyes attacks with its Longsword.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -618,8 +620,9 @@ items:
         dt: null
         conditions: ''
       properties:
+        - mgc
         - ver
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -628,8 +631,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        EoN2WQ55OD1EYW9N:
           type: attack
           activation:
             type: action
@@ -644,10 +646,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -664,7 +667,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -677,35 +681,45 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 3
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
                 denomination: 8
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: EoN2WQ55OD1EYW9N
+          name: ''
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: longsword
       mastery: ''
     effects: []
@@ -717,166 +731,14 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.10ZP2Bu3vnCuYMIB
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956560897
+      systemVersion: 6.0.0
+      createdTime: 1781666709407
+      modifiedTime: 1781666751310
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!3o2rQBqpzjIHmrBW.dvoOA7jzBnq2Lxza'
-  - _id: W7sEr3m8MBrzYq2v
-    name: Parry
-    type: feat
-    img: icons/skills/melee/weapons-crossed-swords-yellow-teal.webp
-    system:
-      description:
-        value: >-
-          <p>The erinyes adds 4 to its AC against one melee Attack that would
-          hit it. To do so, the erinyes must see the attacker and be wielding a
-          melee weapon.</p>
-        chat: >-
-          <p>The erinyes adds 4 to its <strong>AC</strong> against one melee
-          Attack that would hit it.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: reaction
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: parry
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.kfi26Jy0VLXv9TTm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956592936
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!3o2rQBqpzjIHmrBW.W7sEr3m8MBrzYq2v'
-  - _id: WharT2ReFy2FYTG0
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The erinyes has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956540874
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!3o2rQBqpzjIHmrBW.WharT2ReFy2FYTG0'
   - _id: qO61ofcSoMF4uxk8
     name: Plate Armor
     type: equipment
@@ -947,7 +809,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.OjkIqlW2UpgFcjZa
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -958,17 +820,18 @@ items:
   - _id: CElneYmOXIzyfv2a
     name: Longbow
     type: weapon
-    img: icons/weapons/bows/longbow-leather-green.webp
+    img: icons/weapons/bows/bow-recurve-black.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
           succeed on a [[/save]] saving throw or be &amp;Reference[poisoned].
-          The poison lasts until it is removed by the lesser restoration spell
-          or similar magic.</p>
+          The poison lasts until it is removed by the
+          @UUID[Compendium.dnd5e.spells.Item.F0GsG0SJzsIOacwV]{Lesser
+          Restoration} spell or similar magic.</p>
         chat: >-
-          <p>The Erinyes attacks with its Longbow. The target must make a
-          <strong>Constitution</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. The target must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1033,8 +896,9 @@ items:
       properties:
         - amm
         - hvy
+        - mgc
         - two
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1043,8 +907,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        Z4Xacg7E9KTq03mY:
           type: attack
           activation:
             type: action
@@ -1059,10 +922,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1079,7 +943,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1092,39 +957,48 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: ranged
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 3
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
                 denomination: 8
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: Z4Xacg7E9KTq03mY
+          name: ''
+        FSUW5qkqgkRvTUzE:
           type: save
           activation:
-            type: action
+            type: special
             value: 1
-            condition: ''
+            condition: When a creature is hit by this attack.
             override: false
           consumption:
             targets: []
@@ -1134,18 +1008,28 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The target must succeed on a [[/save]] saving throw or be
+              &amp;Reference[poisoned]. The poison lasts until it is removed by
+              the @UUID[Compendium.dnd5e.spells.Item.F0GsG0SJzsIOacwV]{Lesser
+              Restoration} spell or similar magic.</p>
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: o8VWEdzRxZ9UjKls
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '150'
-            units: ft
+            units: spec
             special: ''
-            override: false
+            override: true
           target:
             template:
               count: ''
@@ -1154,10 +1038,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -1167,38 +1052,91 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '14'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: FSUW5qkqgkRvTUzE
+          name: Poison Save
       attuned: false
       ammunition:
         type: ''
-      magicalBonus: null
+      magicalBonus: ''
       identifier: longbow
       mastery: ''
-    effects: []
+    effects:
+      - name: Erinyes Poison
+        img: icons/skills/toxins/symbol-poison-drop-skull-green.webp
+        origin: Compendium.dnd5e.monsters.Actor.3o2rQBqpzjIHmrBW.Item.CElneYmOXIzyfv2a
+        transfer: false
+        _id: o8VWEdzRxZ9UjKls
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are &amp;reference[poisoned apply=false]. This poison lasts
+          until it is removed by the
+          @UUID[Compendium.dnd5e.spells.Item.F0GsG0SJzsIOacwV]{Lesser
+          Restoration} spell or similar magic.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781666829544
+          modifiedTime: 1781666870904
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!3o2rQBqpzjIHmrBW.CElneYmOXIzyfv2a.o8VWEdzRxZ9UjKls
     folder: null
     sort: 300000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.items.3cymOVja8jXbzrdT
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956586249
+      systemVersion: 6.0.0
+      createdTime: 1781666762093
+      modifiedTime: 1781666906858
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!3o2rQBqpzjIHmrBW.CElneYmOXIzyfv2a'
@@ -1208,7 +1146,7 @@ items:
     img: icons/skills/melee/blade-tips-triple-steel.webp
     system:
       description:
-        value: <p>The erinyes makes three attacks.</p>
+        value: <p>The [[lookup @name lowercase]]{monster} makes three attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -1222,13 +1160,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        nVCdmDg1eD7EJp3F:
           type: utility
           activation:
             type: action
@@ -1243,15 +1180,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1262,7 +1200,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1279,7 +1218,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: nVCdmDg1eD7EJp3F
       enchant: {}
       prerequisites:
         level: null
@@ -1293,14 +1240,191 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: 1747956544623
+      systemVersion: 6.0.0
+      createdTime: 1781666697687
+      modifiedTime: 1781666703062
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!3o2rQBqpzjIHmrBW.Fp0Jye7Qwk8KOvH7'
+  - _id: XJBhy8LGBs7BF6SR
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781666668481
+      modifiedTime: 1781666668481
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!3o2rQBqpzjIHmrBW.XJBhy8LGBs7BF6SR'
+  - _id: QPblx5JLbidICNT5
+    name: Parry
+    type: feat
+    img: icons/skills/melee/swords-parry-block-yellow.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} adds 4 to its AC against
+          one melee attack that would hit it. To do so, the [[lookup @name
+          lowercase]]{monster} must see the attacker and be wielding a melee
+          weapon.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} adds 5 to its AC against one melee
+          attack that would hit it.</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties: []
+      activities:
+        5RUe1bRJr64laA0l:
+          type: utility
+          activation:
+            type: reaction
+            value: 1
+            condition: >-
+              When the [[lookup @name lowercase]]{monster} would be hit by a
+              melee attack while it is wielding a melee weapon.
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: self
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          roll:
+            formula: ''
+            name: ''
+            prompt: false
+            visible: false
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: Parry Attack
+          _id: 5RUe1bRJr64laA0l
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: parry
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 50000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.egsSDYbqoLCelb0J.Item.lS2o3QOZ2lxKyi0L
+      duplicateSource: Item.45SLiafyQy1HrDdF
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781666999482
+      modifiedTime: 1781667059014
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!3o2rQBqpzjIHmrBW.QPblx5JLbidICNT5'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1309,7 +1433,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171200935

--- a/packs/_source/monsters/fiend/glabrezu.yml
+++ b/packs/_source/monsters/fiend/glabrezu.yml
@@ -559,8 +559,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes four attacks: two
-          with its [[/item .pEUD99mri5iDNGH7]]{Pincers} and two with its [[/item
-          .VGFZM2Zvp0NT5Yb9]]{Fists}. Alternatively, it makes two attacks with
+          with its [[/item .pEUD99mri5iDNGH7]]{pincers} and two with its [[/item
+          .VGFZM2Zvp0NT5Yb9]]{fists}. Alternatively, it makes two attacks with
           its pincers and casts one spell.</p>
         chat: ''
       source:

--- a/packs/_source/monsters/fiend/glabrezu.yml
+++ b/packs/_source/monsters/fiend/glabrezu.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,6 +492,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: 9kqiKxbLXk7Ved3q
     name: Innate Spellcasting
@@ -545,7 +543,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -553,54 +551,6 @@ items:
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!OGPHF4sCVOAi87TU.9kqiKxbLXk7Ved3q'
-  - _id: 7a3DRiT1Ku9AnAQO
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The glabrezu has advantage on saving throws against spells and
-          other magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956600586
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!OGPHF4sCVOAi87TU.7a3DRiT1Ku9AnAQO'
   - _id: MCquBpEbQDXKRAju
     name: Multiattack
     type: feat
@@ -608,9 +558,9 @@ items:
     system:
       description:
         value: >-
-          <p>The glabrezu makes four attacks: two with its [[/item
-          .pEUD99mri5iDNGH7]]{pincers} and two with its [[/item
-          .VGFZM2Zvp0NT5Yb9]]{fists}. Alternatively, it makes two attacks with
+          <p>The [[lookup @name lowercase]]{monster} makes four attacks: two
+          with its [[/item .pEUD99mri5iDNGH7]]{Pincers} and two with its [[/item
+          .VGFZM2Zvp0NT5Yb9]]{Fists}. Alternatively, it makes two attacks with
           its pincers and casts one spell.</p>
         chat: ''
       source:
@@ -625,13 +575,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        DbbE6Dxoc678lTUh:
           type: utility
           activation:
             type: action
@@ -646,15 +595,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -665,7 +615,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -682,7 +633,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: DbbE6Dxoc678lTUh
       enchant: {}
       prerequisites:
         level: null
@@ -696,11 +655,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273656076
+      systemVersion: 6.0.0
+      createdTime: 1781667266701
+      modifiedTime: 1781667274614
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!OGPHF4sCVOAi87TU.MCquBpEbQDXKRAju'
@@ -711,13 +670,15 @@ items:
     system:
       description:
         value: >-
-          <p>[[/attack extended]]. [[/damage extended]]. </p><p>If the target is
-          a Medium or smaller creature, it is grappled (escape DC 15). The
-          glabrezu has two pincers, each of which can grapple only one
+          <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
+          a Medium or smaller creature, it is &amp;reference[grappled] (escape
+          DC 15). The [[lookup @name lowercase]]{monster} has two [[lookup
+          @item.name lowercase]]s, each of which can grapple only one
           target.</p>
         chat: >-
-          <p>The Glabrezu attacks with its Pincer. If the target is a Medium or
-          smaller creature, it is grappled.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. If the target is a Medium or smaller creature, it is
+          &amp;reference[grappled].</p>
       source:
         custom: ''
         book: ''
@@ -741,7 +702,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -779,9 +740,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -790,8 +750,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        wI906VcbZeDOJ8HT:
           type: attack
           activation:
             type: action
@@ -806,13 +765,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: BxMI1bnTXP73pD8P
+              level: {}
           range:
             value: '10'
             units: ft
@@ -826,7 +788,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -839,25 +802,76 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: wI906VcbZeDOJ8HT
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: pincer
-    effects: []
+      mastery: ''
+    effects:
+      - name: Grappled by Pincer
+        img: icons/commodities/claws/claw-pincer-red.webp
+        origin: Compendium.dnd5e.monsters.Actor.OGPHF4sCVOAi87TU.Item.pEUD99mri5iDNGH7
+        transfer: false
+        _id: BxMI1bnTXP73pD8P
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: <p>You are &amp;reference[grappled apply=false] (escape DC 15).</p>
+        tint: '#ffffff'
+        statuses:
+          - grappled
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781667152346
+          modifiedTime: 1781667176641
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!OGPHF4sCVOAi87TU.pEUD99mri5iDNGH7.BxMI1bnTXP73pD8P
     folder: null
     sort: 0
     ownership:
@@ -866,22 +880,24 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107551551
+      systemVersion: 6.0.0
+      createdTime: 1781667103501
+      modifiedTime: 1781667152379
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!OGPHF4sCVOAi87TU.pEUD99mri5iDNGH7'
   - _id: VGFZM2Zvp0NT5Yb9
     name: Fist
     type: weapon
-    img: icons/magic/fire/flame-burning-fist-strike.webp
+    img: icons/skills/melee/unarmed-punch-fist-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Glabrezu attacks with its Fist.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -944,7 +960,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -953,8 +969,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        wCqEnfpnItvNyPj2:
           type: attack
           activation:
             type: action
@@ -969,10 +984,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -989,7 +1005,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1002,24 +1019,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: wCqEnfpnItvNyPj2
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: fist
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -1029,11 +1059,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107551551
+      systemVersion: 6.0.0
+      createdTime: 1781667193015
+      modifiedTime: 1781667211652
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!OGPHF4sCVOAi87TU.VGFZM2Zvp0NT5Yb9'
@@ -1149,7 +1179,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.S7VbUetIfVT7B6Eq
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1266,7 +1296,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ghXTfe7sgCbgf1Q8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1384,7 +1414,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.15Fa6q1nH27XfbR8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1552,7 +1582,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.9hQXdMSmerkTsHDe
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1676,7 +1706,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.yfbK8gZqESlaoY5t
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1801,7 +1831,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.35j2QIMmIk6aEdxj
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1809,6 +1839,59 @@ items:
       lastModifiedBy: null
       exportSource: null
     _key: '!actors.items!OGPHF4sCVOAi87TU.35j2QIMmIk6aEdxj'
+  - _id: 2DLTpJUuKFmG7yoL
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781667024325
+      modifiedTime: 1781667024325
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!OGPHF4sCVOAi87TU.2DLTpJUuKFmG7yoL'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1817,7 +1900,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171228239

--- a/packs/_source/monsters/fiend/hell-hound.yml
+++ b/packs/_source/monsters/fiend/hell-hound.yml
@@ -445,9 +445,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -462,7 +459,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -482,112 +479,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
-  - _id: fhBBeyLSor6NVA0l
-    name: Keen Hearing and Smell
-    type: feat
-    img: icons/creatures/mammals/wolf-howl-moon-forest-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The hound has advantage on Wisdom (Perception) checks that rely on
-          hearing or smell.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: keen-hearing-and-smell
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956610190
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!iSCL4Q82ivnYelzc.fhBBeyLSor6NVA0l'
-  - _id: BVEOVtTEuJhNvTfo
-    name: Pack Tactics
-    type: feat
-    img: icons/creatures/abilities/paw-print-orange.webp
-    system:
-      description:
-        value: >-
-          <p>The hound has advantage on an attack roll against a creature if at
-          least one of the hound's allies is within 5 ft. of the creature and
-          the ally isn't incapacitated.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: pack-tactics
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.V1lW1vnrTpVTDr6o
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956613705
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!iSCL4Q82ivnYelzc.BVEOVtTEuJhNvTfo'
   - _id: AnHeKid7zbyPKJg9
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-fire-orange.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Hell Hound attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -650,7 +553,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -659,8 +562,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        WomHvOsmasbLtRJi:
           type: attack
           activation:
             type: action
@@ -675,10 +577,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -695,7 +598,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -708,36 +612,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: WomHvOsmasbLtRJi
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -747,28 +662,30 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107552855
+      systemVersion: 6.0.0
+      createdTime: 1781667324721
+      modifiedTime: 1781667342248
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!iSCL4Q82ivnYelzc.AnHeKid7zbyPKJg9'
   - _id: gijcyepmnWeRu4HV
     name: Fire Breath
     type: feat
-    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
+    img: icons/magic/fire/flame-burning-earth-orange.webp
     system:
       description:
         value: >-
-          <p>The hound exhales fire in a 15-foot cone. Each creature in that
-          area must make a [[/save]] saving throw, taking [[/damage average]]
-          damage on a failed save, or half as much damage on a successful
-          one.</p>
+          <p>The [[lookup @name lowercase]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=B2tJnjd8wmeEa8rj]]. Each
+          creature in that area must make a [[/save]] saving throw, taking
+          [[/damage average]] damage on a failed save, or half as much damage on
+          a successful one.</p>
         chat: >-
-          <p>The hound exhales fire in a 15-foot cone. Each creature in that
-          area must make a <strong>Dexterity</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} exhales fire in a [[lookup
+          @labels.description.template activity=B2tJnjd8wmeEa8rj]]. Each
+          creature in that area must make a Dexterity saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -789,8 +706,7 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        B2tJnjd8wmeEa8rj:
           type: save
           activation:
             type: action
@@ -800,26 +716,25 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -831,9 +746,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -845,24 +761,37 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 6
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 6
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '12'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: B2tJnjd8wmeEa8rj
+          name: Exhale Fire
       enchant: {}
       prerequisites:
         level: null
@@ -876,14 +805,122 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.bGSW8IuWURWiWtxr
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956627069
+      systemVersion: 6.0.0
+      createdTime: 1781667354786
+      modifiedTime: 1781667419859
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!iSCL4Q82ivnYelzc.gijcyepmnWeRu4HV'
+  - _id: Y44FPT7C6kpnykZw
+    name: Keen Hearing and Smell
+    type: feat
+    img: icons/creatures/mammals/wolf-howl-moon-forest-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on Wisdom
+          (Perception) checks that rely on hearing or smell.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: keen-hearing-and-smell
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: -250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.yawTeS8u2FCfzzZH.Item.z1WFJdHb8OXvW2yy
+      duplicateSource: Item.UgdVWHzrwE598r6T
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781667310945
+      modifiedTime: 1781667310945
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!iSCL4Q82ivnYelzc.Y44FPT7C6kpnykZw'
+  - _id: H4DaD12Chkk5agFU
+    name: Pack Tactics
+    type: feat
+    img: icons/creatures/abilities/paw-print-orange.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on an attack
+          roll against a creature if at least one of the [[lookup @name
+          lowercase]]{monster}'s allies is within 5 feet of the creature and the
+          ally isn't &amp;reference[incapacitated apply=false].</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: pack-tactics
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: 100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.JW8bXggOMBx1S6tF.Item.yb6o6KfKlg9bGhqA
+      duplicateSource: Item.bYY0d7kkeVIYaNof
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781667315792
+      modifiedTime: 1781667315792
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!iSCL4Q82ivnYelzc.H4DaD12Chkk5agFU'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -892,7 +929,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171250894

--- a/packs/_source/monsters/fiend/hezrou.yml
+++ b/packs/_source/monsters/fiend/hezrou.yml
@@ -676,8 +676,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
-          with its [[/item .UNNl5XqsXZuKOm69]]{Bite} and two with its [[/item
-          .HEQqPUsmmNs178Mj]]{Claws}.</p>
+          with its [[/item .UNNl5XqsXZuKOm69]]{bite} and two with its [[/item
+          .HEQqPUsmmNs178Mj]]{claws}.</p>
         chat: ''
       source:
         custom: ''

--- a/packs/_source/monsters/fiend/hezrou.yml
+++ b/packs/_source/monsters/fiend/hezrou.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,69 +492,25 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
-  - _id: dQt68nlmGdhK2ojI
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The hezrou has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956634899
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ec3lhsNv1ZRu7Qaq.dQt68nlmGdhK2ojI'
   - _id: 0EcUwWcmWzFuiJyg
     name: Stench
     type: feat
-    img: icons/magic/acid/projectile-glowing-bubbles.webp
+    img: icons/magic/acid/dissolve-vomit-green-brown.webp
     system:
       description:
         value: >-
-          <p>Any creature that starts its turn within 10 feet of the hezrou must
-          succeed on a [[/save]] saving throw or be &amp;Reference[poisoned]
-          until the start of its next turn. On a successful saving throw, the
-          creature is immune to the hezrou's stench for 24 hours.</p>
+          <p>Any creature that starts its turn within [[lookup
+          @labels.description.range activity=6R3a5EK9mkBX3oNR]] of the [[lookup
+          @name lowercase]]{monster} must succeed on a [[/save]] saving throw or
+          be &amp;Reference[poisoned] until the start of its next turn. On a
+          successful saving throw, the creature is immune to the [[lookup @name
+          lowercase]]{monster}'s [[lookup @item.name]] for 24 hours.</p>
         chat: >-
-          <p>Any creature that starts its turn <strong>within 10 feet</strong>
-          of the hezrou must succeed on a Constitution saving throw.</p>
+          <p>Any creature that starts its turn within [[lookup
+          @labels.description.range activity=6R3a5EK9mkBX3oNR]] of the [[lookup
+          @name]]{monster} must succeed on a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -570,18 +523,20 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        6R3a5EK9mkBX3oNR:
           type: save
           activation:
-            type: ''
+            type: special
             value: null
-            condition: ''
+            condition: >-
+              When a creature starts its turn within range of the [[lookup @name
+              lowercase]]{monster}.
             override: false
           consumption:
             targets: []
@@ -591,17 +546,22 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
-            value: ''
-            units: ''
+            value: '1'
+            units: round
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: 8m7q66OJYEBYu2DB
+              level: {}
+              onSave: false
           range:
-            units: ''
+            units: ft
             special: ''
             override: false
+            value: '10'
           target:
             template:
               count: ''
@@ -610,10 +570,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -623,32 +584,87 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '14'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 6R3a5EK9mkBX3oNR
+          name: Poison Save
       enchant: {}
       prerequisites:
         level: null
       identifier: stench
-    effects: []
+    effects:
+      - name: Stench Poisoning
+        img: icons/magic/acid/dissolve-vomit-green-brown.webp
+        origin: Compendium.dnd5e.monsters.Actor.ec3lhsNv1ZRu7Qaq.Item.0EcUwWcmWzFuiJyg
+        transfer: false
+        _id: 8m7q66OJYEBYu2DB
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: rounds
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[poisoned apply=false] until the start of
+          your next turn.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781667651553
+          modifiedTime: 1781667682743
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!ec3lhsNv1ZRu7Qaq.0EcUwWcmWzFuiJyg.8m7q66OJYEBYu2DB
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.OsPhT7jA5LlvUA6e
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956652615
+      systemVersion: 6.0.0
+      createdTime: 1781667518551
+      modifiedTime: 1781669728060
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ec3lhsNv1ZRu7Qaq.0EcUwWcmWzFuiJyg'
@@ -659,9 +675,9 @@ items:
     system:
       description:
         value: >-
-          <p>The hezrou makes three attacks: one with its [[/item
-          .UNNl5XqsXZuKOm69]]{bite} and two with its [[/item
-          .HEQqPUsmmNs178Mj]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .UNNl5XqsXZuKOm69]]{Bite} and two with its [[/item
+          .HEQqPUsmmNs178Mj]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -675,13 +691,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        wMpE9Ua0kpLqwvQA:
           type: utility
           activation:
             type: action
@@ -696,15 +711,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -715,7 +731,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -732,7 +749,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: wMpE9Ua0kpLqwvQA
       enchant: {}
       prerequisites:
         level: null
@@ -746,22 +771,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273656573
+      systemVersion: 6.0.0
+      createdTime: 1781669713629
+      modifiedTime: 1781669719874
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ec3lhsNv1ZRu7Qaq.xQ1RYlOxb6lMRhdI'
   - _id: UNNl5XqsXZuKOm69
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Hezrou attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -824,7 +851,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -833,8 +860,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        cY8p7Ce4gMraDHeo:
           type: attack
           activation:
             type: action
@@ -849,10 +875,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -869,7 +896,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -882,24 +910,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: cY8p7Ce4gMraDHeo
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -909,22 +950,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107552533
+      systemVersion: 6.0.0
+      createdTime: 1781667741152
+      modifiedTime: 1781667755619
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ec3lhsNv1ZRu7Qaq.UNNl5XqsXZuKOm69'
   - _id: HEQqPUsmmNs178Mj
     name: Claws
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Hezrou attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -987,7 +1030,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -996,8 +1039,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        UcF34TzuiJ1ygCcz:
           type: attack
           activation:
             type: action
@@ -1012,10 +1054,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1032,7 +1075,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1045,24 +1089,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: UcF34TzuiJ1ygCcz
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -1072,14 +1129,67 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107552533
+      systemVersion: 6.0.0
+      createdTime: 1781669598992
+      modifiedTime: 1781669619194
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ec3lhsNv1ZRu7Qaq.HEQqPUsmmNs178Mj'
+  - _id: WiGntECF3M0m0GY5
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781667515805
+      modifiedTime: 1781667515806
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!ec3lhsNv1ZRu7Qaq.WiGntECF3M0m0GY5'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1088,7 +1198,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171245015

--- a/packs/_source/monsters/fiend/horned-devil.yml
+++ b/packs/_source/monsters/fiend/horned-devil.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,15 +492,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: g8r9DZeHyfNzerHP
     name: Fork
     type: weapon
-    img: icons/tools/cooking/fork-steel-grey.webp
+    img: icons/weapons/polearms/trident-silver-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Horned Devil attacks with its Fork.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -568,7 +568,7 @@ items:
       properties:
         - hvy
         - rch
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -577,8 +577,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        GOj1PqH6UiCMpGE6:
           type: attack
           activation:
             type: action
@@ -593,10 +592,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -613,7 +613,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -626,24 +627,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: GOj1PqH6UiCMpGE6
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: fork
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -653,112 +667,18 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956668824
+      systemVersion: 6.0.0
+      createdTime: 1781669857463
+      modifiedTime: 1781669941651
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MADGs8pWMVyyFOf1.g8r9DZeHyfNzerHP'
-  - _id: smHERNgdj5yGNQuD
-    name: Devil's Sight
-    type: feat
-    img: icons/magic/perception/eye-slit-pink.webp
-    system:
-      description:
-        value: <p>Magical darkness doesn't impede the devil's darkvision.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: devils-sight
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!MADGs8pWMVyyFOf1.smHERNgdj5yGNQuD'
-  - _id: gq4SqLPtYhhtWidm
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The devil has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956666267
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!MADGs8pWMVyyFOf1.gq4SqLPtYhhtWidm'
   - _id: VpvOoT7mbR0XNZiL
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
       description:
         value: >-
@@ -768,12 +688,12 @@ items:
           each of its turns due to an infernal wound. Each time the devil hits
           the wounded target with this attack, the damage dealt by the wound
           increases by 10 (3d6). Any creature can take an action to stanch the
-          wound with a successful DC 12 Wisdom (Medicine) check. The wound also
+          wound with a successful [[/check 12 wis med]] check. The wound also
           closes if the target receives magical healing.</p>
         chat: >-
-          <p>The Horned Devil attacks with its Tail. If the target is a creature
-          other than an undead or a construct, it must make a
-          <strong>Constitution</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. If the target is a creature other than an undead or a
+          construct, it must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -797,7 +717,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -835,9 +755,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -846,8 +765,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        Q2gyRnxRHxsSynrJ:
           type: attack
           activation:
             type: action
@@ -862,10 +780,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -882,7 +801,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -908,14 +828,21 @@ items:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: Q2gyRnxRHxsSynrJ
+        orktvwSaLbcUnXgH:
           type: save
           activation:
-            type: action
+            type: special
             value: 1
-            condition: ''
+            condition: When a creature is hit by this attack.
             override: false
           consumption:
             targets: []
@@ -925,13 +852,22 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>If the target is a creature other than an undead or a
+              construct, it must succeed on a [[/save]] saving throw or lose 5
+              (1d10) hit points at the start of each of its turns due to a
+              @UUID[Compendium.dnd5e.monsters.Actor.MADGs8pWMVyyFOf1.Item.VpvOoT7mbR0XNZiL.ActiveEffect.rkqCY7JoNgMp3P7H]{Deep
+              Infernal Wound}.</p>
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: rkqCY7JoNgMp3P7H
+              level: {}
+              onSave: false
           range:
             value: '10'
             units: ft
@@ -945,10 +881,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -958,37 +895,163 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
-              formula: '17'
-          sort: 0
+              formula: '12'
+            visible: true
+            bonus: ''
+          sort: 300000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: Infernal Wound Save
+          _id: orktvwSaLbcUnXgH
+        IPK6a3329cQMTbKY:
+          type: damage
+          name: Infernal Wound Damage
+          img: ''
+          sort: 400000
+          activation:
+            type: special
+            override: false
+            condition: >-
+              When a creature with a
+              @UUID[Compendium.dnd5e.monsters.Actor.MADGs8pWMVyyFOf1.Item.VpvOoT7mbR0XNZiL.ActiveEffect.rkqCY7JoNgMp3P7H]{Deep
+              Infernal Wound} starts their turn.
+          consumption:
+            scaling:
+              allowed: true
+              max: ''
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: spec
+            override: true
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: creature
+              count: '1'
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          damage:
+            critical:
+              allow: false
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
+                denomination: 6
+                bonus: ''
+                types: []
+                scaling:
+                  mode: whole
+                  number: 3
+                  formula: ''
+          _id: IPK6a3329cQMTbKY
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: tail
       mastery: ''
-    effects: []
+    effects:
+      - name: Deep Infernal Wound
+        img: icons/creatures/abilities/mouth-teeth-fire-orange.webp
+        origin: Compendium.dnd5e.monsters.Actor.MADGs8pWMVyyFOf1.Item.VpvOoT7mbR0XNZiL
+        transfer: false
+        _id: rkqCY7JoNgMp3P7H
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You have been inflicted with an infernal wounds. You lose [[/damage
+          3d6 average]] hit points for each deep infernal wound you have at the
+          start of each of your turns.</p><p>Any creature can take an action to
+          staunch the wound with a successful [[/check 12 wis med]] check. The
+          wound also closes if you receive magical healing.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781670015016
+          modifiedTime: 1781670030087
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: >-
+            Compendium.dnd5e.monsters.Actor.9ggQBmAKXraOtz7S.Item.RgZ4lGrNf9AaIyrG.ActiveEffect.jv3cUKchLC6CUW7D
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!MADGs8pWMVyyFOf1.VpvOoT7mbR0XNZiL.rkqCY7JoNgMp3P7H
     folder: null
     sort: 300000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956694139
+      systemVersion: 6.0.0
+      createdTime: 1781669957487
+      modifiedTime: 1781671379477
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MADGs8pWMVyyFOf1.VpvOoT7mbR0XNZiL'
@@ -999,10 +1062,10 @@ items:
     system:
       description:
         value: >-
-          <p>The devil makes three melee attacks: two with its [[/item
-          .g8r9DZeHyfNzerHP]]{fork} and one with its [[/item
-          .VpvOoT7mbR0XNZiL]]{tail}. It can use [[/item .GFYzWSyeuW9O4a0I]]{Hurl
-          Flame} in place of any melee attack.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three melee attacks:
+          two with its [[/item .g8r9DZeHyfNzerHP]]{Fork} and one with its
+          [[/item .VpvOoT7mbR0XNZiL]]{Tail}. It can use [[/item
+          .GFYzWSyeuW9O4a0I]]{Hurl Flame} in place of any melee attack.</p>
         chat: ''
       source:
         custom: ''
@@ -1016,13 +1079,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        PBPwNEPlsUzazNJC:
           type: utility
           activation:
             type: action
@@ -1037,15 +1099,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1056,7 +1119,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1073,7 +1137,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: PBPwNEPlsUzazNJC
       enchant: {}
       prerequisites:
         level: null
@@ -1087,18 +1159,18 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956669582
+      systemVersion: 6.0.0
+      createdTime: 1781671345240
+      modifiedTime: 1781671354148
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MADGs8pWMVyyFOf1.9FAl5YGUTmt1RnEF'
   - _id: GFYzWSyeuW9O4a0I
     name: Hurl Flame
     type: weapon
-    img: icons/magic/fire/blast-jet-stream-splash.webp
+    img: icons/magic/fire/projectile-fireball-orange-yellow.webp
     system:
       description:
         value: >-
@@ -1106,9 +1178,9 @@ items:
           a flammable object that isn't being worn or carried, it also catches
           fire.</p>
         chat: >-
-          <p>The Horned Devil attacks with its Hurl Flame. If the target is a
-          flammable object that isn't being worn or carried, it also catches
-          fire.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. If the target is a flammable object that isn't being
+          worn or carried, it also catches fire.</p>
       source:
         custom: ''
         book: ''
@@ -1171,17 +1243,16 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: martialR
+        value: natural
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        uTYhYlyZzG1zSeyc:
           type: attack
           activation:
             type: action
@@ -1196,6 +1267,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1216,7 +1288,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1229,8 +1302,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: none
-            bonus: '@abilities.cha.mod'
+            ability: cha
+            bonus: ''
             critical:
               threshold: null
             flat: false
@@ -1242,10 +1315,19 @@ items:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: uTYhYlyZzG1zSeyc
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1256,22 +1338,124 @@ items:
     sort: 400000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956668824
+      systemVersion: 6.0.0
+      createdTime: 1781671224328
+      modifiedTime: 1781671285655
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MADGs8pWMVyyFOf1.GFYzWSyeuW9O4a0I'
+  - _id: IJGBvJg6lrJhY1mv
+    name: Devil Sight
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>Magical &amp;reference[darkness] doesn't impede the [[lookup @name
+          lowercase]]{monster}'s &amp;reference[Darkvision].</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: devil-sight
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/creatures/eyes/lizard-single-slit-pink.webp
+    effects: []
+    folder: null
+    sort: 100000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781669757744
+      modifiedTime: 1781669758760
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.UjbgbOnd6ltjagZm
+    _key: '!actors.items!MADGs8pWMVyyFOf1.IJGBvJg6lrJhY1mv'
+  - _id: ubrf4QuSocHDw9w2
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 200000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781669766331
+      modifiedTime: 1781669767989
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!MADGs8pWMVyyFOf1.ubrf4QuSocHDw9w2'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1280,7 +1464,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171224928

--- a/packs/_source/monsters/fiend/horned-devil.yml
+++ b/packs/_source/monsters/fiend/horned-devil.yml
@@ -1063,8 +1063,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes three melee attacks:
-          two with its [[/item .g8r9DZeHyfNzerHP]]{Fork} and one with its
-          [[/item .VpvOoT7mbR0XNZiL]]{Tail}. It can use [[/item
+          two with its [[/item .g8r9DZeHyfNzerHP]]{fork} and one with its
+          [[/item .VpvOoT7mbR0XNZiL]]{tail}. It can use [[/item
           .GFYzWSyeuW9O4a0I]]{Hurl Flame} in place of any melee attack.</p>
         chat: ''
       source:

--- a/packs/_source/monsters/fiend/ice-devil.yml
+++ b/packs/_source/monsters/fiend/ice-devil.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,15 +492,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: DV4KS0OE541vGOtI
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-white.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ice Devil attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -566,17 +566,16 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: simpleM
+        value: natural
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        dBx1TXvYYuXNKM65:
           type: attack
           activation:
             type: action
@@ -591,10 +590,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -611,7 +611,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -624,36 +625,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 3
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
                 denomination: 6
                 bonus: ''
                 types:
                   - cold
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: dBx1TXvYYuXNKM65
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -663,148 +675,58 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956711108
+      systemVersion: 6.0.0
+      createdTime: 1781671421612
+      modifiedTime: 1781696276217
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!1zzRQps9jZdLZGqI.DV4KS0OE541vGOtI'
-  - _id: WAGF3evP6GTYDvM0
-    name: Devil's Sight
-    type: feat
-    img: icons/magic/perception/eye-slit-pink.webp
-    system:
-      description:
-        value: <p>Magical darkness doesn't impede the devil's darkvision.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: devils-sight
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!1zzRQps9jZdLZGqI.WAGF3evP6GTYDvM0'
-  - _id: IKaEdLLHwVL0s9UP
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The devil has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956708871
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!1zzRQps9jZdLZGqI.IKaEdLLHwVL0s9UP'
   - _id: nCTze3rZpWcTeuYQ
     name: Wall of Ice
     type: feat
-    img: icons/magic/water/barrier-ice-crystal-wall-jagged-blue.webp
+    img: icons/magic/water/barrier-ice-crystal-wall-faceted.webp
     system:
       description:
         value: >-
-          <p>The devil magically forms an opaque wall of ice on a solid surface
-          it can see within 60 feet of it. The wall is 1 foot thick and up to 30
-          feet long and 10 feet high, or it's a hemispherical dome up to 20 feet
-          in diameter.</p><p>When the wall appears, each creature in its space
-          is pushed out of it by the shortest route. The creature chooses which
-          side of the wall to end up on, unless the creature is incapacitated.
+          <p>The [[lookup @name lowercase]]{monster} magically forms an opaque
+          wall of ice on a solid surface it can see within [[lookup
+          @labels.description.range activity=epHS9JFnK0K3AOh0]] of it. The wall
+          is 1 foot thick and up to 30 feet long and 10 feet high, or it's a
+          hemispherical dome up to 20 feet in diameter.</p><p>When the wall
+          appears, each creature in its space is pushed out of it by the
+          shortest route. The creature chooses which side of the wall to end up
+          on, unless the creature is &amp;reference[incapacitated apply=false].
           The creature then makes a [[/save]] saving throw, taking [[/damage
           average]] damage on a failed save, or half as much damage on a
-          successful one.</p><p>The wall lasts for 1 minute or until the devil
-          is incapacitated or dies. The wall can be damaged and breached; each
-          10-foot section has AC 5, 30 hit points, vulnerability to fire damage,
-          and immunity to acid, cold, necrotic, poison, and psychic damage. If a
-          section is destroyed, it leaves behind a sheet of frigid air in the
-          space the wall occupied. Whenever a creature finishes moving through
-          the frigid air on a turn, willingly or otherwise, the creature must
-          make a [[/save activity=1sgpSnbxz7JYshd3]] saving throw, taking
-          [[/damage activity=1sgpSnbxz7JYshd3 average]] damage on a failed save,
-          or half as much damage on a successful one. The frigid air dissipates
-          when the rest of the wall vanishes.</p>
+          successful one.</p><p>The wall lasts for [[lookup @labels.duration
+          activity=epHS9JFnK0K3AOh0]] or until the [[lookup @name
+          lowercase]]{monster} is &amp;reference[incapacitated apply=false] or
+          dies. The wall can be damaged and breached; each 10-foot section has
+          AC 5, 30 hit points, vulnerability to fire damage, and immunity to
+          acid, cold, necrotic, poison, and psychic damage. If a section is
+          destroyed, it leaves behind a sheet of frigid air in the space the
+          wall occupied. Whenever a creature finishes moving through the frigid
+          air on a turn, willingly or otherwise, the creature must make a
+          [[/save activity=qJljbNLNFhF1xbDV]] saving throw, taking [[/damage
+          activity=qJljbNLNFhF1xbDV average]] damage on a failed save, or half
+          as much damage on a successful one. The frigid air dissipates when the
+          rest of the wall vanishes.</p>
         chat: >-
-          <p>The devil magically forms an opaque wall of ice on a solid surface
-          it can see within 60 feet of it. The wall is 1 foot thick and up to 30
-          feet long and 10 feet high, or it's a hemispherical dome up to 20 feet
-          in diameter.When the wall appears, each creature in its space is
-          pushed out of it by the shortest route. The creature chooses which
-          side of the wall to end up on, unless the creature is incapacitated.
-          The creature then makes a Dexterity saving throw.</p>
-
-          <p>The wall can be damaged and breached. If a section is destroyed, it
-          leaves behind a sheet of frigid air in the space the wall occupied.
-          Whenever a creature finishes moving through the frigid air on a turn,
-          willingly or otherwise, the creature must make a
-          <strong>Constitution</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} magically forms an opaque wall of ice
+          on a solid surface it can see within [[lookup
+          @labels.description.range activity=epHS9JFnK0K3AOh0]] of it. The wall
+          is 1 foot thick and up to 30 feet long and 10 feet high, or it's a
+          hemispherical dome up to 20 feet in diameter. When the wall appears,
+          each creature in its space is pushed out of it by the shortest route.
+          The creature chooses which side of the wall to end up on, unless the
+          creature is &amp;reference[incapacitated apply=false]. The creature
+          then makes a Dexterity saving throw.</p><p>The wall can be damaged and
+          breached. If a section is destroyed, it leaves behind a sheet of
+          frigid air in the space the wall occupied. Whenever a creature
+          finishes moving through the frigid air on a turn, willingly or
+          otherwise, the creature must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -817,13 +739,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+        epHS9JFnK0K3AOh0:
           type: save
           activation:
             type: action
@@ -838,6 +760,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
@@ -846,7 +769,7 @@ items:
             override: false
           effects: []
           range:
-            value: '30'
+            value: '60'
             units: ft
             special: ''
             override: false
@@ -859,6 +782,7 @@ items:
               width: '1'
               height: '10'
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -881,24 +805,39 @@ items:
                 bonus: ''
                 types:
                   - cold
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '17'
-          sort: 0
-          name: Create Wall
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Create Wall of Ice
           img: ''
-          appliedEffects: []
-        1sgpSnbxz7JYshd3:
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: epHS9JFnK0K3AOh0
+        qJljbNLNFhF1xbDV:
           type: save
-          name: Pass Through Wall
-          _id: 1sgpSnbxz7JYshd3
-          sort: 0
+          name: Pass Through Frigid Air Save
+          sort: 400000
           activation:
-            type: ''
+            type: special
             override: false
-            condition: ''
+            condition: >-
+              When a creature moves through the sheet of frigid air for the
+              first time on a turn.
           consumption:
             scaling:
               allowed: false
@@ -906,13 +845,22 @@ items:
             targets: []
           description:
             chatFlavor: ''
+            value: >-
+              <p>If a section of the wall is destroyed, it leaves behind a sheet
+              of frigid air in the space the wall occupied. Whenever a creature
+              finishes moving through the frigid air on a turn, willingly or
+              otherwise, the creature must make a [[/save
+              activity=qJljbNLNFhF1xbDV]] saving throw, taking [[/damage
+              activity=qJljbNLNFhF1xbDV average]] damage on a failed save, or
+              half as much damage on a successful one. The frigid air dissipates
+              when the rest of the wall vanishes.</p>
           duration:
             units: inst
             concentration: false
             override: false
           effects: []
           range:
-            units: self
+            units: spec
             override: false
             special: ''
           target:
@@ -920,9 +868,12 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
-              type: ''
+              type: creature
+              count: '1'
+              special: ''
             override: false
             prompt: true
           uses:
@@ -939,15 +890,111 @@ items:
                 bonus: ''
                 types:
                   - cold
+                scaling:
+                  number: 1
             onSave: half
           save:
             ability:
               - con
             dc:
+              calculation: cha
+              formula: '17'
+            visible: true
+            bonus: ''
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: qJljbNLNFhF1xbDV
+        ctGJJGIvlgeN42Va:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: a solid surface it can see within 60 ft.
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '60'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: sphere
+              size: '10'
+              width: '1'
+              height: '10'
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 10
+                denomination: 6
+                bonus: ''
+                types:
+                  - cold
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
               calculation: ''
               formula: '17'
+            visible: true
+            bonus: ''
+          sort: 250000
+          name: Create Dome of Ice
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: ctGJJGIvlgeN42Va
       enchant: {}
       prerequisites:
         level: null
@@ -957,30 +1004,28 @@ items:
     sort: 500000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.Kwt8YDIBHg6JO2v2
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956871882
+      systemVersion: 6.0.0
+      createdTime: 1781671442506
+      modifiedTime: 1781696151713
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!1zzRQps9jZdLZGqI.nCTze3rZpWcTeuYQ'
   - _id: AQ551xglVn90BdwU
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ice Devil attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1004,7 +1049,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -1042,9 +1087,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1053,8 +1097,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        FHOOWrMPxW40D20z:
           type: attack
           activation:
             type: action
@@ -1069,10 +1112,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1089,7 +1133,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1102,36 +1147,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 3
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
                 denomination: 6
                 bonus: ''
                 types:
                   - cold
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: FHOOWrMPxW40D20z
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: tail
+      mastery: ''
     effects: []
     folder: null
     sort: 400000
@@ -1141,22 +1197,24 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956711108
+      systemVersion: 6.0.0
+      createdTime: 1781671432469
+      modifiedTime: 1781696204349
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!1zzRQps9jZdLZGqI.AQ551xglVn90BdwU'
   - _id: E6iXljYXLdQyfk1l
     name: Claws
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/commodities/claws/claw-lizard-white-black.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ice Devil attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1218,9 +1276,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - fin
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1229,8 +1286,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        XPzKvnxmI7skPDUz:
           type: attack
           activation:
             type: action
@@ -1245,10 +1301,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1265,7 +1322,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1278,36 +1336,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 3
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
                 denomination: 6
                 bonus: ''
                 types:
                   - cold
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: XPzKvnxmI7skPDUz
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
     sort: 200000
@@ -1317,11 +1386,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956725985
+      systemVersion: 6.0.0
+      createdTime: 1781671426484
+      modifiedTime: 1781696241091
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!1zzRQps9jZdLZGqI.E6iXljYXLdQyfk1l'
@@ -1349,13 +1418,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        sh0AsZ5AQZJVFdPN:
           type: utility
           activation:
             type: action
@@ -1370,15 +1438,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1389,7 +1458,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1406,7 +1476,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: sh0AsZ5AQZJVFdPN
       enchant: {}
       prerequisites:
         level: null
@@ -1420,14 +1498,120 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956711842
+      systemVersion: 6.0.0
+      createdTime: 1781696286104
+      modifiedTime: 1781696292060
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!1zzRQps9jZdLZGqI.vLQAjoewGE5MAHn2'
+  - _id: xQcDItxuubU3H6Cr
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 200000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781671407919
+      modifiedTime: 1781671413003
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!1zzRQps9jZdLZGqI.xQcDItxuubU3H6Cr'
+  - _id: i6GFKFUS8gJQQ849
+    name: Devil Sight
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>Magical &amp;reference[darkness] doesn't impede the [[lookup @name
+          lowercase]]{monster}'s &amp;reference[Darkvision].</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: devil-sight
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/creatures/eyes/lizard-single-slit-pink.webp
+    effects: []
+    folder: null
+    sort: 100000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781671410868
+      modifiedTime: 1781671411930
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.UjbgbOnd6ltjagZm
+    _key: '!actors.items!1zzRQps9jZdLZGqI.i6GFKFUS8gJQQ849'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1436,7 +1620,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171199419

--- a/packs/_source/monsters/fiend/imp.yml
+++ b/packs/_source/monsters/fiend/imp.yml
@@ -455,9 +455,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -472,7 +469,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -492,11 +489,12 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 0.5
 items:
   - _id: 9ioH5ocevSRjYBaD
     name: Shapechanger
     type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
     system:
       description:
         value: >-
@@ -519,65 +517,96 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties:
         - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        pXG82JA5sw7GF11D:
+          type: transform
+          name: Shapeshift
+          img: ''
+          sort: 100000
           activation:
             type: action
-            value: 1
-            condition: ''
             override: false
+            condition: ''
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
-              special: ''
-            prompt: true
+              type: ''
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          profiles:
+            - name: Rat
+              _id: p7SLorpuBrwc2IGY
+              uuid: Compendium.dnd5e.monsters.Actor.pozQUPTnLZW8epox
+              level:
+                min: null
+                max: null
+              movement: []
+              sizes: []
+              types: []
+            - name: Raven
+              _id: DPTp2z3B8UDGsbAQ
+              uuid: Compendium.dnd5e.monsters.Actor.LPdX5YLlwci0NDZx
+              level:
+                min: null
+                max: null
+              movement: []
+              sizes: []
+              types: []
+            - name: Spider
+              _id: 1OR7BiWrDkYMiSLs
+              uuid: Compendium.dnd5e.monsters.Actor.28gU50HtG8Kp7uIz
+              level:
+                min: null
+                max: null
+              movement: []
+              sizes: []
+              types: []
+          settings: null
+          transform:
+            customize: false
+            mode: ''
+            preset: polymorphSelf
+          _id: pXG82JA5sw7GF11D
       enchant: {}
       prerequisites:
         level: null
@@ -591,122 +620,28 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.VhByyxHJN7MNQJRd
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956891381
+      systemVersion: 6.0.0
+      createdTime: 1781801478899
+      modifiedTime: 1781801565790
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!dLQiESMsfsXijD5c.9ioH5ocevSRjYBaD'
-  - _id: OljCWQpwojS4FKur
-    name: Devil's Sight
-    type: feat
-    img: icons/magic/perception/eye-slit-pink.webp
-    system:
-      description:
-        value: <p>Magical darkness doesn't impede the imp's darkvision.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: devils-sight
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!dLQiESMsfsXijD5c.OljCWQpwojS4FKur'
-  - _id: sl0CxgkL7SkRIv7j
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The imp has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!dLQiESMsfsXijD5c.sl0CxgkL7SkRIv7j'
   - _id: 64Swhse7QnbiLAbi
     name: Sting (Bite in Beast Form)
     type: weapon
-    img: icons/creatures/abilities/fang-tooth-venomous.webp
+    img: icons/creatures/abilities/stinger-poison-green.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
           make on a [[/save]] saving throw, taking [[/damage average
-          activity=dnd5eactivity100]] damage on a failed save, or half as much
+          activity=hUmRNvmmpY5rJfVE]] damage on a failed save, or half as much
           damage on a successful one.</p>
         chat: >-
-          <p>The Imp attacks with its Sting. The target must make a
-          <strong>Constitution</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. The target must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -769,7 +704,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -778,8 +713,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        dljgnmOafe7LqxcY:
           type: attack
           activation:
             type: action
@@ -794,69 +728,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-          duration:
-            concentration: false
             value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '5'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: dex
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts: []
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
           duration:
             concentration: false
             value: ''
@@ -877,10 +749,90 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          attack:
+            ability: ''
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: ''
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: dljgnmOafe7LqxcY
+          name: ''
+        hUmRNvmmpY5rJfVE:
+          type: save
+          activation:
+            type: special
+            value: 1
+            condition: When a creature is hit by this attack.
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The target must make on a [[/save]] saving throw, taking
+              [[/damage average activity=hUmRNvmmpY5rJfVE]] damage on a failed
+              save, or half as much damage on a successful one.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '5'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -896,19 +848,33 @@ items:
                   enabled: false
                   formula: ''
                 number: 3
-                denomination: '6'
+                denomination: 6
                 bonus: ''
                 types:
                   - poison
+                scaling:
+                  number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '11'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 200000
           name: ''
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: hUmRNvmmpY5rJfVE
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -919,35 +885,33 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747956945254
+      systemVersion: 6.0.0
+      createdTime: 1781801371223
+      modifiedTime: 1781801439187
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!dLQiESMsfsXijD5c.64Swhse7QnbiLAbi'
-  - _id: mMdtSlNy6FuPju7p
+  - _id: ABjkKWIBbRYp2fy5
     name: Invisibility
     type: feat
-    img: icons/creatures/webs/webthin-blue.webp
+    img: icons/creatures/magical/spirit-undead-ghost-blue.webp
     system:
       description:
         value: >-
-          <p>The imp magically turns invisible until it attacks, or until its
-          concentration ends (as if concentrating on a spell). Any equipment the
-          imp wears or carries is invisible with it.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically turns
+          &amp;reference[invisible] until it attacks or until its concentration
+          ends (as if concentrating on a spell). Any equipment the [[lookup
+          @name lowercase]]{monster} wears or carries is invisible with it.</p>
         chat: >-
-          <p>The imp magically turns invisible. Any equipment the imp wears or
-          carries is invisible with it.</p>
+          <p>The [[lookup @name]]{monster} magically turns
+          &amp;reference[invisible]. Any equipment the [[lookup @name]]{monster}
+          wears or carries is invisible with it.</p>
       source:
         custom: ''
         book: ''
@@ -960,13 +924,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        CaKaGslGFsgCW6kV:
           type: utility
           activation:
             type: action
@@ -981,15 +945,20 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-          duration:
-            concentration: false
             value: ''
-            units: ''
+          duration:
+            concentration: true
+            value: '1'
+            units: disp
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: dJA0IOGziAr9Onj9
+              level:
+                min: null
+                max: null
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1000,7 +969,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1017,28 +987,191 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: CaKaGslGFsgCW6kV
+          name: Become Invisible
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: invisibility
-    effects: []
+      advancement: {}
+      crewed: false
+    effects:
+      - name: Invisibility
+        img: icons/creatures/magical/spirit-undead-ghost-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.bwtkdzavdNHISgp4.Item.MLfZqvhaJjB78YiT
+        transfer: false
+        _id: dJA0IOGziAr9Onj9
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are &amp;reference[invisible] until you attack or until your
+          concentration ends (as if concentrating on a spell). Any equipment you
+          are wearing or carrying is invisible as well.</p>
+        tint: '#ffffff'
+        statuses:
+          - invisible
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781801344002
+          modifiedTime: 1781801458402
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!dLQiESMsfsXijD5c.ABjkKWIBbRYp2fy5.dJA0IOGziAr9Onj9
     folder: null
-    sort: 200000
+    sort: 650000
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.dA5X2eQuOtHywpQF
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.bwtkdzavdNHISgp4.Item.MLfZqvhaJjB78YiT
+      duplicateSource: Item.6c4SMQeuAWhmqOHx
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956927936
+      systemVersion: 6.0.0
+      createdTime: 1781801344002
+      modifiedTime: 1781801361969
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!dLQiESMsfsXijD5c.mMdtSlNy6FuPju7p'
+    _key: '!actors.items!dLQiESMsfsXijD5c.ABjkKWIBbRYp2fy5'
+  - _id: 4fV0Bx98jhEx562G
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 100000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781801462838
+      modifiedTime: 1781801466565
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!dLQiESMsfsXijD5c.4fV0Bx98jhEx562G'
+  - _id: mE8GYyYeV3dIxYMF
+    name: Devil Sight
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>Magical &amp;reference[darkness] doesn't impede the [[lookup @name
+          lowercase]]{monster}'s &amp;reference[Darkvision].</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: devil-sight
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/creatures/eyes/lizard-single-slit-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781801465657
+      modifiedTime: 1781801465657
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.UjbgbOnd6ltjagZm
+    _key: '!actors.items!dLQiESMsfsXijD5c.mE8GYyYeV3dIxYMF'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1047,7 +1180,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171244145

--- a/packs/_source/monsters/fiend/lemure.yml
+++ b/packs/_source/monsters/fiend/lemure.yml
@@ -452,9 +452,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -469,7 +466,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -489,64 +486,23 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
-  - _id: zEGUljO44aDmj8z5
-    name: Devil's Sight
-    type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
-    system:
-      description:
-        value: <p>Magical darkness doesn't impede the lemure's darkvision.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: Lemure
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: devils-sight
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!tubcO7kaQ4w0soxS.zEGUljO44aDmj8z5'
   - _id: 7gfe5c1qGIvai12V
     name: Hellish Rejuvenation
     type: feat
-    img: icons/skills/wounds/anatomy-organ-heart-red.webp
+    img: icons/creatures/unholy/demon-fanged-horned-yellow.webp
     system:
       description:
         value: >-
-          <p>A lemure that dies in the Nine Hells sometimes comes back to comes
-          back to life with all its hit points in [[/r 1d10]] days unless it is
-          killed by a good-aligned creature with a bless spell cast on that
-          creature or its remains are sprinkled with holy water.</p>
+          <p>A [[lookup @name lowercase]]{monster} that dies in the Nine Hells
+          sometimes comes back to comes back to life with all its hit points in
+          [[/r 1d10 #Days until the lemure revives.]] days unless it is killed
+          by a good-aligned creature with a
+          @UUID[Compendium.dnd5e.spells.Item.8dzaICjGy6mTUaUr]{Bless} spell cast
+          on that creature or its remains are sprinkled with
+          @UUID[Compendium.dnd5e.equipment24.Item.nshr9PBVyB03T7wB]{Holy
+          Water}.</p>
         chat: >-
           <p>A lemure that dies in the Nine Hells sometimes comes back to
           life.</p>
@@ -562,93 +518,43 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
-      requirements: Lemure
-      properties: []
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: ''
-            value: null
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: 1d10
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
       enchant: {}
       prerequisites:
         level: null
       identifier: hellish-rejuvenation
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.XmLuhZYd9WnCWBlU
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957510158
+      systemVersion: 6.0.0
+      createdTime: 1781640254426
+      modifiedTime: 1781640343967
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!tubcO7kaQ4w0soxS.7gfe5c1qGIvai12V'
   - _id: TypCj0S846TqsHzI
     name: Fist
     type: weapon
-    img: icons/magic/fire/flame-burning-fist-strike.webp
+    img: icons/equipment/hand/gauntlet-simple-leather-brown-gold.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Lemure attacks with its Fist.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -711,17 +617,16 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: simpleM
+        value: natural
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        qHbmwJZFvVxyvKy3:
           type: attack
           activation:
             type: action
@@ -736,10 +641,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -756,7 +662,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -769,24 +676,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: qHbmwJZFvVxyvKy3
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: fist
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -796,14 +716,67 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107553926
+      systemVersion: 6.0.0
+      createdTime: 1781640380641
+      modifiedTime: 1781640406035
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!tubcO7kaQ4w0soxS.TypCj0S846TqsHzI'
+  - _id: Di9DB6UXL4OOVV0b
+    name: Devil Sight
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>Magical &amp;reference[darkness] doesn't impede the [[lookup @name
+          lowercase]]{monster}'s &amp;reference[Darkvision].</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: devil-sight
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/creatures/eyes/lizard-single-slit-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781640251133
+      modifiedTime: 1781640251133
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.UjbgbOnd6ltjagZm
+    _key: '!actors.items!tubcO7kaQ4w0soxS.Di9DB6UXL4OOVV0b'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -812,7 +785,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171264005

--- a/packs/_source/monsters/fiend/marilith.yml
+++ b/packs/_source/monsters/fiend/marilith.yml
@@ -547,8 +547,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} can make seven attacks: six
-          with its [[/item .VzPNwzlwJ7knJ9MC]]{Longswords} and one with its
-          [[/item .BoIambnHLbZXr85T]]{Tail}.</p>
+          with its [[/item .VzPNwzlwJ7knJ9MC]]{longswords} and one with its
+          [[/item .BoIambnHLbZXr85T]]{tail}.</p>
         chat: ''
       source:
         custom: ''

--- a/packs/_source/monsters/fiend/marilith.yml
+++ b/packs/_source/monsters/fiend/marilith.yml
@@ -454,9 +454,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -471,7 +468,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -491,108 +488,17 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
-  - _id: JT4JWvnmmQnEJ2qv
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The marilith has advantage on saving throws against spells and
-          other magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747956992088
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!egsSDYbqoLCelb0J.JT4JWvnmmQnEJ2qv'
-  - _id: e5syW3Oa9yNGZ09T
-    name: Magic Weapons
-    type: feat
-    img: icons/weapons/swords/sword-runed-glowing.webp
-    system:
-      description:
-        value: <p>The marilith's weapon attacks are magical.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-weapons
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nahRRxck9R5GVVFS
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!egsSDYbqoLCelb0J.e5syW3Oa9yNGZ09T'
   - _id: rBHEI0gZnnv8h44g
     name: Reactive
     type: feat
-    img: icons/magic/symbols/rune-sigil-black-pink.webp
+    img: icons/skills/melee/strikes-sword-scimitar.webp
     system:
       description:
-        value: <p>The marilith can take one reaction on every turn in combat.</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can take one reaction on
+          every turn in combat.</p>
         chat: ''
       source:
         custom: ''
@@ -606,10 +512,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -617,19 +524,19 @@ items:
       identifier: reactive
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.lhTQJsLKYUZT2gV5
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781640656665
+      modifiedTime: 1781640689390
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!egsSDYbqoLCelb0J.rBHEI0gZnnv8h44g'
   - _id: nEKlIbUhhx9akBjK
@@ -639,9 +546,9 @@ items:
     system:
       description:
         value: >-
-          <p>The marilith can make seven attacks: six with its [[/item
-          .VzPNwzlwJ7knJ9MC]]{longswords} and one with its [[/item
-          .BoIambnHLbZXr85T]]{tail}.</p>
+          <p>The [[lookup @name lowercase]]{monster} can make seven attacks: six
+          with its [[/item .VzPNwzlwJ7knJ9MC]]{Longswords} and one with its
+          [[/item .BoIambnHLbZXr85T]]{Tail}.</p>
         chat: ''
       source:
         custom: ''
@@ -655,13 +562,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        EjFEaoe6iXJVBbDn:
           type: utility
           activation:
             type: action
@@ -676,15 +582,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -695,7 +602,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -712,7 +620,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: EjFEaoe6iXJVBbDn
       enchant: {}
       prerequisites:
         level: null
@@ -726,22 +642,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273656580
+      systemVersion: 6.0.0
+      createdTime: 1781641044474
+      modifiedTime: 1781641049283
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!egsSDYbqoLCelb0J.nEKlIbUhhx9akBjK'
   - _id: VzPNwzlwJ7knJ9MC
     name: Longsword
     type: weapon
-    img: icons/weapons/swords/greatsword-crossguard-steel.webp
+    img: icons/weapons/swords/shortsword-broad-engraved.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Marilith attacks with its Longsword.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -805,7 +723,7 @@ items:
         conditions: ''
       properties:
         - mgc
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -814,8 +732,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        jESnw2fwUUBwYqrk:
           type: attack
           activation:
             type: action
@@ -830,10 +747,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -850,7 +768,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -863,23 +782,35 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: jESnw2fwUUBwYqrk
+          name: ''
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: longsword
       mastery: ''
     effects: []
@@ -891,18 +822,18 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.10ZP2Bu3vnCuYMIB
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378599594
+      systemVersion: 6.0.0
+      createdTime: 1781640999314
+      modifiedTime: 1781641025827
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!egsSDYbqoLCelb0J.VzPNwzlwJ7knJ9MC'
   - _id: BoIambnHLbZXr85T
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-swipe-green.webp
     system:
       description:
         value: >-
@@ -912,11 +843,13 @@ items:
           target with its tail, and the marilith can't make tail attacks against
           other targets.</p>
         chat: >-
-          <p>The Marilith attacks with its Tail. If the target is Medium or
-          smaller, it is grappled. Until this grapple ends, the target is
-          restrained, the marilith can automatically hit the target with its
-          tail, and the marilith can't make tail attacks against other
-          targets.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. If the target is Medium or smaller, it is
+          &amp;referemce[grappled]. Until this grapple ends, the target is
+          &amp;reference[restrained], the [[lookup @name]]{monster} can
+          automatically hit the target with its tail, and the [[lookup
+          @name]]{monster} can't make [[lookup @item.name lowercase]] attacks
+          against other targets.</p>
       source:
         custom: ''
         book: ''
@@ -940,7 +873,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -980,8 +913,7 @@ items:
         conditions: ''
       properties:
         - mgc
-        - rch
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -990,8 +922,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        gXLH8C1oOyQiIDoJ:
           type: attack
           activation:
             type: action
@@ -1006,10 +937,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1026,7 +958,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1045,17 +978,29 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: gXLH8C1oOyQiIDoJ
+          name: ''
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: tail
       mastery: ''
     effects: []
@@ -1067,21 +1012,21 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378603401
+      systemVersion: 6.0.0
+      createdTime: 1781640799143
+      modifiedTime: 1781640989575
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!egsSDYbqoLCelb0J.BoIambnHLbZXr85T'
   - _id: EMJe4NIzUdNIQj9S
     name: Teleport
     type: feat
-    img: icons/magic/symbols/runes-star-pentagon-magenta.webp
+    img: icons/magic/symbols/ring-circle-smoke-blue.webp
     system:
       description:
-        value: "<p>The marilith\_magically\_teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space\_it can see.</p>"
+        value: "<p>The [[lookup @name lowercase]]{monster}\_magically\_teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space\_it can see.</p>"
         chat: >-
           <section class="secret"><p></p></section><p>The marilith magically
           teleports, along with any equipment it is wearing or carrying, up to
@@ -1098,13 +1043,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        NywngA99aYzVVRFV:
           type: utility
           activation:
             type: action
@@ -1119,10 +1064,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1139,10 +1085,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: space
               choice: false
               special: ''
             prompt: true
@@ -1156,7 +1103,19 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: NywngA99aYzVVRFV
+          name: Teleport
       enchant: {}
       prerequisites:
         level: null
@@ -1170,27 +1129,28 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.PPzVD90vab60FqCt
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957059399
+      systemVersion: 6.0.0
+      createdTime: 1781640742790
+      modifiedTime: 1781640787749
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!egsSDYbqoLCelb0J.EMJe4NIzUdNIQj9S'
   - _id: lS2o3QOZ2lxKyi0L
     name: Parry
     type: feat
-    img: icons/skills/melee/weapons-crossed-swords-yellow-teal.webp
+    img: icons/skills/melee/swords-parry-block-yellow.webp
     system:
       description:
         value: >-
-          <p>The marlith adds 5 to its AC against one melee Attack that would
-          hit it. To do so, the marlith must see the attacker and be wielding a
-          melee weapon.</p>
+          <p>The [[lookup @name lowercase]]{monster} adds 5 to its AC against
+          one melee attack that would hit it. To do so, the [[lookup @name
+          lowercase]]{monster} must see the attacker and be wielding a melee
+          weapon.</p>
         chat: >-
-          <p>The marlith adds 5 to its <strong>AC</strong> against one melee
-          Attack that would hit it.</p>
+          <p>The [[lookup @name]]{monster} adds 5 to its AC against one melee
+          attack that would hit it.</p>
       source:
         custom: ''
         book: ''
@@ -1203,18 +1163,19 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        5RUe1bRJr64laA0l:
           type: utility
           activation:
             type: reaction
             value: 1
-            condition: ''
+            condition: >-
+              When the [[lookup @name lowercase]]{monster} would be hit by a
+              melee attack while it is wielding a melee weapon.
             override: false
           consumption:
             targets: []
@@ -1224,15 +1185,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1243,10 +1205,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1260,7 +1223,19 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: Parry Attack
+          _id: 5RUe1bRJr64laA0l
       enchant: {}
       prerequisites:
         level: null
@@ -1274,14 +1249,120 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.kfi26Jy0VLXv9TTm
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957066760
+      systemVersion: 6.0.0
+      createdTime: 1781641058843
+      modifiedTime: 1781667086282
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!egsSDYbqoLCelb0J.lS2o3QOZ2lxKyi0L'
+  - _id: bbSTKf4I6P8WpLkz
+    name: Magic Weapons
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster}'s weapon attacks are
+          magical.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-weapons
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/weapons/swords/sword-runed-glowing.webp
+    effects: []
+    folder: null
+    sort: 75000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781640682117
+      modifiedTime: 1781640696163
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.nahRRxck9R5GVVFS
+    _key: '!actors.items!egsSDYbqoLCelb0J.bbSTKf4I6P8WpLkz'
+  - _id: UnrtjJToJnn6qgVC
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 50000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781640694580
+      modifiedTime: 1781640695382
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!egsSDYbqoLCelb0J.UnrtjJToJnn6qgVC'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1290,7 +1371,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 5.1.0
   createdTime: 1726171245247

--- a/packs/_source/monsters/fiend/nalfeshnee.yml
+++ b/packs/_source/monsters/fiend/nalfeshnee.yml
@@ -499,8 +499,8 @@ items:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} uses [[/item
           .RFPDYIhkmBW2B47S]]{Horror Nimbus} if it can. It then makes three
-          attacks: one with its [[/item .524dkWbpWUJKFaj2]]{Bite} and two with
-          its [[/item .xhKo80CbyA57Kl1l]]{Claws}.</p>
+          attacks: one with its [[/item .524dkWbpWUJKFaj2]]{bite} and two with
+          its [[/item .xhKo80CbyA57Kl1l]]{claws}.</p>
         chat: ''
       source:
         custom: ''

--- a/packs/_source/monsters/fiend/nalfeshnee.yml
+++ b/packs/_source/monsters/fiend/nalfeshnee.yml
@@ -454,9 +454,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -471,7 +468,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -491,55 +488,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
-  - _id: jZeQHAOQV365hmZF
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The nalfeshnee has advantage on saving throws against spells and
-          other magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957072839
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!rUg5JMnKNnZNBAq9.jZeQHAOQV365hmZF'
   - _id: swlYyGYwkdNzuRkG
     name: Multiattack
     type: feat
@@ -547,10 +497,10 @@ items:
     system:
       description:
         value: >-
-          <p>The nalfeshnee uses [[/item .RFPDYIhkmBW2B47S]]{Horror Nimbus} if
-          it can. It then makes three attacks: one with its [[/item
-          .524dkWbpWUJKFaj2]]{bite} and two with its [[/item
-          .xhKo80CbyA57Kl1l]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} uses [[/item
+          .RFPDYIhkmBW2B47S]]{Horror Nimbus} if it can. It then makes three
+          attacks: one with its [[/item .524dkWbpWUJKFaj2]]{Bite} and two with
+          its [[/item .xhKo80CbyA57Kl1l]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -564,13 +514,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        PNSvDHvNCMsHXYWm:
           type: utility
           activation:
             type: action
@@ -585,15 +534,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -604,7 +554,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -621,7 +572,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: PNSvDHvNCMsHXYWm
       enchant: {}
       prerequisites:
         level: null
@@ -635,22 +594,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273657367
+      systemVersion: 6.0.0
+      createdTime: 1781793591550
+      modifiedTime: 1781793596259
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!rUg5JMnKNnZNBAq9.swlYyGYwkdNzuRkG'
   - _id: 524dkWbpWUJKFaj2
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Nalfeshnee attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name lowercase]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -713,7 +674,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -722,8 +683,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        rEXxJb0k6IQUPfFc:
           type: attack
           activation:
             type: action
@@ -738,10 +698,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -758,7 +719,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -771,24 +733,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: rEXxJb0k6IQUPfFc
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -798,22 +773,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107553648
+      systemVersion: 6.0.0
+      createdTime: 1781793547030
+      modifiedTime: 1781793563220
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!rUg5JMnKNnZNBAq9.524dkWbpWUJKFaj2'
   - _id: xhKo80CbyA57Kl1l
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-glowing-orange.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Nalfeshnee attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name lowercase]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -837,7 +814,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -875,9 +852,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -886,8 +862,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        zSquIy2mUfmQeIP4:
           type: attack
           activation:
             type: action
@@ -902,10 +877,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -922,7 +898,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -941,18 +918,31 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: zSquIy2mUfmQeIP4
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -962,11 +952,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107553648
+      systemVersion: 6.0.0
+      createdTime: 1781793500303
+      modifiedTime: 1781793541750
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!rUg5JMnKNnZNBAq9.xhKo80CbyA57Kl1l'
@@ -977,14 +967,15 @@ items:
     system:
       description:
         value: >-
-          <p>The nalfeshnee magically emits scintillating, multicolored light.
-          Each creature within 15 feet of the nalfeshnee that can see the light
-          must succeed on a [[/save]] saving throw or be
-          &amp;Reference[frightened] for 1 minute.</p><p>A creature can repeat
-          the saving throw at the end of each of its turns, ending the effect on
-          itself on a success. If a creature's saving throw is successful or the
-          effect ends for it, the creature is immune to the nalfeshnee's Horror
-          Nimbus for the next 24 hours.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically emits
+          scintillating, multicolored light. Each creature within 15 feet of the
+          [[lookup @name lowercase]]{monster} that can see the light must
+          succeed on a [[/save]] saving throw or be &amp;Reference[frightened]
+          for 1 minute.</p><p>A creature can repeat the saving throw at the end
+          of each of its turns, ending the effect on itself on a success. If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{monster}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
         chat: >-
           <p>A creature can repeat the saving throw at the end of each of its
           turns, ending the effect on itself on a success. If a creature's
@@ -1021,11 +1012,9 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
@@ -1038,7 +1027,12 @@ items:
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: 8yRrVxNl9Ndvr6F8
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             units: self
             special: ''
@@ -1064,19 +1058,68 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
             ability: wis
             dc:
               calculation: ''
               formula: '15'
+            bonus: ''
           sort: 0
+          name: Frighten
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
       enchant: {}
       prerequisites:
         level: null
       identifier: horror-nimbus
-    effects: []
+    effects:
+      - name: Horror Nimbus
+        img: icons/creatures/unholy/demons-horned-glowing-pink.webp
+        origin: Compendium.dnd5e.monsters.Actor.rUg5JMnKNnZNBAq9.Item.RFPDYIhkmBW2B47S
+        transfer: false
+        _id: 8yRrVxNl9Ndvr6F8
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for 1
+          minute.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781645330454
+          modifiedTime: 1781645403530
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!rUg5JMnKNnZNBAq9.RFPDYIhkmBW2B47S.8yRrVxNl9Ndvr6F8
     folder: null
     sort: 0
     ownership:
@@ -1085,25 +1128,79 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hu2pgYS1RD7hglvg
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957090259
+      systemVersion: 6.0.0
+      createdTime: 1781645326750
+      modifiedTime: 1781645453235
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!rUg5JMnKNnZNBAq9.RFPDYIhkmBW2B47S'
-  - _id: zK5E9yD6BR0fZRBo
-    name: Teleport
+  - _id: FHVDMSqY433bBryM
+    name: Magic Resistance
+    ownership:
+      default: 0
     type: feat
-    img: icons/magic/symbols/runes-star-pentagon-magenta.webp
     system:
       description:
-        value: "<p>The nalfeshnee magically teleports, along with any equipment\_it\_is wearing\_or\_carrying, up to 120 feet\_to\_an\_unoccupied\_space it can\_see.</p>"
-        chat: >-
-          <section class="secret"><p></p></section><p>The nalfeshnee magically
-          teleports, along with any equipment it is wearing or carrying, up to
-          120 feet to an unoccupied space it can see.</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781645279933
+      modifiedTime: 1781645279934
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!rUg5JMnKNnZNBAq9.FHVDMSqY433bBryM'
+  - _id: vzwfZvoOTxx0afIN
+    name: Teleport
+    type: feat
+    img: icons/magic/symbols/ring-circle-smoke-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} magically teleports, along
+          with any equipment it is wearing or carrying, up to [[lookup
+          @labels.description.range activity=ceqRWRMK1a37epib]] to an unoccupied
+          space it can see.</p>
+        chat: ''
       source:
         custom: ''
         book: ''
@@ -1116,17 +1213,17 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        ceqRWRMK1a37epib:
           type: utility
           activation:
             type: action
-            value: 1
+            value: null
             condition: ''
             override: false
           consumption:
@@ -1137,10 +1234,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1157,7 +1255,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1174,28 +1273,44 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          name: Reposition
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: ceqRWRMK1a37epib
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: teleport
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
-    sort: 0
+    sort: 118750
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.PPzVD90vab60FqCt
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.lOYt73eaJojBDxAV.Item.H4Qnl5aNwIuOiKvm
+      duplicateSource: Item.F4RvgKoeOdcVw8YS
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957138149
+      systemVersion: 6.0.0
+      createdTime: 1781793470620
+      modifiedTime: 1781793476970
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!rUg5JMnKNnZNBAq9.zK5E9yD6BR0fZRBo'
+    _key: '!actors.items!rUg5JMnKNnZNBAq9.vzwfZvoOTxx0afIN'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1204,7 +1319,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171261206

--- a/packs/_source/monsters/fiend/night-hag.yml
+++ b/packs/_source/monsters/fiend/night-hag.yml
@@ -456,9 +456,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -473,7 +470,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -493,6 +490,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: bUkTkdnQ3XbRcXkD
     name: Innate Spellcasting
@@ -542,7 +540,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -735,7 +733,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.J6Jpw5XzB5aTeqnz
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -743,62 +741,16 @@ items:
       lastModifiedBy: null
       exportSource: null
     _key: '!actors.items!xvh2UOKv1bh03Gih.9Gf1hal94HjuAHMN'
-  - _id: OMZ6qNK1bdpI8ryh
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The hag has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957153574
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!xvh2UOKv1bh03Gih.OMZ6qNK1bdpI8ryh'
   - _id: Um3cK4i4ZQSTqodb
     name: Claws (Hag Form Only)
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-glowing-purple.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Night Hag attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -861,7 +813,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -870,8 +822,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        x7F4Avg3BO3HExQX:
           type: attack
           activation:
             type: action
@@ -886,10 +837,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -906,7 +858,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -919,24 +872,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: x7F4Avg3BO3HExQX
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claws-hag-form-only
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -946,25 +912,26 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107554139
+      systemVersion: 6.0.0
+      createdTime: 1781797148332
+      modifiedTime: 1781797197662
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!xvh2UOKv1bh03Gih.Um3cK4i4ZQSTqodb'
   - _id: ftmaVOSJXvHPhraJ
     name: Change Shape
     type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
     system:
       description:
         value: >-
-          <p>The hag magically polymorphs into a Small or Medium female
-          humanoid, or back into her true form. Her statistics are the same in
-          each form. Any equipment she is wearing or carrying isn't transformed.
-          She reverts to her true form if she dies.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically polymorphs into a
+          Small or Medium female humanoid, or back into her true form. Her
+          statistics are the same in each form. Any equipment she is wearing or
+          carrying isn't transformed. She reverts to her true form if she
+          dies.</p>
         chat: ''
       source:
         custom: ''
@@ -978,64 +945,78 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        CTYIMIlC30bYuq9I:
+          type: transform
+          name: Transform
+          _id: CTYIMIlC30bYuq9I
+          img: ''
+          sort: 100000
           activation:
             type: action
-            value: 1
-            condition: ''
             override: false
+            condition: ''
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
-              special: ''
-            prompt: true
+              type: ''
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - name: ''
+              _id: 38uM2l8UeX75XsYT
+              uuid: Compendium.dnd5e.monsters.Actor.SqZRuJ8lt2KGJBbq
+              level:
+                min: null
+                max: null
+              movement: []
+              sizes: []
+              types: []
+          settings: null
+          transform:
+            customize: false
+            mode: ''
+            preset: polymorphSelf
       enchant: {}
       prerequisites:
         level: null
@@ -1049,28 +1030,30 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.JsAys4RSGi4lN5Jy
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957160662
+      systemVersion: 6.0.0
+      createdTime: 1781797230538
+      modifiedTime: 1781797406783
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!xvh2UOKv1bh03Gih.ftmaVOSJXvHPhraJ'
   - _id: 0blKOND2AnsMsZa6
     name: Etherealness
     type: feat
-    img: icons/magic/unholy/barrier-shield-glowing-pink.webp
+    img: icons/magic/unholy/silhouette-robe-evil-glow.webp
     system:
       description:
         value: >-
-          <p>The hag magically enters the Ethereal Plane from the Material
-          Plane, or vice versa. To do so, the hag must have a
-          <em>heartstone</em> in her possession.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically enters the
+          Ethereal Plane from the Material Plane, or vice versa. To do so, the
+          [[lookup @name lowercase]]{monster} must have a <em>heartstone</em> in
+          her possession.</p>
         chat: >-
-          <section class="secret"><p></p></section><p>The hag magically enters
-          the Ethereal Plane from the Material Plane, or vice versa. To do so,
-          the hag must have a heartstone in her possession.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically enters the
+          Ethereal Plane from the Material Plane, or vice versa. To do so, the
+          [[lookup @name lowercase]]{monster} must have a heartstone in her
+          possession.</p>
       source:
         custom: ''
         book: ''
@@ -1083,13 +1066,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        yFm9Vg5vVLjCxS7q:
           type: utility
           activation:
             type: action
@@ -1104,15 +1087,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1123,7 +1107,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1140,7 +1125,19 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          name: Traverse Planes
+          _id: yFm9Vg5vVLjCxS7q
       enchant: {}
       prerequisites:
         level: null
@@ -1154,32 +1151,36 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.rDoNJnKdY47x8MD4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957200757
+      systemVersion: 6.0.0
+      createdTime: 1781793642303
+      modifiedTime: 1781799194867
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!xvh2UOKv1bh03Gih.0blKOND2AnsMsZa6'
   - _id: tYZggJHgAbixP5rs
     name: Nightmare Haunting
     type: feat
-    img: icons/commodities/tech/smoke-bomb-purple.webp
+    img: icons/magic/unholy/silhouette-light-fire-blue.webp
     system:
       description:
         value: >-
-          <p>While on the Ethereal Plane, the hag magically touches a sleeping
-          humanoid on the Material Plane. A protection from evil and good spell
-          cast on the target prevents this contact, as does a magic circle.
-          </p><p>As long as the contact persists, the target has dreadful
-          visions. If these visions last for at least 1 hour, the target gains
-          no benefit from its rest, and its hit point maximum is reduced by 5
-          (1d10). If this effect reduces the target's hit point maximum to 0,
-          the target dies, and if the target was evil, its soul is trapped in
-          the hag's soul bag. The reduction to the target's hit point maximum
-          lasts until removed by the greater restoration spell or similar
-          magic.</p>
+          <p>While on the Ethereal Plane, the [[lookup @name
+          lowercase]]{monster} magically touches a sleeping humanoid on the
+          Material Plane. A
+          @UUID[Compendium.dnd5e.spells.Item.xmDBqZhRVrtLP8h2]{Protection from
+          Evil and Good} spell cast on the target prevents this contact, as does
+          a @UUID[Compendium.dnd5e.spells.Item.y8A4HfTwd93ypdEz]{Magic
+          Circle}.</p><p>As long as the contact persists, the target has
+          dreadful visions. If these visions last for at least 1 hour, the
+          target gains no benefit from its rest, and its hit point maximum is
+          reduced by 5 (1d10). If this effect reduces the target's hit point
+          maximum to 0, the target dies, and if the target was evil, its soul is
+          trapped in the hag's soul bag. The reduction to the target's hit point
+          maximum lasts until removed by the
+          @UUID[Compendium.dnd5e.spells.Item.WzvJ7G3cqvIubsLk]{Greater
+          Restoration} spell or similar magic.</p>
         chat: >-
           <p>While on the Ethereal Plane, the hag magically touches a sleeping
           humanoid on the Material Plane. As long as the contact persists, the
@@ -1198,13 +1199,13 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        sqyzSx2CwAVKAFE1:
           type: utility
           activation:
             type: action
@@ -1214,26 +1215,25 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1244,7 +1244,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1261,7 +1262,19 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: sqyzSx2CwAVKAFE1
+          name: Induce Nightmares
       enchant: {}
       prerequisites:
         level: null
@@ -1275,11 +1288,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.VbBHypDc0eLWbsNE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.2.0
-      createdTime: null
-      modifiedTime: 1736804676758
+      systemVersion: 6.0.0
+      createdTime: 1781793662770
+      modifiedTime: 1781799201174
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!xvh2UOKv1bh03Gih.tYZggJHgAbixP5rs'
@@ -1392,7 +1405,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ghXTfe7sgCbgf1Q8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1513,7 +1526,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.41JIhpDyM9Anm7cs
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1695,7 +1708,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ODhLKBxLnvvLOnw1
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1839,7 +1852,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.KhwiSi9fwVfUPtku
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1847,6 +1860,59 @@ items:
       lastModifiedBy: null
       exportSource: null
     _key: '!actors.items!xvh2UOKv1bh03Gih.KhwiSi9fwVfUPtku'
+  - _id: F9SUUafNFPf0hmqr
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781793604022
+      modifiedTime: 1781793604022
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!xvh2UOKv1bh03Gih.F9SUUafNFPf0hmqr'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1855,7 +1921,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171266109

--- a/packs/_source/monsters/fiend/nightmare.yml
+++ b/packs/_source/monsters/fiend/nightmare.yml
@@ -419,35 +419,32 @@ prototypeToken:
   randomImg: false
   alpha: 1
   light:
-    alpha: 1
+    alpha: 0.35
     angle: 360
-    bright: 0
+    bright: 10
     coloration: 1
-    dim: 0
+    dim: 20
     luminosity: 0.5
     saturation: 0
     contrast: 0
     shadows: 0
     animation:
-      speed: 5
-      intensity: 5
-      type: null
+      speed: 1
+      intensity: 1
+      type: flame
       reverse: false
     darkness:
       min: 0
       max: 1
     attenuation: 0.5
-    color: null
+    color: '#6c4714'
     negative: false
     priority: 0
   texture:
-    src: null
+    src: systems/dnd5e/tokens/fiend/Nightmare.webp
     tint: '#ffffff'
-    scaleX: 1
-    scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
+    scaleX: 1.5
+    scaleY: 1.5
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -462,7 +459,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -472,7 +469,7 @@ prototypeToken:
     colors:
       ring: null
       background: null
-    effects: 1
+    effects: 0
     subject:
       scale: 1
       texture: null
@@ -482,16 +479,17 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: ez0lp4uo2fLOc5Yf
     name: Confer Fire Resistance
     type: feat
-    img: icons/magic/fire/explosion-mushroom-nuke-orange.webp
+    img: icons/magic/fire/flame-burning-yellow-orange.webp
     system:
       description:
         value: >-
-          <p>The nightmare can grant resistance to <em>fire damage</em> to
-          anyone riding it.</p>
+          <p>The [[lookup @name lowercase]]{monster} can grant resistance to
+          <em>fire damage</em> to anyone riding it.</p>
         chat: ''
       source:
         custom: ''
@@ -505,16 +503,125 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
-      activities: {}
+      properties:
+        - trait
+      activities:
+        pqCpYgARr0z9rs8q:
+          type: utility
+          name: Grant Fire Resistance
+          img: ''
+          sort: 100000
+          activation:
+            type: special
+            override: false
+            condition: >-
+              While a creature is riding the [[lookup @name
+              lowercase]]{monster}.
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: MNgx8MPcSucyc8VN
+              level:
+                min: null
+                max: null
+          flags: {}
+          range:
+            units: touch
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              count: '1'
+              type: creature
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          roll:
+            prompt: false
+            visible: false
+            formula: ''
+            name: ''
+          _id: pqCpYgARr0z9rs8q
       enchant: {}
       prerequisites:
         level: null
       identifier: confer-fire-resistance
-    effects: []
+    effects:
+      - name: Confered Fire Resistance
+        img: icons/magic/fire/flame-burning-yellow-orange.webp
+        origin: Compendium.dnd5e.monsters.Actor.5SgVGhQBswgWRwsF.Item.ez0lp4uo2fLOc5Yf
+        transfer: false
+        _id: MNgx8MPcSucyc8VN
+        type: base
+        system:
+          changes:
+            - key: system.traits.dr.value
+              type: add
+              value: fire
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>The nightmare has confered resistance to fire damage to you while
+          you are riding it.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781641187853
+          modifiedTime: 1781641224891
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!5SgVGhQBswgWRwsF.ez0lp4uo2fLOc5Yf.MNgx8MPcSucyc8VN
     folder: null
     sort: 0
     ownership:
@@ -523,23 +630,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.wzgGJyVFGIcj1XAb
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781641168640
+      modifiedTime: 1781641258840
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!5SgVGhQBswgWRwsF.ez0lp4uo2fLOc5Yf'
   - _id: YXCQq6M3IGaLDz2M
     name: Illumination
     type: feat
-    img: icons/magic/light/explosion-star-glow-blue-purple.webp
+    img: icons/magic/light/explosion-glow-spiral-yellow.webp
     system:
       description:
         value: >-
-          <p>The nightmare sheds bright light in a 10-foot radius and dim light
-          for an additional 10 feet.</p>
+          <p>The [[lookup @name lowercase]]{monster} sheds &amp;reference[bright
+          light] in a 10-foot radius and &amp;reference[dim light] for an
+          additional 10 feet.</p>
         chat: ''
       source:
         custom: ''
@@ -553,10 +661,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -571,11 +680,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.F3gzBbCW7U14zkBF
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957221726
+      systemVersion: 6.0.0
+      createdTime: 1781641272144
+      modifiedTime: 1781641295239
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!5SgVGhQBswgWRwsF.YXCQq6M3IGaLDz2M'
@@ -586,7 +695,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Nightmare attacks with its Hooves.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -649,7 +760,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -658,8 +769,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        qTkLLQjnpd851mxZ:
           type: attack
           activation:
             type: action
@@ -674,10 +784,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -694,7 +805,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -707,36 +819,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: qTkLLQjnpd851mxZ
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: hooves
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -746,28 +869,27 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.re3oXQ3Xg4Z3Fr6O
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107549944
+      systemVersion: 6.0.0
+      createdTime: 1781642856400
+      modifiedTime: 1781642866377
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!5SgVGhQBswgWRwsF.lzv29dS3tAUUuVlI'
   - _id: XtK73VCT1s8abvjs
     name: Ethereal Stride
     type: feat
-    img: icons/magic/lightning/orb-ball-purple.webp
+    img: icons/creatures/magical/spirit-mischief-fire-ice-blue.webp
     system:
       description:
         value: >-
-          <p>The nightmare and up to three willing creatures within 5 feet of it
+          <p>The [[lookup @name lowercase]]{monster} and up to [[lookup
+          @labels.description.affects activity=g0q1v5S5s6ZLTZcz]] within
+          [[lookup @labels.description.range activity=g0q1v5S5s6ZLTZcz]] of it
           magically enter the Ethereal Plane from the Material Plane, or vice
           versa.</p>
-        chat: >-
-          <section class="secret"><p></p></section><p>The nightmare and up to
-          three willing creatures within 5 feet of it magically enter the
-          Ethereal Plane from the Material Plane, or vice versa.</p>
+        chat: ''
       source:
         custom: ''
         book: ''
@@ -780,13 +902,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        g0q1v5S5s6ZLTZcz:
           type: utility
           activation:
             type: action
@@ -801,17 +923,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: ft
             special: ''
             override: false
+            value: '5'
           target:
             template:
               count: ''
@@ -820,10 +944,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '3'
+              type: willing
               choice: false
               special: ''
             prompt: true
@@ -837,7 +962,19 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: g0q1v5S5s6ZLTZcz
+          name: Travel Planes
       enchant: {}
       prerequisites:
         level: null
@@ -851,11 +988,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.NfTCXq8eRrqjhvAo
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957255597
+      systemVersion: 6.0.0
+      createdTime: 1781642543927
+      modifiedTime: 1781642890124
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!5SgVGhQBswgWRwsF.XtK73VCT1s8abvjs'
@@ -867,11 +1004,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171203363
-  modifiedTime: 1726171439705
+  modifiedTime: 1781642697516
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!5SgVGhQBswgWRwsF'

--- a/packs/_source/monsters/fiend/nightmare.yml
+++ b/packs/_source/monsters/fiend/nightmare.yml
@@ -441,10 +441,10 @@ prototypeToken:
     negative: false
     priority: 0
   texture:
-    src: systems/dnd5e/tokens/fiend/Nightmare.webp
+    src: null
     tint: '#ffffff'
-    scaleX: 1.5
-    scaleY: 1.5
+    scaleX: 1
+    scaleY: 1
     anchorX: 0.5
     anchorY: 0.5
     fit: contain

--- a/packs/_source/monsters/fiend/pit-fiend.yml
+++ b/packs/_source/monsters/fiend/pit-fiend.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,24 +492,29 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: wkqjn4bqhPIUUo7k
     name: Fear Aura
     type: feat
-    img: icons/magic/water/elemental-water.webp
+    img: icons/magic/control/fear-fright-monster-grin-red-orange.webp
     system:
       description:
         value: >-
-          <p>Any creature hostile to the pit fiend that starts its turn within
-          20 feet of the pit fiend must make a [[/save]] saving throw, unless
-          the pit fiend is incapacitated. On a failed save, the creature is
-          &amp;Reference[frightened] until the start of its next turn. If a
-          creature's saving throw is successful, the creature is immune to the
-          pit fiend's Fear Aura for the next 24 hours.</p>
+          <p>Any creature hostile to the [[lookup @name lowercase]]{monster}
+          that starts its turn within [[lookup @labels.description.range
+          activity=2EPr5relqpSLmasf]] of the [[lookup @name lowercase]]{monster}
+          must make a [[/save]] saving throw, unless the [[lookup @name
+          lowercase]]{monster} is &amp;reference[incapacitated apply=false]. On
+          a failed save, the creature is &amp;Reference[frightened] until the
+          start of its next turn. If a creature's saving throw is successful,
+          the creature is immune to the [[lookup @name lowercase]]{monster}'s
+          [[lookup @item.name]] for the next 24 hours.</p>
         chat: >-
-          <p>Any creature hostile to the pit fiend that starts its turn
-          <strong>within 20 feet</strong> of the pit fiend must make a
-          <strong>Wisdom</strong> saving throw.</p>
+          <p>Any creature hostile to the [[lookup @name]]{monster} that starts
+          its turn within [[lookup @labels.description.range
+          activity=2EPr5relqpSLmasf]] of the [[lookup @name]]{monster} must make
+          a Wisdom saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -525,19 +527,22 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties:
         - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        2EPr5relqpSLmasf:
           type: save
           activation:
-            type: ''
+            type: special
             value: null
-            condition: ''
+            condition: >-
+              When a creature hostile to the [[lookup @name lowercase]]{monster}
+              starts its turn within range of the [[lookup @name
+              lowercase]]{monster} (unless the [[lookup @name
+              lowercase]]{monster} is &reference[incapacitated apply=false]).
             override: false
           consumption:
             targets: []
@@ -547,29 +552,37 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
-            units: turn
+            units: round
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: 7nIc5RnZTZ9Eocv8
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
-            units: ''
+            units: ft
             special: ''
             override: false
+            value: '20'
           target:
             template:
               count: ''
               contiguous: false
-              type: radius
-              size: '20'
+              type: ''
+              size: ''
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -579,151 +592,103 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
-              calculation: ''
+              calculation: cha
               formula: '21'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Fear Save
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2EPr5relqpSLmasf
       enchant: {}
       prerequisites:
         level: null
       identifier: fear-aura
-    effects: []
+    effects:
+      - name: Terrified
+        img: icons/magic/control/fear-fright-monster-grin-red-orange.webp
+        origin: Compendium.dnd5e.monsters.Actor.RCv5y7iWlfNxkinx.Item.wkqjn4bqhPIUUo7k
+        transfer: false
+        _id: 7nIc5RnZTZ9Eocv8
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: rounds
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] until the start of
+          your next turn.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781643189758
+          modifiedTime: 1781643234729
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!RCv5y7iWlfNxkinx.wkqjn4bqhPIUUo7k.7nIc5RnZTZ9Eocv8
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.MLVEyA7VcWu9uXqV
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957309086
+      systemVersion: 6.0.0
+      createdTime: 1781642904487
+      modifiedTime: 1781643296531
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!RCv5y7iWlfNxkinx.wkqjn4bqhPIUUo7k'
-  - _id: 2MKXiCJeOrUJIEto
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The pit fiend has advantage on saving throws against spells and
-          other magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957270896
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!RCv5y7iWlfNxkinx.2MKXiCJeOrUJIEto'
-  - _id: TT2YmAw82Sj1WNKn
-    name: Magic Weapons
-    type: feat
-    img: icons/weapons/swords/sword-runed-glowing.webp
-    system:
-      description:
-        value: <p>The pit fiend's weapon attacks are magical.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-weapons
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nahRRxck9R5GVVFS
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!RCv5y7iWlfNxkinx.TT2YmAw82Sj1WNKn'
   - _id: 2Wh1GHIIzBfCm8md
     name: Innate Spellcasting
     type: feat
-    img: icons/magic/light/projectiles-star-purple.webp
+    img: icons/magic/symbols/star-yellow.webp
     system:
       description:
         value: >-
-          <p>The pit fiend's spellcasting ability is Charisma (spell save DC
-          21). The pit fiend can innately cast the following spells, requiring
-          no material components:</p>
-
-          <p>At will: [[/item .ghXTfe7sgCbgf1Q8]]{detect magic}, [[/item
-          .ztgcdrWPshKRpFd0]]{fireball}</p>
-
-          <p>3/day each: [[/item .l9Ju5KE7bbn3WpTm]]{hold monster}, [[/item
+          <p>The [[lookup @name lowercase]]{monster}'s spellcasting ability is
+          Charisma (spell save DC 21). The [[lookup @name lowercase]]{monster}
+          can innately cast the following spells, requiring no material
+          components:</p><p><strong>At will:</strong> [[/item
+          .ghXTfe7sgCbgf1Q8]]{detect magic}, [[/item
+          .ztgcdrWPshKRpFd0]]{fireball}</p><p><strong>3/day each:</strong>
+          [[/item .l9Ju5KE7bbn3WpTm]]{hold monster}, [[/item
           .X3DrXgxjwI2dvkD6]]{wall of fire}</p>
         chat: ''
       source:
@@ -738,10 +703,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -749,18 +715,18 @@ items:
       identifier: innate-spellcasting
     effects: []
     folder: null
-    sort: 0
+    sort: 500000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745447015780
+      systemVersion: 6.0.0
+      createdTime: 1781643296531
+      modifiedTime: 1781643360103
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!RCv5y7iWlfNxkinx.2Wh1GHIIzBfCm8md'
@@ -771,11 +737,11 @@ items:
     system:
       description:
         value: >-
-          <p>The pit fiend makes four attacks: one with its [[/item
-          .GjIQl7UOQUtsrj2v]]{bite}, one with its [[/item
-          .RkuPEGbAXHhxfNWJ]]{claw}, one with its [[/item
-          .gpjBebqxqbQA35st]]{mace}, and one with its [[/item
-          .Gh1DbMpJiaTlTwWp]]{tail}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes four attacks: one
+          with its [[/item .GjIQl7UOQUtsrj2v]]{Bite}, one with its [[/item
+          .RkuPEGbAXHhxfNWJ]]{Claw}, one with its [[/item
+          .gpjBebqxqbQA35st]]{Mace}, and one with its [[/item
+          .Gh1DbMpJiaTlTwWp]]{Tail}.</p>
         chat: ''
       source:
         custom: ''
@@ -789,13 +755,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        sySrKKcfckLISejq:
           type: utility
           activation:
             type: action
@@ -810,15 +775,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -829,7 +795,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -846,7 +813,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: sySrKKcfckLISejq
       enchant: {}
       prerequisites:
         level: null
@@ -860,33 +835,34 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273656170
+      systemVersion: 6.0.0
+      createdTime: 1781643383626
+      modifiedTime: 1781643390788
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!RCv5y7iWlfNxkinx.BFv56pkQ54pdTkYM'
   - _id: GjIQl7UOQUtsrj2v
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
-          succeed on a [[/save]] saving throw or become poisoned. While poisoned
-          in this way, the target can't regain hit points, and it takes
-          [[/damage average activity=dnd5eactivity100]] damage at the start of
-          each of its turns. The poisoned target can repeat the saving throw at
-          the end of each of its turns, ending the effect on itself on a
-          success.</p>
+          succeed on a [[/save]] saving throw or become
+          &amp;reference[poisoned]. While poisoned in this way, the target can't
+          regain hit points, and it takes [[/damage average
+          activity=JtAxEJ6yXykPXhDf]] damage at the start of each of its turns.
+          The poisoned target can repeat the saving throw at the end of each of
+          its turns, ending the effect on itself on a success.</p>
         chat: >-
-          <p>The Pit Fiend attacks with its Bite. The target must succeed on a 
-          <strong>DC 21 Constitution</strong> saving throw or become poisoned.
-          The target can repeat the saving throw at the end of each of its
-          turns, ending the effect on itself on a success.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. The target must succeed on a Constitution saving throw
+          or become &amp;reference[poisoned]. The target can repeat the saving
+          throw at the end of each of its turns, ending the effect on itself on
+          a success.</p>
       source:
         custom: ''
         book: ''
@@ -950,7 +926,7 @@ items:
         conditions: ''
       properties:
         - mgc
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -959,8 +935,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        FwBmw1fKbjf4r7Fm:
           type: attack
           activation:
             type: action
@@ -975,69 +950,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-          duration:
-            concentration: false
             value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '5'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: str
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts: []
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
           duration:
             concentration: false
             value: ''
@@ -1058,7 +971,95 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          attack:
+            ability: ''
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: ''
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: FwBmw1fKbjf4r7Fm
+          name: ''
+        t62QSFrpupkF6Qav:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>The target must succeed on a [[/save]] saving throw or become
+              poisoned. While poisoned in this way, the target can't regain hit
+              points, and it takes [[/damage average activity=JtAxEJ6yXykPXhDf]]
+              damage at the start of each of its turns. The poisoned target can
+              repeat the saving throw at the end of each of its turns, ending
+              the effect on itself on a success.</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects:
+            - _id: lezzp3EJSn2vM7mL
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '5'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1071,59 +1072,177 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - con
+            dc:
+              calculation: ''
+              formula: '21'
+            visible: true
+            bonus: ''
+          sort: 200000
+          name: Poison Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: t62QSFrpupkF6Qav
+        JtAxEJ6yXykPXhDf:
+          type: damage
+          name: Start of Turn Poison Damage
+          _id: JtAxEJ6yXykPXhDf
+          img: ''
+          sort: 300000
+          activation:
+            type: special
+            override: false
+            condition: >-
+              When a creature &reference[poisoned apply=false] by this attack
+              starts their turn.
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: >-
+              <p>A takes [[/damage average activity=JtAxEJ6yXykPXhDf]] damage at
+              the start of each of its turns. The poisoned target can repeat the
+              saving throw at the end of each of its turns, ending the effect on
+              itself on a success.</p>
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: spec
+            override: true
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: creature
+              count: '1'
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          damage:
+            critical:
+              allow: false
             parts:
               - custom:
                   enabled: false
                   formula: ''
                 number: 6
-                denomination: '6'
+                denomination: 6
                 bonus: ''
                 types:
                   - poison
-          save:
-            ability: con
-            dc:
-              calculation: ''
-              formula: '21'
-          sort: 0
-          name: ''
-          img: ''
-          appliedEffects: []
+                scaling:
+                  number: 1
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: bite
       mastery: ''
-    effects: []
+    effects:
+      - name: Pit Fiend Poison
+        img: icons/skills/toxins/symbol-poison-drop-skull-green.webp
+        origin: Compendium.dnd5e.monsters.Actor.RCv5y7iWlfNxkinx.Item.GjIQl7UOQUtsrj2v
+        transfer: false
+        _id: lezzp3EJSn2vM7mL
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are &amp;reference[poisoned apply=false]. While poisoned in
+          this way, you can't regain hit points, and you take [[/damage 6d6
+          poison average]] damage at the start of each of your turns.</p><p>You
+          can repeat the saving throw at the end of each of your turns, ending
+          the effect on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781643665595
+          modifiedTime: 1781643822221
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!RCv5y7iWlfNxkinx.GjIQl7UOQUtsrj2v.lezzp3EJSn2vM7mL
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378617409
+      systemVersion: 6.0.0
+      createdTime: 1781643394966
+      modifiedTime: 1781644134512
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!RCv5y7iWlfNxkinx.GjIQl7UOQUtsrj2v'
   - _id: RkuPEGbAXHhxfNWJ
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Pit Fiend attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1147,7 +1266,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -1187,8 +1306,7 @@ items:
         conditions: ''
       properties:
         - mgc
-        - rch
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1197,8 +1315,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        dLSo535zC0amzPaJ:
           type: attack
           activation:
             type: action
@@ -1213,10 +1330,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1233,7 +1351,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1246,23 +1365,35 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: dLSo535zC0amzPaJ
+          name: ''
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: claw
       mastery: ''
     effects: []
@@ -1274,11 +1405,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378620819
+      systemVersion: 6.0.0
+      createdTime: 1781644143515
+      modifiedTime: 1781644165402
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!RCv5y7iWlfNxkinx.RkuPEGbAXHhxfNWJ'
@@ -1289,7 +1420,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Pit Fiend attacks with its Mace.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1354,7 +1487,7 @@ items:
       properties:
         - mgc
         - rch
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1363,8 +1496,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        BQgv1qZJeBWfYajj:
           type: attack
           activation:
             type: action
@@ -1379,10 +1511,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1399,7 +1532,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1412,35 +1546,45 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 6
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 6
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: BQgv1qZJeBWfYajj
+          name: ''
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: mace
       mastery: ''
     effects: []
@@ -1452,22 +1596,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.Ajyq6nGwF7FtLhDQ
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378625159
+      systemVersion: 6.0.0
+      createdTime: 1781644443549
+      modifiedTime: 1781644456085
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!RCv5y7iWlfNxkinx.gpjBebqxqbQA35st'
   - _id: Gh1DbMpJiaTlTwWp
     name: Tail
     type: weapon
-    img: icons/skills/wounds/injury-pain-impaled-hand-blood.webp
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Pit Fiend attacks with its Tail.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1491,7 +1637,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -1531,8 +1677,7 @@ items:
         conditions: ''
       properties:
         - mgc
-        - rch
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1541,8 +1686,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        FBEeJj038NWWJaFH:
           type: attack
           activation:
             type: action
@@ -1557,10 +1701,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1577,7 +1722,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1590,23 +1736,35 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: FBEeJj038NWWJaFH
+          name: ''
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: tail
       mastery: ''
     effects: []
@@ -1618,11 +1776,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378629200
+      systemVersion: 6.0.0
+      createdTime: 1781644468762
+      modifiedTime: 1781644492069
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!RCv5y7iWlfNxkinx.Gh1DbMpJiaTlTwWp'
@@ -1735,7 +1893,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ghXTfe7sgCbgf1Q8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1870,7 +2028,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ztgcdrWPshKRpFd0
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2001,7 +2159,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.l9Ju5KE7bbn3WpTm
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2149,7 +2307,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.X3DrXgxjwI2dvkD6
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2157,6 +2315,112 @@ items:
       lastModifiedBy: null
       exportSource: null
     _key: '!actors.items!RCv5y7iWlfNxkinx.X3DrXgxjwI2dvkD6'
+  - _id: wSv6itzApAoj3Rxb
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 400000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781643295099
+      modifiedTime: 1781643296531
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!RCv5y7iWlfNxkinx.wSv6itzApAoj3Rxb'
+  - _id: xyT7cWc2NsSDZyYn
+    name: Magic Weapons
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster}'s weapon attacks are
+          magical.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-weapons
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/weapons/swords/sword-runed-glowing.webp
+    effects: []
+    folder: null
+    sort: 450000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781643304171
+      modifiedTime: 1781643307163
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.nahRRxck9R5GVVFS
+    _key: '!actors.items!RCv5y7iWlfNxkinx.xyT7cWc2NsSDZyYn'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -2165,7 +2429,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171231220

--- a/packs/_source/monsters/fiend/pit-fiend.yml
+++ b/packs/_source/monsters/fiend/pit-fiend.yml
@@ -738,10 +738,10 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes four attacks: one
-          with its [[/item .GjIQl7UOQUtsrj2v]]{Bite}, one with its [[/item
-          .RkuPEGbAXHhxfNWJ]]{Claw}, one with its [[/item
-          .gpjBebqxqbQA35st]]{Mace}, and one with its [[/item
-          .Gh1DbMpJiaTlTwWp]]{Tail}.</p>
+          with its [[/item .GjIQl7UOQUtsrj2v]]{bite}, one with its [[/item
+          .RkuPEGbAXHhxfNWJ]]{claw}, one with its [[/item
+          .gpjBebqxqbQA35st]]{mace}, and one with its [[/item
+          .Gh1DbMpJiaTlTwWp]]{tail}.</p>
         chat: ''
       source:
         custom: ''

--- a/packs/_source/monsters/fiend/quasit.yml
+++ b/packs/_source/monsters/fiend/quasit.yml
@@ -455,9 +455,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -472,7 +469,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -492,20 +489,24 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 0.5
 items:
   - _id: MLfZqvhaJjB78YiT
     name: Invisibility
     type: feat
-    img: icons/creatures/webs/webthin-blue.webp
+    img: icons/creatures/magical/spirit-undead-ghost-blue.webp
     system:
       description:
         value: >-
-          <p>The quasit magically turns invisible until it attacks or uses
-          Scare, or until its concentration ends (as if concentrating on a
-          spell). Any equipment the quasit wears or carries is invisible with
-          it.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically turns 
+          &amp;reference[invisible] until it attacks or uses
+          @UUID[Compendium.dnd5e.monsters.Actor.bwtkdzavdNHISgp4.Item.1YhP86rTuRIXKFi2]{Scare},
+          or until its concentration ends (as if concentrating on a spell). Any
+          equipment the [[lookup @name lowercase]]{monster} wears or carries is
+          invisible with it.</p>
         chat: >-
-          <p>The quasit magically turns invisible. Any equipment the quasit
+          <p>The [[lookup @name]]{monster} magically turns
+          &amp;reference[invisible]. Any equipment the [[lookup @name]]{monster}
           wears or carries is invisible with it.</p>
       source:
         custom: ''
@@ -519,13 +520,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        CaKaGslGFsgCW6kV:
           type: utility
           activation:
             type: action
@@ -540,15 +541,20 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-          duration:
-            concentration: false
             value: ''
-            units: ''
+          duration:
+            concentration: true
+            value: '1'
+            units: disp
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: dJA0IOGziAr9Onj9
+              level:
+                min: null
+                max: null
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -559,7 +565,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -576,12 +583,66 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: CaKaGslGFsgCW6kV
+          name: Become Invisible
       enchant: {}
       prerequisites:
         level: null
       identifier: invisibility
-    effects: []
+    effects:
+      - name: Invisibility
+        img: icons/creatures/magical/spirit-undead-ghost-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.bwtkdzavdNHISgp4.Item.MLfZqvhaJjB78YiT
+        transfer: false
+        _id: dJA0IOGziAr9Onj9
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are &amp;reference[invisible] until you attack or use
+          @UUID[Compendium.dnd5e.monsters.Actor.bwtkdzavdNHISgp4.Item.1YhP86rTuRIXKFi2]{Scare},
+          or until your concentration ends (as if concentrating on a spell). Any
+          equipment you are wearing or carrying is invisible as well.</p>
+        tint: '#ffffff'
+        statuses:
+          - invisible
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781801074023
+          modifiedTime: 1781801163332
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!bwtkdzavdNHISgp4.MLfZqvhaJjB78YiT.dJA0IOGziAr9Onj9
     folder: null
     sort: 100000
     ownership:
@@ -590,31 +651,33 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.dA5X2eQuOtHywpQF
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.2.0
-      createdTime: null
-      modifiedTime: 1747957321172
+      systemVersion: 6.0.0
+      createdTime: 1781800950884
+      modifiedTime: 1781801147908
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!bwtkdzavdNHISgp4.MLfZqvhaJjB78YiT'
   - _id: ae0OI3obJqa4AS7U
     name: Claw (Bite in Beast Form)
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-glowing-orange.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]].</p><p>The target must
-          succeed on a [[/save]] saving throw or take [[/damage average
-          activity=dnd5eactivity100]] damage and become &amp;Reference[poisoned]
-          for 1 minute. The target can repeat the saving throw at the end of
-          each of its turns, ending the effect on itself on a success.</p>
+          succeed on a [[/save activity=YYGdywRW1up1nXSJ]] saving throw or take
+          [[/damage average activity=YYGdywRW1up1nXSJ]] damage and become
+          &amp;Reference[poisoned] for [[lookup @labels.duration
+          activity=YYGdywRW1up1nXSJ]]. The target can repeat the saving throw at
+          the end of each of its turns, ending the effect on itself on a
+          success.</p>
         chat: >-
-          <p>The Quasit attacks with its Claw. The target must make a
-          <strong>Constitution</strong> saving throw. The target can repeat the
-          saving throw at the end of each of its turns, ending the effect on
-          itself on a success.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. The target must make a Constitution saving throw. The
+          target can repeat the saving throw at the end of each of its turns,
+          ending the effect on itself on a success.</p>
       source:
         custom: ''
         book: ''
@@ -677,17 +740,16 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: simpleM
+        value: natural
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        zoPZrSG1OVFrLQPx:
           type: attack
           activation:
             type: action
@@ -702,69 +764,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-          duration:
-            concentration: false
             value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '5'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: dex
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts: []
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
           duration:
             concentration: false
             value: ''
@@ -785,7 +785,89 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          attack:
+            ability: ''
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: ''
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: zoPZrSG1OVFrLQPx
+          name: ''
+        YYGdywRW1up1nXSJ:
+          type: save
+          activation:
+            type: special
+            value: 1
+            condition: When a creature is hit by this attack.
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: '1'
+            units: minute
+            special: ''
+            override: false
+          effects:
+            - _id: lj4cHP3WVTg1ePKt
+              onSave: false
+              level:
+                min: null
+                max: null
+          range:
+            value: '5'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -804,49 +886,100 @@ items:
                   enabled: false
                   formula: ''
                 number: 2
-                denomination: '4'
+                denomination: 4
                 bonus: ''
                 types:
                   - poison
+                scaling:
+                  number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '10'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 200000
+          name: Poison Save
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: YYGdywRW1up1nXSJ
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw-bite-in-beast-form
       mastery: ''
-    effects: []
+    effects:
+      - name: Quasit Poison
+        img: icons/skills/toxins/symbol-poison-drop-skull-green.webp
+        origin: Compendium.dnd5e.monsters.Actor.bwtkdzavdNHISgp4.Item.ae0OI3obJqa4AS7U
+        transfer: false
+        _id: lj4cHP3WVTg1ePKt
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[poisoned apply=false].</p><p>You can repeat
+          the saving throw at the end of each of your turns, ending the effect
+          on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781800511672
+          modifiedTime: 1781800563183
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!bwtkdzavdNHISgp4.ae0OI3obJqa4AS7U.lj4cHP3WVTg1ePKt
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745175290818
+      systemVersion: 6.0.0
+      createdTime: 1781799942640
+      modifiedTime: 1781800611553
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!bwtkdzavdNHISgp4.ae0OI3obJqa4AS7U'
   - _id: e8rpvJJVWCN4HU7I
     name: Shapechanger
     type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
     system:
       description:
         value: >-
@@ -871,64 +1004,96 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        Xw2uhanKyF8msNlO:
+          type: transform
+          name: Shapeshift
+          _id: Xw2uhanKyF8msNlO
+          img: ''
+          sort: 100000
           activation:
             type: action
-            value: 1
-            condition: ''
             override: false
+            condition: ''
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
-              special: ''
-            prompt: true
+              type: ''
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          profiles:
+            - name: Bat
+              _id: p7SLorpuBrwc2IGY
+              uuid: Compendium.dnd5e.monsters.Actor.qav2dvMIUiMQCCsy
+              level:
+                min: null
+                max: null
+              movement: []
+              sizes: []
+              types: []
+            - name: Centipede
+              _id: DPTp2z3B8UDGsbAQ
+              uuid: Compendium.dnd5e.monsters.Actor.Hn8FFLEzscgT7azz
+              level:
+                min: null
+                max: null
+              movement: []
+              sizes: []
+              types: []
+            - name: Toad
+              _id: 1OR7BiWrDkYMiSLs
+              uuid: Compendium.dnd5e.monsters.Actor.Ixo5shumxy4I9qyD
+              level:
+                min: null
+                max: null
+              movement: []
+              sizes: []
+              types: []
+          settings: null
+          transform:
+            customize: false
+            mode: ''
+            preset: polymorphSelf
       enchant: {}
       prerequisites:
         level: null
@@ -942,74 +1107,29 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.VhByyxHJN7MNQJRd
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957367424
+      systemVersion: 6.0.0
+      createdTime: 1781800739602
+      modifiedTime: 1781801583178
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!bwtkdzavdNHISgp4.e8rpvJJVWCN4HU7I'
-  - _id: vlmHYqAZxNGh8xQ6
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The quasit has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957317985
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!bwtkdzavdNHISgp4.vlmHYqAZxNGh8xQ6'
   - _id: 1YhP86rTuRIXKFi2
     name: Scare
     type: feat
-    img: icons/creatures/unholy/demon-winged-cyclops-drooling.webp
+    img: icons/magic/control/fear-fright-monster-grin-purple-blue.webp
     system:
       description:
         value: >-
-          <p>One creature of the quasit's choice within 20 ft. of it must
-          succeed on a [[/save]] saving throw or be &amp;Reference[frightened]
-          for 1 minute.</p><p>The target can repeat the saving throw at the end
-          of each of its turns, with disadvantage if the quasit is within line
-          of sight, ending the effect on itself on a success.</p>
+          <p>One creature of the [[lookup @name lowercase]]{monster}'s choice
+          within [[lookup @labels.description.range activity=zQ8s6ZTP8J2d98cR]]
+          of it must succeed on a [[/save]] saving throw or be
+          &amp;Reference[frightened] for [[lookup @labels.duration
+          activity=zQ8s6ZTP8J2d98cR]].</p><p>The target can repeat the saving
+          throw at the end of each of its turns, with disadvantage if the
+          [[lookup @name lowercase]]{monster} is within line of sight, ending
+          the effect on itself on a success.</p>
         chat: >-
           <p>One creature of the quasit's choice within 20 ft. of it must make a
           <strong>Wisdom</strong> saving throw. The target can repeat the saving
@@ -1029,13 +1149,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+        zQ8s6ZTP8J2d98cR:
           type: save
           activation:
             type: action
@@ -1045,24 +1164,26 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
-            value: ''
-            units: ''
+            value: '1'
+            units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: DiTStRlGa6CI65oe
+              level: {}
+              onSave: false
           range:
             value: '20'
             units: ft
@@ -1076,7 +1197,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '1'
               type: creature
@@ -1089,39 +1211,145 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
               calculation: ''
               formula: '10'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: zQ8s6ZTP8J2d98cR
+          name: Frighten Creature
       enchant: {}
       prerequisites:
         level: null
       identifier: scare
-    effects: []
+    effects:
+      - name: Scared
+        img: icons/magic/control/fear-fright-white.webp
+        origin: Compendium.dnd5e.monsters.Actor.bwtkdzavdNHISgp4.Item.1YhP86rTuRIXKFi2
+        transfer: false
+        _id: DiTStRlGa6CI65oe
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false].</p><p>You can
+          repeat the saving throw at the end of each of your turns, with
+          disadvantage if the quasit is within line of sight, ending the effect
+          on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781800826861
+          modifiedTime: 1781800884126
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!bwtkdzavdNHISgp4.1YhP86rTuRIXKFi2.DiTStRlGa6CI65oe
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.gqrKcFwxHhmwrP2q
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957347912
+      systemVersion: 6.0.0
+      createdTime: 1781800759056
+      modifiedTime: 1781801173800
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!bwtkdzavdNHISgp4.1YhP86rTuRIXKFi2'
+  - _id: BazHsWJucole1yk3
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781799287829
+      modifiedTime: 1781799287829
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!bwtkdzavdNHISgp4.BazHsWJucole1yk3'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1130,7 +1358,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171242436

--- a/packs/_source/monsters/fiend/rakshasa.yml
+++ b/packs/_source/monsters/fiend/rakshasa.yml
@@ -450,9 +450,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -467,7 +464,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -487,17 +484,19 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: ChSnKd7pSLoN1Jeu
     name: Limited Magic Immunity
     type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
+    img: icons/magic/defensive/barrier-shield-dome-blue-purple.webp
     system:
       description:
         value: >-
-          <p>The rakshasa can't be affected or detected by spells of 6th level
-          or lower unless it wishes to be. It has advantage on saving throws
-          against all other spells and magical effects.</p>
+          <p>The [[lookup @name lowercase]]{monster} can't be affected or
+          detected by spells of 6th level or lower unless it wishes to be. It
+          has advantage on saving throws against all other spells and magical
+          effects.</p>
         chat: ''
       source:
         custom: ''
@@ -511,10 +510,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -529,18 +529,18 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.MBOiQSnMr02wUpEN
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957375754
+      systemVersion: 6.0.0
+      createdTime: 1781644517340
+      modifiedTime: 1781644533159
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qXzMsRTHEodqO8l2.ChSnKd7pSLoN1Jeu'
   - _id: NYUeQsYqRhROcVMQ
     name: Innate Spellcasting
     type: feat
-    img: icons/magic/light/projectiles-star-purple.webp
+    img: icons/magic/symbols/star-yellow.webp
     system:
       description:
         value: >-
@@ -573,10 +573,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -591,11 +592,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745447015959
+      systemVersion: 6.0.0
+      createdTime: 1781644542079
+      modifiedTime: 1781644546657
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qXzMsRTHEodqO8l2.NYUeQsYqRhROcVMQ'
@@ -606,8 +607,8 @@ items:
     system:
       description:
         value: >-
-          <p>The rakshasa makes two [[/item .pHBLWUN5VKEjSBh6]]{claw}
-          attacks.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two [[/item
+          .pHBLWUN5VKEjSBh6]]{Claw} attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -621,13 +622,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        oVxZNPEi8kDnYP9y:
           type: utility
           activation:
             type: action
@@ -642,15 +642,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -661,7 +662,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -678,7 +680,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: oVxZNPEi8kDnYP9y
       enchant: {}
       prerequisites:
         level: null
@@ -692,27 +702,29 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273657271
+      systemVersion: 6.0.0
+      createdTime: 1781644564080
+      modifiedTime: 1781644569214
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qXzMsRTHEodqO8l2.18NEVoD84KHDcWoG'
   - _id: pHBLWUN5VKEjSBh6
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]], and the target is
-          cursed if it is a creature. </p><p>The magical curse takes effect
+          cursed if it is a creature.</p><p>The magical curse takes effect
           whenever the target takes a short or long rest, filling the target's
           thoughts with horrible images and dreams. The cursed target gains no
           benefit from finishing a short or long rest. The curse lasts until it
-          is lifted by a remove curse spell or similar magic.</p>
+          is lifted by a
+          @UUID[Compendium.dnd5e.spells.Item.XZhdgVK3cLoxNCQl]{Remove Curse}
+          spell or similar magic.</p>
         chat: <p>The Rakshasa attacks with its Claw.</p>
       source:
         custom: ''
@@ -776,7 +788,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -785,8 +797,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        edPztdn9nDIBu6Pc:
           type: attack
           activation:
             type: action
@@ -801,13 +812,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: YiUixfCTC5JZGAZm
+              level: {}
           range:
             value: '5'
             units: ft
@@ -821,7 +835,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -840,19 +855,76 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: edPztdn9nDIBu6Pc
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
-    effects: []
+      mastery: ''
+    effects:
+      - name: Rakshasa's Curse
+        img: icons/magic/death/skull-flames-white-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.qXzMsRTHEodqO8l2.Item.pHBLWUN5VKEjSBh6
+        transfer: false
+        _id: YiUixfCTC5JZGAZm
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are cursed. While cursed, whenever you take a short or long
+          rest, your thoughts are filled with horrible images and dreams. You
+          gain no benefit from finishing short or long rests.</p><p>The curse
+          lasts until it is lifted by a
+          @UUID[Compendium.dnd5e.spells.Item.XZhdgVK3cLoxNCQl]{Remove Curse}
+          spell or similar magic.</p>
+        tint: '#ffffff'
+        statuses:
+          - cursed
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781644637908
+          modifiedTime: 1781644731871
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!qXzMsRTHEodqO8l2.pHBLWUN5VKEjSBh6.YiUixfCTC5JZGAZm
     folder: null
     sort: 0
     ownership:
@@ -861,11 +933,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745173385709
+      systemVersion: 6.0.0
+      createdTime: 1781644576569
+      modifiedTime: 1781644637961
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!qXzMsRTHEodqO8l2.pHBLWUN5VKEjSBh6'
@@ -1005,7 +1077,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ppWAAEul0QHtm4er
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1127,7 +1199,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.A3q2gTNqG6fvNGrv
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1245,7 +1317,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.Utk1OQRwYkMkFRD3
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1371,7 +1443,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.oIzA2MEHwxhtQneU
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1499,7 +1571,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.eS7XnnApoxRxYXPs
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1624,7 +1696,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ghXTfe7sgCbgf1Q8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1748,7 +1820,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.1N8dDMMgZ1h1YJ3B
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1892,7 +1964,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.nslx2nT3p4lNkmdp
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2030,7 +2102,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.zMAWdyc8UVb37BK4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2175,7 +2247,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.91Sw6vOIaO7U8DvM
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2299,7 +2371,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.yfbK8gZqESlaoY5t
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2495,7 +2567,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.J6Jpw5XzB5aTeqnz
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2618,7 +2690,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.XzkJpE6XpZfKjODD
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2634,7 +2706,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171259963

--- a/packs/_source/monsters/fiend/succubus-incubus.yml
+++ b/packs/_source/monsters/fiend/succubus-incubus.yml
@@ -456,9 +456,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -473,7 +470,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -493,17 +490,19 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: P3P1EukfOip32dtd
     name: Telepathic Bond
     type: feat
-    img: icons/magic/control/debuff-energy-hold-levitate-pink.webp
+    img: icons/magic/movement/trail-streak-impact-blue.webp
     system:
       description:
         value: >-
-          <p>The fiend ignores the range restriction on its telepathy when
-          communicating with a creature it has charmed. The two don't even need
-          to be on the same plane of existence.</p>
+          <p>The [[lookup @name lowercase]]{monster} ignores the range
+          restriction on its telepathy when communicating with a creature it has
+          &amp;reference[charmed apply=false]. The two don't even need to be on
+          the same plane of existence.</p>
         chat: ''
       source:
         custom: ''
@@ -536,26 +535,27 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.eVKgO2130oiJqsjY
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.3.8
-      createdTime: null
-      modifiedTime: 1744058659464
+      systemVersion: 6.0.0
+      createdTime: 1781644799052
+      modifiedTime: 1781644822387
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VmdyZDjqAc8vdncY.P3P1EukfOip32dtd'
   - _id: ZVMVqd01HraMcenH
     name: Shapechanger
     type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
     system:
       description:
         value: >-
-          <p>The fiend can use its action to polymorph into a Small or Medium
-          humanoid, or back into its true form. Without wings, the fiend loses
-          its flying speed. Other than its size and speed, its statistics are
-          the same in each form.</p><p>Any equipment it is wearing or carrying
-          isn't transformed. It reverts to its true form if it dies.</p>
+          <p>The [[lookup @details.type.value]]{monster} can use its action to
+          polymorph into a Small or Medium humanoid, or back into its true form.
+          Without wings, the [[lookup @details.type.value]]{monster} loses its
+          flying speed. Other than its size and speed, its statistics are the
+          same in each form.</p><p>Any equipment it is wearing or carrying isn't
+          transformed. It reverts to its true form if it dies.</p>
         chat: >-
           <p>The fiend can use its action to <strong>polymorph</strong> into a
           humanoid, or back into its true form.</p>
@@ -571,94 +571,113 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties:
-        - trait
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        3d9h1RzUjvJRdk5C:
+          type: transform
+          name: Shapeshift
+          img: ''
+          sort: 100000
           activation:
             type: action
-            value: 1
-            condition: ''
             override: false
+            condition: ''
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
-              special: ''
-            prompt: true
+              type: ''
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: ''
+              name: ''
+              _id: hAZbWYsA1wVyGXVn
+              uuid: null
+              sizes:
+                - sm
+                - med
+              types:
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings: null
+          transform:
+            customize: false
+            mode: cr
+            preset: polymorphSelf
+          _id: 3d9h1RzUjvJRdk5C
       enchant: {}
       prerequisites:
         level: null
       identifier: shapechanger
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.VhByyxHJN7MNQJRd
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957384472
+      systemVersion: 6.0.0
+      createdTime: 1781644867040
+      modifiedTime: 1781797982176
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VmdyZDjqAc8vdncY.ZVMVqd01HraMcenH'
   - _id: oSlFzVMu0fdEfYt1
     name: Claw (Fiend Form Only)
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Succubus/Incubus attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @details.type.value]]{monster} attacks with its
+          [[lookup @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -720,9 +739,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - fin
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -731,8 +749,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        yHIsof4m2BrnwUL9:
           type: attack
           activation:
             type: action
@@ -747,6 +764,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -767,7 +785,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -787,16 +806,25 @@ items:
             flat: false
             type:
               value: ''
-              classification: weapon
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: yHIsof4m2BrnwUL9
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -807,38 +835,39 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.3.8
-      createdTime: null
-      modifiedTime: 1744058885337
+      systemVersion: 6.0.0
+      createdTime: 1781797989164
+      modifiedTime: 1781798015323
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VmdyZDjqAc8vdncY.oSlFzVMu0fdEfYt1'
   - _id: 2bFCfFfjRNmhyE8A
     name: Charm
     type: feat
-    img: icons/magic/air/wind-tornado-spiral-pink-purple.webp
+    img: icons/magic/life/heart-shadow-red.webp
     system:
       description:
         value: >-
-          <p>One humanoid the fiend can see within 30 feet of it must make a
-          [[/save]] saving throw or be magically charmed for 1 day. The charmed
-          target obeys the fiend's verbal or telepathic commands.</p><p>If the
-          target suffers any harm or receives a suicidal command, it can repeat
-          the saving throw, ending the effect on a success. If the target
-          successfully saves against the effect, or if the effect on it ends,
-          the target is immune to this fiend's Charm for the next 24 hours.The
-          fiend can have only one target charmed at a time. If it charms
-          another, the effect on the previous target ends.</p>
+          <p>One humanoid the [[lookup @details.type.value]]{monster} can see
+          within [[lookup @labels.description.range activity=ZFCUDfqONxiB5KBa]]
+          of it must make a [[/save]] saving throw or be magically
+          &amp;reference[charmed apply=false] for [[lookup @labels.duration
+          activity=ZFCUDfqONxiB5KBa]]. The charmed target obeys the [[lookup
+          @details.type.value]]{monster}'s verbal or telepathic
+          commands.</p><p>If the target suffers any harm or receives a suicidal
+          command, it can repeat the saving throw, ending the effect on a
+          success. If the target successfully saves against the effect, or if
+          the effect on it ends, the target is immune to this [[lookup
+          @details.type.value]]{monster}'s [[lookup @item.name]] for the next 24
+          hours.The [[lookup @details.type.value]]{monster} can have only one
+          target charmed at a time. If it charms another, the effect on the
+          previous target ends.</p>
         chat: >-
           <p>One humanoid the fiend can see within 30 feet of it must make a
           <strong>Wisdom</strong> saving throw.</p>
@@ -860,8 +889,7 @@ items:
       properties:
         - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        ZFCUDfqONxiB5KBa:
           type: save
           activation:
             type: action
@@ -876,6 +904,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
@@ -884,6 +913,10 @@ items:
             override: false
           effects:
             - _id: iuVbm8rd6UWg36yg
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '30'
             units: ft
@@ -897,7 +930,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '1'
               type: creature
@@ -913,44 +947,50 @@ items:
             onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
               calculation: cha
               formula: '15'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Charm Target
           img: ''
-          appliedEffects:
-            - iuVbm8rd6UWg36yg
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: ZFCUDfqONxiB5KBa
       enchant: {}
       prerequisites:
         level: null
       identifier: charm
     effects:
       - name: Charmed
-        img: systems/dnd5e/icons/svg/statuses/charmed.svg
+        img: icons/magic/life/heart-shadow-red.webp
         origin: Compendium.dnd5e.monsters.Actor.VmdyZDjqAc8vdncY.Item.2bFCfFfjRNmhyE8A
         transfer: false
         _id: iuVbm8rd6UWg36yg
         type: base
-        system: {}
-        changes: []
+        system:
+          changes: []
         disabled: false
         duration:
-          startTime: null
-          seconds: 86400
-          combat: null
-          rounds: null
-          turns: null
-          startRound: null
-          startTurn: null
+          value: 1
+          units: days
+          expiry: turnStart
+          expired: false
         description: >-
-          <p>The charmed target obeys the fiend's verbal or telepathic
-          commands.</p><p>If the target suffers any harm or receives a suicidal
-          command, it can repeat the saving throw, ending the effect on a
-          success. If the target successfully saves against the effect, or if
-          the effect on it ends, the target is immune to this fiend's Charm for
-          the next 24 hours.</p>
+          <p>You are &amp;reference[charmed apply=false] and obey the fiend's
+          verbal or telepathic commands.</p><p>If you suffer any harm or recieve
+          a suicidal command, you can repeat the saving throw, ending the effect
+          on a success.</p>
         tint: '#ffffff'
         statuses:
           - charmed
@@ -962,52 +1002,58 @@ items:
         _stats:
           compendiumSource: null
           duplicateSource: null
-          coreVersion: '13.344'
+          coreVersion: '14.361'
           systemId: dnd5e
           systemVersion: 4.3.8
           createdTime: 1744059005231
-          modifiedTime: 1744059080198
+          modifiedTime: 1781798535446
           lastModifiedBy: dnd5ebuilder0000
           exportSource: null
+        showIcon: 2
+        start: null
+        folder: null
         _key: >-
           !actors.items.effects!VmdyZDjqAc8vdncY.2bFCfFfjRNmhyE8A.iuVbm8rd6UWg36yg
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.ykoo88OJOdfYH7mH
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.3.8
-      createdTime: null
-      modifiedTime: 1744059148476
+      systemVersion: 6.0.0
+      createdTime: 1781798033178
+      modifiedTime: 1781798575854
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VmdyZDjqAc8vdncY.2bFCfFfjRNmhyE8A'
   - _id: eb0O9cQ8N6lovLyI
     name: Draining Kiss
     type: feat
-    img: icons/magic/air/wind-vortex-swirl-purple.webp
+    img: icons/magic/death/mouth-teeth-fangs-vampire.webp
     system:
       description:
         value: >-
-          <p>The fiend kisses a creature charmed by it or a willing creature.
-          The target must make a [[/save]] saving throw against this magic,
-          taking [[/damage]] damage on a failed save, or half as much damage on
-          a successful one.</p><p>The target's hit point maximum is reduced by
-          an amount equal to the damage taken. This reduction lasts until the
-          target finishes a long rest. The target dies if this effect reduces
-          its hit point maximum to 0.</p>
+          <p>The [[lookup @details.type.value]]{monster} kisses a
+          &amp;reference[charmed apply=false] charmed by it or a willing
+          creature. The target must make a [[/save activity=hczxJO21CcoyyyO7]]
+          saving throw against this magic, taking [[/damage
+          activity=hczxJO21CcoyyyO7]] damage on a failed save, or half as much
+          damage on a successful one.</p><p>The target's hit point maximum is
+          reduced by an amount equal to the damage taken. This reduction lasts
+          until the target finishes a long rest. The target dies if this effect
+          reduces its hit point maximum to 0.</p><section
+          id="secret-o3d8RMpsTX8cJQ42" class="secret"><p><strong>Foundry
+          Note</strong></p><p>You can use the <em><strong>"Maximum Hit Point
+          Damage"</strong></em><strong> </strong>activity to input the amount of
+          damage a creature took from this attack and reduce their hit point
+          maximum by that amount.</p></section>
         chat: >-
-          <p>The target must make a <strong>Constitution</strong> saving throw
-          against this magic.</p>
+          <p>The target must make a Constitution saving throw against this
+          magic.</p>
       source:
         custom: ''
         book: ''
@@ -1022,12 +1068,11 @@ items:
       type:
         value: monster
         subtype: ''
-      requirements: Targets a charmed or willing creature
+      requirements: ''
       properties:
         - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        hczxJO21CcoyyyO7:
           type: save
           activation:
             type: action
@@ -1042,6 +1087,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1061,7 +1107,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '1'
               type: creature
@@ -1080,19 +1127,102 @@ items:
                   enabled: false
                   formula: ''
                 number: 5
-                denomination: '10'
+                denomination: 10
                 bonus: '@mod'
                 types:
                   - psychic
+                scaling:
+                  number: 1
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: cha
               formula: '15'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Kiss Creature
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: hczxJO21CcoyyyO7
+        OIVnQaEHfNO9SoVc:
+          type: damage
+          name: Maximum Hit Point Damage
+          _id: OIVnQaEHfNO9SoVc
+          img: ''
+          sort: 200000
+          activation:
+            type: special
+            override: false
+            condition: When a creature takes damage from this feature.
+          consumption:
+            scaling:
+              allowed: true
+              max: ''
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: touch
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: creature
+              count: '1'
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          damage:
+            critical:
+              allow: false
+            parts:
+              - custom:
+                  enabled: true
+                  formula: '@scaling'
+                number: null
+                denomination: null
+                bonus: ''
+                types:
+                  - maximum
+                scaling:
+                  mode: ''
+                  number: 1
       enchant: {}
       prerequisites:
         level: null
@@ -1102,31 +1232,27 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.iq0J225DCbHYU2hU
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.3.8
-      createdTime: null
-      modifiedTime: 1744059474380
+      systemVersion: 6.0.0
+      createdTime: 1781798588203
+      modifiedTime: 1781799145205
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VmdyZDjqAc8vdncY.eb0O9cQ8N6lovLyI'
   - _id: s1s5asgUorljP7SV
     name: Etherealness
     type: feat
-    img: icons/magic/unholy/barrier-shield-glowing-pink.webp
+    img: icons/magic/unholy/silhouette-robe-evil-glow.webp
     system:
       description:
         value: >-
-          <p>The fiend magically enters the Ethereal Plane from the Material
-          Plane, or vice versa.</p>
+          <p>The [[lookup @details.type.value]]{monster} magically enters the
+          Ethereal Plane from the Material Plane, or vice versa.</p>
         chat: ''
       source:
         custom: ''
@@ -1146,8 +1272,7 @@ items:
       properties:
         - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        dUsf5fP5foZoaddo:
           type: utility
           activation:
             type: action
@@ -1162,14 +1287,14 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: perm
+            units: inst
             special: ''
             override: false
-          effects:
-            - _id: 1Bd78CAdilT57jFe
+          effects: []
           range:
             units: self
             special: ''
@@ -1182,10 +1307,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: self
+              type: ''
               choice: false
               special: ''
             prompt: true
@@ -1199,10 +1325,19 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
-          name: ''
+          sort: 100000
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          name: Traverse Planes
+          _id: dUsf5fP5foZoaddo
       enchant: {}
       prerequisites:
         level: null
@@ -1214,17 +1349,14 @@ items:
         transfer: true
         _id: 1Bd78CAdilT57jFe
         type: base
-        system: {}
-        changes: []
+        system:
+          changes: []
         disabled: true
         duration:
-          startTime: null
-          seconds: null
-          combat: null
-          rounds: null
-          turns: null
-          startRound: null
-          startTurn: null
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
         description: ''
         tint: '#ffffff'
         statuses:
@@ -1237,32 +1369,31 @@ items:
         _stats:
           compendiumSource: null
           duplicateSource: null
-          coreVersion: '13.344'
+          coreVersion: '14.361'
           systemId: dnd5e
           systemVersion: 4.3.8
           createdTime: 1744059571494
           modifiedTime: 1744059585380
           lastModifiedBy: dnd5ebuilder0000
           exportSource: null
+        showIcon: 2
+        start: null
+        folder: null
         _key: >-
           !actors.items.effects!VmdyZDjqAc8vdncY.s1s5asgUorljP7SV.1Bd78CAdilT57jFe
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.rDoNJnKdY47x8MD4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.3.8
-      createdTime: null
-      modifiedTime: 1744059571510
+      systemVersion: 6.0.0
+      createdTime: 1781799158044
+      modifiedTime: 1781799184676
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!VmdyZDjqAc8vdncY.s1s5asgUorljP7SV'
@@ -1274,7 +1405,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171236478

--- a/packs/_source/monsters/fiend/vrock.yml
+++ b/packs/_source/monsters/fiend/vrock.yml
@@ -502,8 +502,8 @@ items:
       description:
         value: >-
           <p>The [[lookup @name lowercase]]{monster} makes two attacks: one with
-          its [[/item .JwAFMjU7vHDDL2Ib]]{Beak} and one with its [[/item
-          .H5JJE8uS39dTI3Vg]]{Talons}.</p>
+          its [[/item .JwAFMjU7vHDDL2Ib]]{beak} and one with its [[/item
+          .H5JJE8uS39dTI3Vg]]{talons}.</p>
         chat: ''
       source:
         custom: ''

--- a/packs/_source/monsters/fiend/vrock.yml
+++ b/packs/_source/monsters/fiend/vrock.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,55 +492,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
-  - _id: mViCCkDhb1mA9oO6
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The vrock has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957394650
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!6oc29m5uzzzb0pk3.mViCCkDhb1mA9oO6'
   - _id: oWzM562ozNrlfOZe
     name: Multiattack
     type: feat
@@ -551,9 +501,9 @@ items:
     system:
       description:
         value: >-
-          <p>The vrock makes two attacks: one with its [[/item
-          .JwAFMjU7vHDDL2Ib]]{beak} and one with its [[/item
-          .H5JJE8uS39dTI3Vg]]{talons}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two attacks: one with
+          its [[/item .JwAFMjU7vHDDL2Ib]]{Beak} and one with its [[/item
+          .H5JJE8uS39dTI3Vg]]{Talons}.</p>
         chat: ''
       source:
         custom: ''
@@ -567,13 +517,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        P8LopvxsCDjVrGDA:
           type: utility
           activation:
             type: action
@@ -588,15 +537,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -607,7 +557,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -624,7 +575,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 200000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: P8LopvxsCDjVrGDA
       enchant: {}
       prerequisites:
         level: null
@@ -638,11 +597,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273655175
+      systemVersion: 6.0.0
+      createdTime: 1781797542608
+      modifiedTime: 1781797725694
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!6oc29m5uzzzb0pk3.oWzM562ozNrlfOZe'
@@ -653,7 +612,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Vrock attacks with its Beak.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -716,7 +677,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -725,8 +686,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        lkibmRoOjNJ69VI1:
           type: attack
           activation:
             type: action
@@ -741,10 +701,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -761,7 +722,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -787,11 +749,20 @@ items:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: lkibmRoOjNJ69VI1
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: beak
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -801,22 +772,24 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107550046
+      systemVersion: 6.0.0
+      createdTime: 1781639881662
+      modifiedTime: 1781639886973
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!6oc29m5uzzzb0pk3.JwAFMjU7vHDDL2Ib'
   - _id: H5JJE8uS39dTI3Vg
     name: Talons
     type: weapon
-    img: icons/creatures/claws/claw-scaled-red.webp
+    img: icons/commodities/claws/claw-bird-pink.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Vrock attacks with its Talons.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -888,8 +861,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        QEjyxKiDwYu2RYwW:
           type: attack
           activation:
             type: action
@@ -904,10 +876,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -924,7 +897,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -937,24 +911,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: QEjyxKiDwYu2RYwW
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: talons
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -964,35 +951,38 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107550046
+      systemVersion: 6.0.0
+      createdTime: 1781639894622
+      modifiedTime: 1781639905178
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!6oc29m5uzzzb0pk3.H5JJE8uS39dTI3Vg'
   - _id: eEVWpD5omMdUkWLu
     name: Spores
     type: feat
-    img: icons/magic/earth/orb-stone-smoke-teal.webp
+    img: icons/magic/nature/plant-undersea-seaweed-glow-green.webp
     system:
       description:
         value: >-
-          <p>A 15-foot-radius cloud of toxic spores extends out from the vrock.
-          The spores spread around corners. Each creature in that area must
-          succeed on a [[/save]] saving throw or become
-          &amp;Reference[poisoned].</p><p>While poisoned in this way, a target
-          takes [[/damage average]] damage at the start of each of its turns. A
-          target can repeat the saving throw at the end of each of its turns,
-          ending the effect on itself on a success. Emptying a vial of holy
-          water on the target also ends the effect on it.</p>
+          <p>A [[lookup @labels.description.template activity=6NlNH6h0uxCCjmPL]]
+          cloud of toxic spores extends out from the vrock. The spores spread
+          around corners. Each creature in that area must succeed on a [[/save]]
+          saving throw or become &amp;Reference[poisoned].</p><p>While poisoned
+          in this way, a target takes [[/damage average]] damage at the start of
+          each of its turns. A target can repeat the saving throw at the end of
+          each of its turns, ending the effect on itself on a success. Emptying
+          a vial of
+          @UUID[Compendium.dnd5e.equipment24.Item.nshr9PBVyB03T7wB]{Holy Water}
+          on the target also ends the effect on it.</p>
         chat: >-
-          <p>A 15-foot-radius cloud of toxic spores extends out from the vrock.
+          <p>A [[lookup @labels.description.template activity=6NlNH6h0uxCCjmPL]]
+          cloud of toxic spores extends out from the [[lookup @name]]{monster}.
           The spores spread around corners. Each creature in that area must make
-          a <strong>Constitution</strong> saving throw. A target can repeat the
-          saving throw at the end of each of its turns, ending the effect on
-          itself on a success.</p>
+          a Constitution saving throw. A target can repeat the saving throw at
+          the end of each of its turns, ending the effect on itself on a
+          success.</p>
       source:
         custom: ''
         book: ''
@@ -1008,13 +998,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        6NlNH6h0uxCCjmPL:
           type: save
           activation:
             type: action
@@ -1024,24 +1013,26 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: U7J7WV9lQsBGVdVA
+              level: {}
+              onSave: false
           range:
             units: self
             special: ''
@@ -1055,6 +1046,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1067,31 +1059,144 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
+            parts: []
+          save:
+            ability:
+              - con
+            dc:
+              calculation: ''
+              formula: '14'
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 6NlNH6h0uxCCjmPL
+          name: Spread Spores
+        cM4sk9IHslq0iS0v:
+          type: damage
+          name: Start of Turn Poison Damage
+          _id: cM4sk9IHslq0iS0v
+          img: ''
+          sort: 200000
+          activation:
+            type: special
+            override: false
+            condition: >-
+              When a creature &reference[poisoned apply=false] by the [[lookup
+              @name lowercase]]{monster}'s spores.
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: >-
+              <p>A target takes [[/damage average]] damage at the start of each
+              of its turns while &amp;reference[poisoned apply=false] by these
+              spores. A target can repeat the saving throw at the end of each of
+              its turns, ending the effect on itself on a success. Emptying a
+              vial of
+              @UUID[Compendium.dnd5e.equipment24.Item.nshr9PBVyB03T7wB]{Holy
+              Water} on the target also ends the effect on it.</p>
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: spec
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: creature
+              count: '1'
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          damage:
+            critical:
+              allow: false
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 10
                 bonus: ''
                 types:
                   - poison
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          save:
-            ability: con
-            dc:
-              calculation: ''
-              formula: '14'
-          sort: 0
+                  number: 1
       enchant: {}
       prerequisites:
         level: null
       identifier: spores
-    effects: []
+    effects:
+      - name: Spread Spores
+        img: icons/magic/nature/plant-undersea-seaweed-glow-green.webp
+        origin: Compendium.dnd5e.monsters.Actor.6oc29m5uzzzb0pk3.Item.eEVWpD5omMdUkWLu
+        transfer: false
+        _id: U7J7WV9lQsBGVdVA
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: ''
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags: {}
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781640130096
+          modifiedTime: 1781640130096
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!6oc29m5uzzzb0pk3.eEVWpD5omMdUkWLu.U7J7WV9lQsBGVdVA
     folder: null
     sort: 0
     ownership:
@@ -1100,29 +1205,30 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.ihWvcWsnfqW2HFlA
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957416876
+      systemVersion: 6.0.0
+      createdTime: 1781639916905
+      modifiedTime: 1781640130127
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!6oc29m5uzzzb0pk3.eEVWpD5omMdUkWLu'
   - _id: Ijd3GKLRlMzwoSe1
     name: Stunning Screech
     type: feat
-    img: icons/skills/toxins/cup-goblet-poisoned-spilled.webp
+    img: icons/magic/sonic/projectile-sound-rings-wave.webp
     system:
       description:
         value: >-
-          <p>The vrock emits a horrific screech. Each creature within 20 feet of
-          it that can hear it and that isn't a demon must succeed on a [[/save]]
-          saving throw or be stunned until the end of the vrock's next turn
-          .</p>
+          <p>The [[lookup @name lowercase]]{monster} emits a horrific screech.
+          Each creature within 20 feet of it that can hear it and that isn't a
+          demon must succeed on a [[/save]] saving throw or be
+          &amp;reference[stunned] until the end of the [[lookup @name
+          lowercase]]{monster}'s next turn .</p>
         chat: >-
-          <p>The vrock emits a horrific screech. Each creature within 20 feet of
-          it that can hear it and that isn't a demon must make a
-          <strong>Constitution</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} emits a horrific screech. Each
+          creature within 20 feet of it that can hear it and that isn't a demon
+          must make a Constitution saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -1137,13 +1243,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        OwngUc3uEBmyHoMl:
           type: save
           activation:
             type: action
@@ -1153,38 +1258,38 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            value: '20'
-            units: ft
+            value: ''
+            units: self
             special: ''
             override: false
           target:
             template:
               count: ''
               contiguous: false
-              type: ''
-              size: ''
+              type: radius
+              size: '20'
               width: ''
               height: ''
-              units: any
+              units: ft
+              stationary: true
             affects:
               count: ''
               type: creature
@@ -1200,11 +1305,26 @@ items:
             onSave: half
             parts: []
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '14'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: OwngUc3uEBmyHoMl
+          name: Screech
       enchant: {}
       prerequisites:
         level: null
@@ -1218,14 +1338,67 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.aD3HKoBnJtZL6cDj
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747957425282
+      systemVersion: 6.0.0
+      createdTime: 1781797466940
+      modifiedTime: 1781797730455
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!6oc29m5uzzzb0pk3.Ijd3GKLRlMzwoSe1'
+  - _id: lFkc4XAUH21VJuuU
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781639875090
+      modifiedTime: 1781639875090
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!6oc29m5uzzzb0pk3.lFkc4XAUH21VJuuU'
 effects: []
 folder: P1YKVDd1IN7XXWWy
 sort: 0
@@ -1234,7 +1407,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171204531


### PR DESCRIPTION
Updates to the 5.1 SRD Fiends. This does not touch spellcasting features or actual spells that these creatures may have because the spells are still yet to be updated.

Some features like transform / shapechange abilities could be better, but would like to rely on #6660 to make these feel better to use in the case of Imp / Quasit. Tried something new with Chain Devil, using a few flags to add extra text to its multiattack feature while it was animated chains active.

Related #6712