### PR TITLE
Add system active effect sheet, separate choice config

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -138,6 +138,11 @@ Hooks.once("init", function() {
 
   // Register sheet application classes
   const DocumentSheetConfig = foundry.applications.apps.DocumentSheetConfig;
+  DocumentSheetConfig.registerSheet(ActiveEffect, "dnd5e", applications.activeEffect.ActiveEffectSheet5e, {
+    makeDefault: true,
+    label: "DND5E.SheetClass.ActiveEffect"
+  });
+
   DocumentSheetConfig.unregisterSheet(Actor, "core", foundry.appv1.sheets.ActorSheet);
   DocumentSheetConfig.registerSheet(Actor, "dnd5e", applications.actor.CharacterActorSheet, {
     types: ["character"],

--- a/lang/en.json
+++ b/lang/en.json
@@ -2641,7 +2641,7 @@
   "Change": {
     "Configuration": "Change Configuration",
     "Label": "Change",
-    "Title": "{effect} Change #{number}"
+    "Title": "{effect} Change {number}"
   },
   "DropHint": "Drop an Active Effect here",
   "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -289,7 +289,7 @@
 },
 
 "DND5E.ACTIVEEFFECT": {
-  "AttributeKeyTooltip": "For a list of common keys, see <a href=\"{url}\">the wiki</a>.",
+  "AttributeKeyTooltip": "For a list of common keys and their accepted values, see <a href=\"{url}\">the wiki</a>.",
   "FIELDS": {
     "statuses": {
       "label": "Status Conditions",
@@ -2580,9 +2580,12 @@
 "DND5E.Effect": "Effect",
 "DND5E.EFFECT": {
   "Action": {
+    "AddChange": "Add Change",
     "CreateEffect": "Create Effect",
     "DeleteEffect": "Delete Effect",
+    "DeleteChange": "Delete Change",
     "DissociateEffect": "Dissociate Effect",
+    "EditChange": "Edit Change",
     "EditEffect": "Edit Effect",
     "RemoveStatus": {
       "all": "All Sources",
@@ -2590,6 +2593,7 @@
     },
     "Search": "Search effects"
   },
+  "AdditionalChanges": "Additional Changes",
   "Application": {
     "Action": {
       "ApplyTokens": "Apply to selected tokens"
@@ -2602,6 +2606,26 @@
   },
   "BASE": {
     "FIELDS": {
+      "changes": {
+        "element": {
+          "key": {
+            "label": "Attribute Key"
+          },
+          "phase": {
+            "hint": "The point in data preparation or another event a change is to be applied.",
+            "label": "Phase"
+          },
+          "priority": {
+            "label": "Priority"
+          },
+          "type": {
+            "label": "Type"
+          },
+          "value": {
+            "label": "Value"
+          }
+        }
+      },
       "magical": {
         "hint": "This effect is from a magical source and should be disabled when magic isn't available.",
         "label": "Magical"
@@ -2613,6 +2637,11 @@
     "Passive": "Passive Effects",
     "Inactive": "Inactive Effects",
     "Unavailable": "Unavailable Effects"
+  },
+  "Change": {
+    "Configuration": "Change Configuration",
+    "Label": "Change",
+    "Title": "{effect} Change #{number}"
   },
   "DropHint": "Drop an Active Effect here",
   "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",
@@ -4396,6 +4425,7 @@
 "DND5E.Shape": "Shape",
 
 "DND5E.SheetClass": {
+  "ActiveEffect": "D&D 5e Active Effect Sheet",
   "AdventureImporter": "D&D 5e Adventure Importer",
   "Character": "D&D 5e Character Sheet",
   "ClassSummary": "D&D 5e Class Summary Sheet",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2612,7 +2612,7 @@
             "label": "Attribute Key"
           },
           "phase": {
-            "hint": "The point in data preparation or another event a change is to be applied.",
+            "hint": "The point in data preparation, or another event, at which a change is to be applied.",
             "label": "Phase"
           },
           "priority": {
@@ -2641,7 +2641,7 @@
   "Change": {
     "Configuration": "Change Configuration",
     "Label": "Change",
-    "Title": "{effect} Change {number}"
+    "Title": "{effect} Change #{number}"
   },
   "DropHint": "Drop an Active Effect here",
   "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1181,6 +1181,10 @@
     }
   }
 
+  &.hidden-title:not(.minimized) .window-header .window-title {
+    visibility: hidden;
+  }
+
   .window-content {
     background: transparent;
     padding-block-start: 8px;

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -435,7 +435,7 @@
 
   /* Form Fields */
   textarea, select, input[type="text"], input[type="number"], input[type="search"],
-  input[type="file"], file-picker, formula-input {
+  input[type="file"], color-picker, file-picker, formula-input {
     --input-box-shadow: none;
     --input-text-color: var(--color-text-primary);
     transition: all 250ms ease, block-size, inline-size;
@@ -469,7 +469,7 @@
     font-size: var(--font-size-11);
   }
 
-  :is(formula-input, file-picker) {
+  :is(color-picker, formula-input, file-picker) {
     overflow: hidden;
     &:focus-within { outline: none; }
     &:enabled {

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -683,6 +683,7 @@
   /* Control buttons */
   button.control-button, button.config-button {
     padding: 0;
+    flex: none;
     width: unset;
     display: inline-block;
     color: var(--color-text-secondary);
@@ -691,6 +692,9 @@
       box-shadow: none;
       text-shadow: 0 0 5px var(--color-shadow-primary);
       background: none;
+    }
+    &.icon {
+      height: unset;
     }
   }
 

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -492,12 +492,13 @@
     .changes .change-row {
       border-block-start: var(--activity-row-border);
       min-block-size: 32px;
-      padding-inline-start: 29px;
+      padding-inline-start: 6px;
       position: relative;
 
       &:last-child { border-block-end: var(--activity-row-border); }
 
-      &::before {
+      &[data-change-type] { padding-inline-start: 29px; }
+      &[data-change-type]::before {
         content: "\f192";
         position: absolute;
         inset: 9px auto auto 13px;

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -361,6 +361,11 @@
         &.item-detail { color: var(--color-text-secondary); }
       }
 
+      /* Effect Change Type */
+      .effect-type {
+        width: 70px;
+      }
+
       /* Effect Value */
       .effect-value {
         width: 70px;

--- a/less/v2/sheets.less
+++ b/less/v2/sheets.less
@@ -49,13 +49,11 @@
   }
 }
 
-.dnd5e2.sheet:is(.item, .actor, .roll-table-sheet) {
+.dnd5e2.sheet:is(.item, .actor) {
   &:where(:not(.minimized)) > header {
     background: transparent;
     position: relative;
     z-index: 1;
-
-    .window-title { visibility: hidden; }
   }
 }
 
@@ -240,9 +238,22 @@ body.detached .dnd5e2.sheet .tab { max-height: unset; }
   }
 
   /* ---------------------------------- */
-  /*  Child Creation                    */
+  /*  Interactivity                     */
   /* ---------------------------------- */
 
+  &.locked {
+    .rollable, .draggable { cursor: var(--cursor-default); }
+    .rollable:hover { text-shadow: none; }
+  }
+
+  &:not(.locked) .rollable.draggable { cursor: var(--cursor-pointer); }
+}
+
+/* ---------------------------------- */
+/*  Child Creation                    */
+/* ---------------------------------- */
+
+.dnd5e2.sheet:is(.active-effect-config, .actor, .item) {
   .create-child {
     display: none;
     position: absolute;
@@ -254,21 +265,32 @@ body.detached .dnd5e2.sheet .tab { max-height: unset; }
     line-height: 24px;
   }
 
-  form:is(.tab-inventory, .tab-features, .tab-spells, .tab-effects, .tab-advancement, .tab-activities, .tab-crew) .create-child,
-  &:is(.tab-inventory, .tab-features, .tab-spells, .tab-effects, .tab-advancement, .tab-activities, .tab-crew) .create-child {
+  form:is(.tab-inventory, .tab-features, .tab-spells, .tab-effects, .tab-advancement, .tab-activities, .tab-crew, .tab-changes) .create-child,
+  &:is(.tab-inventory, .tab-features, .tab-spells, .tab-effects, .tab-advancement, .tab-activities, .tab-crew, .tab-changes) .create-child, {
     display: block;
   }
+}
 
-  /* ---------------------------------- */
-  /*  Interactivity                     */
-  /* ---------------------------------- */
+/* ---------------------------------- */
+/*  Active Effect Sheets              */
+/* ---------------------------------- */
 
-  &.locked {
-    .rollable, .draggable { cursor: var(--cursor-default); }
-    .rollable:hover { text-shadow: none; }
+.dnd5e2.active-effect-config {
+  .sheet-header { --dnd5e-document-image-size: 96px; }
+  .document-name {
+    font-family: var(--dnd5e-font-modesto);
+    font-size: var(--font-size-32);
+    font-weight: bold;
+    text-align: center;
   }
-
-  &:not(.locked) .rollable.draggable { cursor: var(--cursor-pointer); }
+  .tab.changes {
+    overflow-y: auto;
+    padding-block-end: 35px;
+    padding-inline-end: 2px;
+  }
+  .changes-list {
+    ol, li { display: block; }
+  }
 }
 
 /* ---------------------------------- */

--- a/less/v2/sheets.less
+++ b/less/v2/sheets.less
@@ -291,6 +291,15 @@ body.detached .dnd5e2.sheet .tab { max-height: unset; }
   }
   .changes-list {
     ol, li { display: block; }
+    .items-section .item .item-controls {
+      justify-content: space-evenly;
+      padding-inline-end: 16px;
+
+      button.control-button:not(.always-interactive) {
+        color: var(--control-button-text-color);
+        font-size: var(--font-size-11);
+      }
+    }
   }
 }
 
@@ -346,5 +355,6 @@ body.detached .dnd5e2.sheet .tab { max-height: unset; }
     }
   }
 
+  .controls { justify-content: space-evenly; }
   &.edit-mode table .controls { flex: 0 0 90px; }
 }

--- a/less/v2/sheets.less
+++ b/less/v2/sheets.less
@@ -266,7 +266,7 @@ body.detached .dnd5e2.sheet .tab { max-height: unset; }
   }
 
   form:is(.tab-inventory, .tab-features, .tab-spells, .tab-effects, .tab-advancement, .tab-activities, .tab-crew, .tab-changes) .create-child,
-  &:is(.tab-inventory, .tab-features, .tab-spells, .tab-effects, .tab-advancement, .tab-activities, .tab-crew, .tab-changes) .create-child, {
+  &:is(.tab-inventory, .tab-features, .tab-spells, .tab-effects, .tab-advancement, .tab-activities, .tab-crew, .tab-changes) .create-child {
     display: block;
   }
 }
@@ -278,6 +278,7 @@ body.detached .dnd5e2.sheet .tab { max-height: unset; }
 .dnd5e2.active-effect-config {
   .sheet-header { --dnd5e-document-image-size: 96px; }
   .document-name {
+    background: var(--dnd5e-background-5);
     font-family: var(--dnd5e-font-modesto);
     font-size: var(--font-size-32);
     font-weight: bold;

--- a/less/variables/dark.less
+++ b/less/variables/dark.less
@@ -158,22 +158,22 @@
     --control-active-background-color: rgb(0 0 0 / 45%);
   }
 
-  input, textarea, file-picker, formula-input, document-tags, string-tags {
+  input, textarea, color-picker, file-picker, formula-input, document-tags, string-tags {
     --input-placeholder-color: var(--dnd5e-color-blue-gray-3);
   }
 
-  input, select, file-picker, formula-input, document-tags, string-tags {
+  input, select, color-picker, file-picker, formula-input, document-tags, string-tags {
     --input-background-color: var(--dnd5e-color-blue-gray-2);
     --input-disabled-background-color: var(--dnd5e-color-dark-gray);
   }
 
-  input:not([type=range]), select, file-picker, formula-input, document-tags, string-tags {
+  input:not([type=range]), select, color-picker, file-picker, formula-input, document-tags, string-tags {
     --input-border-color: var(--dnd5e-color-blue-gray-1);
     --input-hover-border-color: transparent;
   }
 
   fieldset.card {
-    input:not([type=range]), select, file-picker, formula-input, document-tags, string-tags {
+    input:not([type=range]), select, color-picker, file-picker, formula-input, document-tags, string-tags {
       --input-background-color: var(--dnd5e-background-25);
     }
     .input-element-tags .tag {

--- a/less/variables/light.less
+++ b/less/variables/light.less
@@ -153,18 +153,18 @@
     --control-active-background-color: rgb(0 0 0 / 20%);
   }
 
-  input, textarea, file-picker, formula-input, document-tags, string-tags { --input-placeholder-color: var(--color-text-light-6); }
+  input, textarea, color-picker, file-picker, formula-input, document-tags, string-tags { --input-placeholder-color: var(--color-text-light-6); }
 
-  input, textarea, select, file-picker, formula-input, document-tags, string-tags {
+  input, textarea, select, color-picker, file-picker, formula-input, document-tags, string-tags {
     --input-background-color: rgb(0 0 0 / 10%);
     --input-disabled-background-color: rgb(0 0 0 / 20%);
   }
-  file-picker > input, formula-input > input {
+  color-picker > input, file-picker > input, formula-input > input {
     --input-background-color: transparent;
     --input-disabled-background-color: transparent;
   }
 
-  input:not([type=range]), textarea, select, file-picker, formula-input, document-tags, string-tags {
+  input:not([type=range]), textarea, select, color-picker, file-picker, formula-input, document-tags, string-tags {
     --input-border-color: transparent;
     --input-hover-border-color: var(--dnd5e-color-gold);
   }

--- a/less/variables/light.less
+++ b/less/variables/light.less
@@ -143,6 +143,8 @@
   --radio-list-hover: var(--dnd5e-color-parchment);
   --formula-input-icon-color: var(--color-text-primary);
 
+  a[href] { color: var(--dnd5e-color-maroon); }
+
   button {
     --button-border-color: var(--color-border-light-2);
     --button-hover-border-color: var(--dnd5e-color-gold);

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -1,3 +1,4 @@
+export * as activeEffect from "./active-effect/_module.mjs";
 export * as activity from "./activity/_module.mjs";
 export * as actor from "./actor/_module.mjs";
 export * as advancement from "./advancement/_module.mjs";

--- a/module/applications/active-effect/_module.mjs
+++ b/module/applications/active-effect/_module.mjs
@@ -1,0 +1,2 @@
+export {default as ActiveEffectSheet5e} from "./active-effect-sheet.mjs";
+export {default as EffectChangeConfig} from "./effect-change-config.mjs";

--- a/module/applications/active-effect/active-effect-sheet.mjs
+++ b/module/applications/active-effect/active-effect-sheet.mjs
@@ -83,7 +83,9 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
    * @protected
    */
   async _prepareChangesContext(context, options) {
-    context.changes = context.document.system.changes.map(c => this.document.getSheetChangeContext(c));
+    context.changes = await Promise.all(
+      context.document.system.changes.map(c => this.document.getSheetChangeContext(c))
+    );
     return context;
   }
 
@@ -168,7 +170,7 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
    * @type {ApplicationClickAction}
    */
   static async #onDeleteChange(event, target) {
-    const index = Number(event.target.closest("[data-index]")?.dataset.index || 0);
+    const index = Number(target.closest("[data-index]")?.dataset.index || 0);
     return this.submit({
       updateData: {
         system: {
@@ -186,7 +188,7 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
    * @type {ApplicationClickAction}
    */
   static async #onEditChange(event, target) {
-    const { changeId } = event.target.closest("[data-change-id]")?.dataset ?? {};
+    const { changeId } = target.closest("[data-change-id]")?.dataset ?? {};
     const app = new EffectChangeConfig({ changeId, document: this.document });
     this._renderChild(app);
   }

--- a/module/applications/active-effect/active-effect-sheet.mjs
+++ b/module/applications/active-effect/active-effect-sheet.mjs
@@ -27,7 +27,7 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
   /** @override */
   static PARTS = {
     header: {
-      template: "templates/sheets/active-effect/header.hbs"
+      template: "systems/dnd5e/templates/effects/effect-header.hbs"
     },
     tabs: {
       template: "templates/generic/tab-navigation.hbs"
@@ -81,8 +81,8 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
    */
   async _prepareChangesContext(context, options) {
     // TODO: Make use of change context preparation in AE breakout PR once it is merged
-    context.changes = context.source.changes.map(c => ({
-      key: c.key, value: c.value,
+    context.changes = context.document.system.changes.map(c => ({
+      id: c._id, key: c.key, value: c.value,
       type: _loc(ActiveEffect.CHANGE_TYPES[c.type]?.label)
     }));
     return context;
@@ -128,15 +128,6 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
   }
 
   /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  async _onRender(context, options) {
-    await super._onRender(context, options);
-    this.element.querySelector(".sheet-header img").classList.add("document-image");
-    this.element.querySelector('.sheet-header [name="name"]').classList.add("document-name");
-  }
-
-  /* -------------------------------------------- */
   /*  Event Listeners and Handlers                */
   /* -------------------------------------------- */
 
@@ -166,7 +157,7 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
         }
       }
     });
-    const app = new EffectChangeConfig({ effect: this.document, index: this.document.system.changes.length - 1 });
+    const app = new EffectChangeConfig({ changeId: this.document.system.changes.at(-1)._id, document: this.document });
     this._renderChild(app);
   }
 
@@ -196,8 +187,8 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
    * @type {ApplicationClickAction}
    */
   static async #onEditChange(event, target) {
-    const index = Number(event.target.closest("[data-index]")?.dataset.index || 0);
-    const app = new EffectChangeConfig({ effect: this.document, index });
+    const { changeId } = event.target.closest("[data-change-id]")?.dataset ?? {};
+    const app = new EffectChangeConfig({ changeId, document: this.document });
     this._renderChild(app);
   }
 

--- a/module/applications/active-effect/active-effect-sheet.mjs
+++ b/module/applications/active-effect/active-effect-sheet.mjs
@@ -1,0 +1,205 @@
+import ApplicationV2Mixin from "../api/application-v2-mixin.mjs";
+import EffectChangeConfig from "./effect-change-config.mjs";
+
+const { ActiveEffectConfig } = foundry.applications.sheets;
+
+/**
+ * Extension of the default active effect sheet to add conditional fields & dnd5e styling.
+ */
+export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffectConfig, { handlebars: false }) {
+
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    actions: {
+      addChange: ActiveEffectSheet5e.#onAddChange,
+      deleteChange: ActiveEffectSheet5e.#onDeleteChange,
+      editChange: ActiveEffectSheet5e.#onEditChange
+    },
+    classes: ["standard-form", "titlebar", "hidden-title"],
+    form: {
+      closeOnSubmit: false,
+      submitOnChange: true
+    }
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    header: {
+      template: "templates/sheets/active-effect/header.hbs"
+    },
+    tabs: {
+      template: "templates/generic/tab-navigation.hbs"
+    },
+    details: {
+      template: "systems/dnd5e/templates/effects/effect-details.hbs",
+      scrollable: [""]
+    },
+    duration: {
+      template: "templates/sheets/active-effect/duration.hbs"
+    },
+    changes: {
+      template: "systems/dnd5e/templates/effects/effect-changes.hbs",
+      scrollable: ["ol.changes"]
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    context.systemFields = this.document.system.schema.fields;
+    context.additionalChangesFields = [];
+    await this.document.system.getSheetData?.(context);
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preparePartContext(partId, context, options) {
+    context = await super._preparePartContext(partId, context, options);
+    switch ( partId ) {
+      case "changes": return this._prepareChangesContext(context, options);
+      case "details": return this._prepareDetailsContext(context, options);
+    }
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the changes tab.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {ApplicationRenderContext}
+   * @protected
+   */
+  async _prepareChangesContext(context, options) {
+    // TODO: Make use of change context preparation in AE breakout PR once it is merged
+    context.changes = context.source.changes.map(c => ({
+      key: c.key, value: c.value,
+      type: _loc(ActiveEffect.CHANGE_TYPES[c.type]?.label)
+    }));
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the details tab.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {ApplicationRenderContext}
+   * @protected
+   */
+  async _prepareDetailsContext(context, options) {
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _renderChange(context) {}
+
+  /* -------------------------------------------- */
+  /*  Life-Cycle Handlers                         */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onFirstRender(context, options) {
+    await super._onFirstRender(context, options);
+    this.element.classList.add(`tab-${this.tabGroups.sheet}`);
+
+    // Create child button
+    if ( this.isEditable ) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.ariaLabel = _loc("CONTROLS.CommonCreate");
+      button.classList.add("create-child", "gold-button", "always-interactive");
+      button.dataset.action = "addChange";
+      button.innerHTML = '<i class="fas fa-plus" inert></i>';
+      this.element.querySelector(".window-content").append(button);
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onRender(context, options) {
+    await super._onRender(context, options);
+    this.element.querySelector(".sheet-header img").classList.add("document-image");
+    this.element.querySelector('.sheet-header [name="name"]').classList.add("document-name");
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  changeTab(tab, group, options) {
+    super.changeTab(tab, group, options);
+    if ( group !== "sheet" ) return;
+    this.element.className = this.element.className.replace(/tab-\w+/g, "");
+    this.element.classList.add(`tab-${tab}`);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Add a change from the effect's changes array.
+   * @this {ActiveEffectSheet5e}
+   * @type {ApplicationClickAction}
+   */
+  static async #onAddChange(event, target) {
+    await this.submit({
+      updateData: {
+        system: {
+          changes: [
+            ...this.document.system.toObject().changes,
+            this.document.system.schema.fields.changes.element.getInitialValue()
+          ]
+        }
+      }
+    });
+    const app = new EffectChangeConfig({ effect: this.document, index: this.document.system.changes.length - 1 });
+    this._renderChild(app);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Delete a change from the effect's changes array.
+   * @this {ActiveEffectSheet5e}
+   * @type {ApplicationClickAction}
+   */
+  static async #onDeleteChange(event, target) {
+    const index = Number(event.target.closest("[data-index]")?.dataset.index || 0);
+    return this.submit({
+      updateData: {
+        system: {
+          changes: this.document.system.toObject().changes.toSpliced(index, 1)
+        }
+      }
+    });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Open the config application for editing a change.
+   * @this {ActiveEffectSheet5e}
+   * @type {ApplicationClickAction}
+   */
+  static async #onEditChange(event, target) {
+    const index = Number(event.target.closest("[data-index]")?.dataset.index || 0);
+    const app = new EffectChangeConfig({ effect: this.document, index });
+    this._renderChild(app);
+  }
+
+  // TODO: Add context options to changes
+}

--- a/module/applications/active-effect/active-effect-sheet.mjs
+++ b/module/applications/active-effect/active-effect-sheet.mjs
@@ -41,6 +41,9 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
     },
     changes: {
       template: "systems/dnd5e/templates/effects/effect-changes.hbs",
+      templates: [
+        "systems/dnd5e/templates/effects/columns/value.hbs"
+      ],
       scrollable: ["ol.changes"]
     }
   };
@@ -80,11 +83,7 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
    * @protected
    */
   async _prepareChangesContext(context, options) {
-    // TODO: Make use of change context preparation in AE breakout PR once it is merged
-    context.changes = context.document.system.changes.map(c => ({
-      id: c._id, key: c.key, value: c.value,
-      type: _loc(ActiveEffect.CHANGE_TYPES[c.type]?.label)
-    }));
+    context.changes = context.document.system.changes.map(c => this.document.getSheetChangeContext(c));
     return context;
   }
 

--- a/module/applications/active-effect/effect-change-config.mjs
+++ b/module/applications/active-effect/effect-change-config.mjs
@@ -1,22 +1,24 @@
 import { formatNumber } from "../../utils.mjs";
-import Application5e from "../api/application.mjs";
+import DocumentSheet5e from "../api/document-sheet.mjs";
 
 /**
  * Application for editing a single active effect change.
  */
-export default class EffectChangeConfig extends Application5e {
+export default class EffectChangeConfig extends DocumentSheet5e {
   /** @inheritDoc */
   static DEFAULT_OPTIONS = {
+    canImport: false,
+    changeId: null,
     classes: ["standard-form"],
-    effect: null,
     form: {
       closeOnSubmit: true,
       handler: EffectChangeConfig.#handleFormSubmission
     },
-    index: null,
+    ownershipConfig: false,
     position: {
       width: 500
     },
+    sheetConfig: false,
     tag: "form"
   };
 
@@ -40,7 +42,7 @@ export default class EffectChangeConfig extends Application5e {
    * Active effect to which this change belongs.
    */
   get effect() {
-    return this.options.effect;
+    return this.options.document;
   }
 
   /* -------------------------------------------- */
@@ -48,12 +50,21 @@ export default class EffectChangeConfig extends Application5e {
   /** @override */
   get title() {
     return _loc("DND5E.EFFECT.Change.Title", {
-      effect: this.effect.name, number: formatNumber(this.options.index + 1)
+      effect: this.effect.name, number: this.options.changeId
     });
   }
 
   /* -------------------------------------------- */
   /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _initializeApplicationOptions(options) {
+    options = super._initializeApplicationOptions(options);
+    options.uniqueId = `${options.uniqueId}-Change-${options.changeId}`;
+    return options;
+  }
+
   /* -------------------------------------------- */
 
   /** @inheritDoc */
@@ -76,8 +87,8 @@ export default class EffectChangeConfig extends Application5e {
    * @protected
    */
   async _prepareConfigContext(context, options) {
-    context.source = this.effect.system._source.changes[this.options.index];
-    context.defaultPriority = ActiveEffect.CHANGE_TYPES[context.source.type]?.defaultPriority;
+    context.source = this.effect.system._source.changes.find(c => c._id === this.options.changeId);
+    context.defaultPriority = ActiveEffect.CHANGE_TYPES[context.source?.type]?.defaultPriority;
     context.fields = this.effect.system.schema.fields.changes.element.fields;
 
     context.hintText = _loc("DND5E.ACTIVEEFFECT.AttributeKeyTooltip", {
@@ -108,6 +119,14 @@ export default class EffectChangeConfig extends Application5e {
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async render(...args) {
+    if ( !this.effect.system.changes.find(c => c._id === this.options.changeId) ) return this.close();
+    return super.render(...args);
+  }
+
+  /* -------------------------------------------- */
   /*  Form Handling                               */
   /* -------------------------------------------- */
 
@@ -119,9 +138,10 @@ export default class EffectChangeConfig extends Application5e {
    * @param {FormDataExtended} formData  Data from the dialog.
    */
   static #handleFormSubmission(event, form, formData) {
-    const submitData = foundry.utils.expandObject(formData.object);
     const changes = this.effect.system.toObject().changes;
-    foundry.utils.mergeObject(changes[this.options.index], submitData);
+    const change = changes.find(c => c._id === this.options.changeId);
+    if ( !change ) return;
+    foundry.utils.mergeObject(change, foundry.utils.expandObject(formData.object));
     this.effect.update({ "system.changes": changes });
   }
 }

--- a/module/applications/active-effect/effect-change-config.mjs
+++ b/module/applications/active-effect/effect-change-config.mjs
@@ -1,0 +1,127 @@
+import { formatNumber } from "../../utils.mjs";
+import Application5e from "../api/application.mjs";
+
+/**
+ * Application for editing a single active effect change.
+ */
+export default class EffectChangeConfig extends Application5e {
+  /** @inheritDoc */
+  static DEFAULT_OPTIONS = {
+    classes: ["standard-form"],
+    effect: null,
+    form: {
+      closeOnSubmit: true,
+      handler: EffectChangeConfig.#handleFormSubmission
+    },
+    index: null,
+    position: {
+      width: 500
+    },
+    tag: "form"
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  static PARTS = {
+    config: {
+      template: "systems/dnd5e/templates/effects/change-config.hbs"
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs"
+    }
+  };
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Active effect to which this change belongs.
+   */
+  get effect() {
+    return this.options.effect;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  get title() {
+    return _loc("DND5E.EFFECT.Change.Title", {
+      effect: this.effect.name, number: formatNumber(this.options.index + 1)
+    });
+  }
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preparePartContext(partId, context, options) {
+    context = await super._preparePartContext(partId, context, options);
+    switch ( partId ) {
+      case "config": return this._prepareConfigContext(context, options);
+      case "footer": return this._prepareFooterContext(context, options);
+    }
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the config section.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {ApplicationRenderContext}
+   * @protected
+   */
+  async _prepareConfigContext(context, options) {
+    context.source = this.effect.system._source.changes[this.options.index];
+    context.defaultPriority = ActiveEffect.CHANGE_TYPES[context.source.type]?.defaultPriority;
+    context.fields = this.effect.system.schema.fields.changes.element.fields;
+
+    context.hintText = _loc("DND5E.ACTIVEEFFECT.AttributeKeyTooltip", {
+      url: this.effect.type === "enchantment"
+        ? "https://github.com/foundryvtt/dnd5e/wiki/Enchantment"
+        : "https://github.com/foundryvtt/dnd5e/wiki/Active-Effect-Guide"
+    });
+
+    context.typeOptions = Object.entries(ActiveEffect.CHANGE_TYPES)
+      .map(([value, { label }]) => ({ value, label: _loc(label) }))
+      .sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang));
+
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare rendering context for the footer buttons.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   * @returns {ApplicationRenderContext}
+   * @protected
+   */
+  async _prepareFooterContext(context, options) {
+    context.buttons = [{ type: "submit", icon: "fa-solid fa-floppy-disk", label: "EFFECT.Submit" }];
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Form Handling                               */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle submission of the application.
+   * @this {EffectChangeConfig}
+   * @param {Event|SubmitEvent} event    The form submission event.
+   * @param {HTMLFormElement} form       The submitted form.
+   * @param {FormDataExtended} formData  Data from the dialog.
+   */
+  static #handleFormSubmission(event, form, formData) {
+    const submitData = foundry.utils.expandObject(formData.object);
+    const changes = this.effect.system.toObject().changes;
+    foundry.utils.mergeObject(changes[this.options.index], submitData);
+    this.effect.update({ "system.changes": changes });
+  }
+}

--- a/module/applications/active-effect/effect-change-config.mjs
+++ b/module/applications/active-effect/effect-change-config.mjs
@@ -39,7 +39,18 @@ export default class EffectChangeConfig extends DocumentSheet5e {
   /* -------------------------------------------- */
 
   /**
+   * The change's source data.
+   * @type {object}
+   */
+  get change() {
+    return this.effect.system._source.changes.find(c => c._id === this.options.changeId);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Active effect to which this change belongs.
+   * @type {ActiveEffect5e}
    */
   get effect() {
     return this.options.document;
@@ -49,9 +60,8 @@ export default class EffectChangeConfig extends DocumentSheet5e {
 
   /** @override */
   get title() {
-    return _loc("DND5E.EFFECT.Change.Title", {
-      effect: this.effect.name, number: this.options.changeId
-    });
+    const number = formatNumber(this.effect.system.changes.findIndex(c => c._id === this.options.changeId) + 1);
+    return _loc("DND5E.EFFECT.Change.Title", { effect: this.effect.name, number });
   }
 
   /* -------------------------------------------- */
@@ -87,7 +97,7 @@ export default class EffectChangeConfig extends DocumentSheet5e {
    * @protected
    */
   async _prepareConfigContext(context, options) {
-    context.source = this.effect.system._source.changes.find(c => c._id === this.options.changeId);
+    context.source = this.change;
     context.defaultPriority = ActiveEffect.CHANGE_TYPES[context.source?.type]?.defaultPriority;
     context.fields = this.effect.system.schema.fields.changes.element.fields;
 
@@ -122,7 +132,7 @@ export default class EffectChangeConfig extends DocumentSheet5e {
 
   /** @inheritDoc */
   async render(...args) {
-    if ( !this.effect.system.changes.find(c => c._id === this.options.changeId) ) return this.close();
+    if ( !this.change ) return this.close();
     return super.render(...args);
   }
 

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -81,7 +81,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
       togglePip: BaseActorSheet.#togglePip,
       toggleSidebar: BaseActorSheet.#toggleSidebar
     },
-    classes: ["actor", "standard-form"],
+    classes: ["actor", "standard-form", "hidden-title"],
     elements: {
       effects: "dnd5e-effects",
       inventory: "dnd5e-inventory"

--- a/module/applications/api/application-v2-mixin.mjs
+++ b/module/applications/api/application-v2-mixin.mjs
@@ -474,6 +474,30 @@ export default function ApplicationV2Mixin(Base, { handlebars=true }={}) {
       if ( this.parent ) return this.parent.renderChild(app, options);
       return this.renderChild(app, options);
     }
+
+    /* -------------------------------------------- */
+    /*  Helpers                                     */
+    /* -------------------------------------------- */
+
+    /**
+     * Replace all matching elements with a new tag, keeping all existing attributes.
+     * @param {string} selector              CSS selector to find elements to replace.
+     * @param {string} tagName               Tag name for the new element to use.
+     * @param {object} [options={}]
+     * @param {Function} [options.callback]  Method called for each new element before it replaces the old one.
+     * @protected
+     */
+    _replaceElements(selector, tagName, { callback }={}) {
+      for ( const oldElement of this.element.querySelectorAll(selector) ) {
+        const newElement = document.createElement(tagName);
+        for ( const attr of oldElement.attributes ) {
+          newElement.setAttribute(attr.name, attr.value);
+        }
+        newElement.innerHTML = oldElement.innerHTML;
+        if ( callback ) callback(newElement);
+        oldElement.replaceWith(newElement);
+      }
+    }
   }
   return BaseApplication5e;
 }

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -32,7 +32,7 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
       showIcon: ItemSheet5e.#showIcon,
       toggleState: ItemSheet5e.#toggleState
     },
-    classes: ["item"],
+    classes: ["item", "hidden-title"],
     editingDescriptionTarget: null,
     elements: {
       activities: "dnd5e-activities",

--- a/module/applications/roll-table-sheet.mjs
+++ b/module/applications/roll-table-sheet.mjs
@@ -13,7 +13,7 @@ export default class RollTableSheet5e extends ApplicationV2Mixin(RollTableSheet,
       changeMode: RollTableSheet5e.#onChangeMode,
       editImage: RollTableSheet5e._onEditImage
     },
-    classes: ["titlebar"]
+    classes: ["titlebar", "hidden-title"]
   };
 
   /* -------------------------------------------- */
@@ -35,28 +35,6 @@ export default class RollTableSheet5e extends ApplicationV2Mixin(RollTableSheet,
       }
     });
     this.element.querySelectorAll("table td.image img").forEach(icon => icon.classList.add("gold-icon"));
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Replace all matching elements with a new tag, keeping all existing attributes.
-   * @param {string} selector              CSS selector to find elements to replace.
-   * @param {string} tagName               Tag name for the new element to use.
-   * @param {object} [options={}]
-   * @param {Function} [options.callback]  Method called for each new element before it replaces the old one.
-   * @protected
-   */
-  _replaceElements(selector, tagName, { callback }={}) {
-    for ( const oldElement of this.element.querySelectorAll(selector) ) {
-      const newElement = document.createElement(tagName);
-      for ( const attr of oldElement.attributes ) {
-        newElement.setAttribute(attr.name, attr.value);
-      }
-      newElement.innerHTML = oldElement.innerHTML;
-      if ( callback ) callback(newElement);
-      oldElement.replaceWith(newElement);
-    }
   }
 
   /* -------------------------------------------- */

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -57,4 +57,15 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
    * @param {ApplicationRenderContext} context  The app's rendering context.
    */
   onRenderActiveEffectConfig(app, html, context) {}
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare type-specific data for the Active Effect config sheet.
+   * @param {ApplicationRenderContext} context  Sheet context data.
+   * @returns {Promise<void>}
+   */
+  async getSheetData(context) {}
 }

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -1,3 +1,5 @@
+import { getHumanReadableAttributeLabel } from "../../utils.mjs";
+
 const { DocumentIdField } = foundry.data.fields;
 
 /**
@@ -75,6 +77,19 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
 
   /* -------------------------------------------- */
   /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare the context for individual changes to display on actor, item, or active effect sheets.
+   * @param {object} change  Change to prepare.
+   * @returns {object}       An object of chat data to render.
+   */
+  async getSheetChangeContext(change) {
+    return {
+      name: getHumanReadableAttributeLabel(change.key, { actor: this.actor, prefixItemName: false })
+    };
+  }
+
   /* -------------------------------------------- */
 
   /**

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -1,8 +1,23 @@
+const { DocumentIdField } = foundry.data.fields;
+
 /**
  * Abstract base class to add some shared functionality to all of the system's custom active effect types.
  * @abstract
  */
 export default class ActiveEffectDataModel extends foundry.data.ActiveEffectTypeDataModel {
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static defineSchema() {
+    const schema = super.defineSchema();
+    schema.changes.element.extendFields({
+      _id: new DocumentIdField({ initial: () => foundry.utils.randomID() })
+    });
+    return schema;
+  }
+
   /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */

--- a/module/data/active-effect/base.mjs
+++ b/module/data/active-effect/base.mjs
@@ -50,4 +50,17 @@ export default class BaseEffectData extends ActiveEffectDataModel {
   get isRider() {
     return this.item?.getFlag("dnd5e", "riders.effect")?.includes?.(this.parent.id) ?? false;
   }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async getSheetData(context) {
+    context.additionalChangesFields.unshift({
+      field: context.systemFields.rider.fields.statuses,
+      options: Object.values(CONFIG.statusEffects).map(se => ({ value: se.id, label: se.name })),
+      value: context.source.system.rider.statuses
+    });
+  }
 }

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -1,3 +1,4 @@
+import { getHumanReadableAttributeLabel } from "../../utils.mjs";
 import ActiveEffectDataModel from "../abstract/active-effect-data-model.mjs";
 import { DamageData } from "../shared/damage-field.mjs";
 
@@ -221,5 +222,18 @@ export default class EnchantmentData extends ActiveEffectDataModel {
    */
   static availableForItem(doc) {
     return !doc || (doc instanceof Item);
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async getSheetChangeContext(change) {
+    return {
+      name: getHumanReadableAttributeLabel(change.key, {
+        item: this.isAppliedEnchantment ? this.item : true, prefixItemName: false
+      })
+    };
   }
 }

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -18,7 +18,7 @@ export default class EnchantmentData extends ActiveEffectDataModel {
   /* -------------------------------------------- */
 
   /** @override */
-  static LOCALIZATION_PREFIXES = ["DND5E.ENCHANTMENT"];
+  static LOCALIZATION_PREFIXES = ["DND5E.EFFECT.BASE", "DND5E.ENCHANTMENT"];
 
   /* -------------------------------------------- */
 
@@ -160,7 +160,7 @@ export default class EnchantmentData extends ActiveEffectDataModel {
 
   /** @override */
   onRenderActiveEffectConfig(app, html, context) {
-    const toRemove = html.querySelectorAll('.form-group:has([name="transfer"], [name="statuses"])');
+    const toRemove = html.querySelectorAll('.form-group:has([name="transfer"], [name="statuses"], [name="showIcon"])');
     toRemove.forEach(f => f.remove());
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -2,7 +2,7 @@ import CreateDocumentDialog from "../applications/create-document-dialog.mjs";
 import ConditionData from "../data/active-effect/condition.mjs";
 import FormulaField from "../data/fields/formula-field.mjs";
 import MappingField from "../data/fields/mapping-field.mjs";
-import { getHumanReadableAttributeLabel, parseOrString, staticID } from "../utils.mjs";
+import { parseOrString, staticID } from "../utils.mjs";
 import Item5e from "./item.mjs";
 import DependentDocumentMixin from "./mixins/dependent.mjs";
 
@@ -950,7 +950,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /**
    * Prepare the context used to display an effect on an actor or item sheet.
-   * @returns {object}  An object of chat data to render.
+   * @returns {object}  Context needed to render the effect on an actor or item sheet.
    */
   async getSheetContext() {
     this.updateDuration();
@@ -958,7 +958,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     const source = await this.getSource();
     return {
       id, name, img, disabled, duration, source,
-      changes: this.changes.map(change => this.getSheetChangeContext(change)),
+      changes: await Promise.all(this.changes.map(change => this.getSheetChangeContext(change))),
       durationParts: Number.isFinite(duration.remaining) ? duration.label.split(", ") : [],
       showDuration: Number.isFinite(duration.value),
       effect: this
@@ -969,17 +969,14 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /**
    * Prepare the context for individual changes to display on actor, item, or active effect sheets.
-   * @param {object} change                     Change to prepare.
-   * @returns {object}  An object of chat data to render.
+   * @param {object} change  Change to prepare.
+   * @returns {object}       Context needed to render the change.
    */
-  getSheetChangeContext(change) {
-    const attributeCtx = this.type === "enchantment"
-      ? { item: this.isAppliedEnchantment ? this.item : true }
-      : { actor: this.actor };
+  async getSheetChangeContext(change) {
     return {
       ...change,
-      name: getHumanReadableAttributeLabel(change.key, { ...attributeCtx, prefixItemName: false }),
-      typeLabel: _loc(ActiveEffect.CHANGE_TYPES[change.type]?.label)
+      typeLabel: _loc(ActiveEffect.CHANGE_TYPES[change.type]?.label),
+      ...((await this.system.getSheetChangeContext?.(change)) ?? {})
     };
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -973,11 +973,13 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @returns {object}       Context needed to render the change.
    */
   async getSheetChangeContext(change) {
-    return {
+    const context = {
       ...change,
       typeLabel: _loc(ActiveEffect.CHANGE_TYPES[change.type]?.label),
       ...((await this.system.getSheetChangeContext?.(change)) ?? {})
     };
+    context.name ||= change.key;
+    return context;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -223,6 +223,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /** @inheritDoc */
   static applyChange(model, change, options={}) {
+    // Apply shims to moved fields
     change = change.effect._applyChangeShim(change);
 
     // Handle special actor flags
@@ -236,7 +237,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
     // Handle activity-targeted changes
     if ( (change.key.startsWith("activities[") || change.key.startsWith("system.activities."))
-      && (model instanceof Item) ) return change.effect.applyActivity(model, change);
+      && (model instanceof Item) ) return change.effect.applyActivity(model, change, options);
 
     // Handle hiding items
     if ( (change.key === "items.hidden") && (model instanceof Actor) ) {
@@ -259,12 +260,13 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * Apply a change to activities on this item.
    * @param {Item5e} item              The Item to whom this change should be applied.
    * @param {EffectChangeData} change  The change data being applied.
+   * @param {object} [options]         Options passed through to `ActiveEffect#applyChange`.
    * @returns {Record<string, *>}      An object of property paths and their updated values.
    */
-  applyActivity(item, change) {
+  applyActivity(item, change, options) {
     const changes = {};
     const apply = (activity, key) => {
-      const c = this.constructor.applyChange(activity, { ...change, key });
+      const c = this.constructor.applyChange(activity, { ...change, key }, options);
       Object.entries(c).forEach(([k, v]) => changes[`system.activities.${activity.id}.${k}`] = v);
     };
     if ( change.key.startsWith("system.activities.") ) {
@@ -718,37 +720,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @param {ApplicationRenderContext} context The app's rendering context.
    */
   static onRenderActiveEffectConfig(app, html, context) {
-    if ( app.document.system.onRenderActiveEffectConfig?.(app, html, context) === false ) return;
-    const fields = app.document.system.schema.fields;
-    const magicalField = fields.magical?.toFormGroup({}, {
-      value: app.document.system._source.magical,
-      disabled: !context.editable
-    });
-    const statusesField = fields.rider?.fields?.statuses?.toFormGroup({}, {
-      value: app.document.system._source.rider?.statuses ?? [],
-      options: Object.values(CONFIG.statusEffects).map(se => ({ value: se.id, label: se.name })),
-      disabled: !context.editable
-    });
-    const detailsTab = html.querySelector("[data-application-part=details]");
-    const statuses = detailsTab.querySelector("& > .form-group:has([name=statuses])");
-    if ( statuses ) {
-      if ( magicalField ) statuses?.before(magicalField);
-      if ( statusesField ) statuses?.after(statusesField);
-    } else {
-      detailsTab.append(...[magicalField, statusesField].filter(_ => _));
-    }
-
-    // Add tooltip with link to wiki for effects/enchantments
-    const helpIconElement = document.createElement("i");
-    helpIconElement.classList.add("fa-solid", "fa-circle-question");
-    const tooltipText = _loc("DND5E.ACTIVEEFFECT.AttributeKeyTooltip", {
-      url: app.document.type === "enchantment"
-        ? "https://github.com/foundryvtt/dnd5e/wiki/Enchantment"
-        : "https://github.com/foundryvtt/dnd5e/wiki/Active-Effect-Guide"
-    });
-    Object.assign(helpIconElement.dataset, { tooltip: tooltipText, tooltipDirection: "RIGHT", locked: "" });
-    const targetElement = html.querySelector("section:is([data-tab='effects'], [data-tab='changes']) .key");
-    if ( targetElement ) targetElement.insertAdjacentElement("beforeend", helpIconElement);
+    app.document.system.onRenderActiveEffectConfig?.(app, html, context);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -950,34 +950,36 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /**
    * Prepare the context used to display an effect on an actor or item sheet.
-   * @param {object} [options={}]
-   * @param {number} [options.maxKeyLength=35]  Maximum length of the attribute key displayed.
    * @returns {object}  An object of chat data to render.
    */
-  async getSheetContext({ maxKeyLength=35 }={}) {
+  async getSheetContext() {
     this.updateDuration();
     const { id, name, img, disabled, duration } = this;
     const source = await this.getSource();
+    return {
+      id, name, img, disabled, duration, source,
+      changes: this.changes.map(change => this.getSheetChangeContext(change)),
+      durationParts: Number.isFinite(duration.remaining) ? duration.label.split(", ") : [],
+      showDuration: Number.isFinite(duration.value),
+      effect: this
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare the context for individual changes to display on actor, item, or active effect sheets.
+   * @param {object} change                     Change to prepare.
+   * @returns {object}  An object of chat data to render.
+   */
+  getSheetChangeContext(change) {
     const attributeCtx = this.type === "enchantment"
       ? { item: this.isAppliedEnchantment ? this.item : true }
       : { actor: this.actor };
     return {
-      id, name, img, disabled, duration, source,
-      changes: this.changes.map(change => {
-        let displayKey = change.key;
-        if ( displayKey.length > (maxKeyLength + 5) ) {
-          displayKey = displayKey.replace(/^systems.|^flags.|^activities\[/, "");
-          if ( displayKey.length > maxKeyLength ) displayKey = displayKey.slice(1 - maxKeyLength);
-          displayKey = `…${displayKey}`;
-        }
-        return {
-          ...change, displayKey,
-          name: getHumanReadableAttributeLabel(change.key, { ...attributeCtx, prefixItemName: false })
-        };
-      }),
-      durationParts: Number.isFinite(duration.remaining) ? duration.label.split(", ") : [],
-      showDuration: Number.isFinite(duration.value),
-      effect: this
+      ...change,
+      name: getHumanReadableAttributeLabel(change.key, { ...attributeCtx, prefixItemName: false }),
+      typeLabel: _loc(ActiveEffect.CHANGE_TYPES[change.type]?.label)
     };
   }
 

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -680,7 +680,9 @@ export function migrateEffects(parent, migrationData, itemUpdateData, flags={}) 
   if ( !parent.effects ) return [];
   return parent.effects.reduce((arr, e) => {
     const effectData = e instanceof CONFIG.ActiveEffect.documentClass ? e.toObject() : e;
-    let effectUpdate = migrateEffectData(effectData, migrationData, { parent });
+    let effectUpdate = migrateEffectData(effectData, migrationData, {
+      bypassVersionCheck: flags.bypassVersionCheck, parent
+    });
     if ( effectData.flags?.dnd5e?.rider ) {
       itemUpdateData["flags.dnd5e.riders.effect"] ??= [];
       itemUpdateData["flags.dnd5e.riders.effect"].push(effectData._id);
@@ -732,19 +734,23 @@ export function migrateCopyActorTransferEffects(actor, effects, { actorUuid }={}
  * @param {object} effect            Effect data to migrate.
  * @param {object} [migrationData]   Additional data to perform the migration.
  * @param {object} [options]         Additional options.
+ * @param {boolean} [options.bypassVersionCheck=false]  Bypass certain migration restrictions gated behind system
+ *                                                      version stored in item stats.
  * @param {object} [options.parent]  Parent of this effect.
  * @returns {object}                 The updateData to apply.
  */
-export function migrateEffectData(effect, migrationData, { parent }={}) {
+export function migrateEffectData(effect, migrationData, { bypassVersionCheck, parent }={}) {
   const updateData = {};
-  _migrateDocumentIcon(effect, updateData, {...migrationData, field: "img"});
-  _migrateEffectArmorClass(effect, updateData);
-  if ( foundry.utils.isNewerVersion("6.0.0", effect._stats?.systemVersion ?? parent?._stats?.systemVersion) ) {
-    _migrateEffectMagical(effect, parent, updateData);
-  }
-  if ( foundry.utils.isNewerVersion("3.1.0", effect._stats?.systemVersion ?? parent?._stats?.systemVersion) ) {
+  const version = effect._stats?.systemVersion ?? parent?._stats?.systemVersion;
+  const migrate600 = bypassVersionCheck || foundry.utils.isNewerVersion("6.0.0", version);
+
+  _migrateDocumentIcon(effect, updateData, { ...migrationData, field: "img" });
+  _migrateEffectChanges(effect, updateData, { setIds: migrate600 });
+  if ( migrate600 ) _migrateEffectMagical(effect, parent, updateData);
+  if ( bypassVersionCheck || foundry.utils.isNewerVersion("3.1.0", version) ) {
     _migrateEffectTransfer(effect, parent, updateData);
   }
+
   return updateData;
 }
 
@@ -1024,20 +1030,28 @@ function _migrateDocumentIcon(document, updateData, { iconMap, field="img" }={})
 /* -------------------------------------------- */
 
 /**
- * Change active effects that target AC.
- * @param {object} effect      Effect data to migrate.
- * @param {object} updateData  Existing update to expand upon.
- * @returns {object}           The updateData to apply.
+ * Migrate active effect changes, modifying AC-targeting effects & adding IDs.
+ * @param {object} effect             Effect data to migrate.
+ * @param {object} updateData         Existing update to expand upon.
+ * @param {object} [options={}]
+ * @param {boolean} [options.setIds]  Commit newly created IDs to system data.
+ * @returns {object}                  The updateData to apply.
  */
-function _migrateEffectArmorClass(effect, updateData) {
+function _migrateEffectChanges(effect, updateData, { setIds }={}) {
   let containsUpdates = false;
-  const changes = (effect.changes || []).map(c => {
-    if ( c.key !== "system.attributes.ac.base" ) return c;
-    c.key = "system.attributes.ac.armor";
-    containsUpdates = true;
+  const changes = (effect.system.changes || []).map(c => {
+    // Add ID
+    if ( setIds ) containsUpdates = true;
+
+    // Migrate AC keys
+    if ( c.key === "system.attributes.ac.base" ) {
+      c.key = "system.attributes.ac.armor";
+      containsUpdates = true;
+    }
+
     return c;
   });
-  if ( containsUpdates ) updateData.changes = changes;
+  if ( containsUpdates ) updateData["system.changes"] = changes;
   return updateData;
 }
 

--- a/system.json
+++ b/system.json
@@ -601,7 +601,7 @@
         "SRD 5.2": "SOURCE.BOOK.SRD52"
       }
     },
-    "needsMigrationVersion": "5.3.0",
+    "needsMigrationVersion": "6.0.0",
     "compatibleMigrationVersion": "0.8",
     "hotReload": {
       "extensions": ["css", "hbs", "json"],

--- a/templates/effects/change-config.hbs
+++ b/templates/effects/change-config.hbs
@@ -5,5 +5,5 @@
     {{ formField fields.type name=(concat prefix "type") value=source.type options=typeOptions rootId=partId }}
     {{ formField fields.value name=(concat prefix "value") value=source.value elementType="input" rootId=partId }}
     {{ formField fields.priority name=(concat prefix "priority") value=source.priority
-                 placeholder=defaultPriority rootId=@root.partId }}
+                 placeholder=defaultPriority rootId=partId }}
 </fieldset>

--- a/templates/effects/change-config.hbs
+++ b/templates/effects/change-config.hbs
@@ -1,0 +1,9 @@
+<fieldset>
+    <legend>{{ localize "DND5E.EFFECT.Change.Configuration" }}</legend>
+    <p class="note info">{{{ hintText }}}</p>
+    {{ formField fields.key name=(concat prefix "key") value=source.key rootId=partId }}
+    {{ formField fields.type name=(concat prefix "type") value=source.type options=typeOptions rootId=partId }}
+    {{ formField fields.value name=(concat prefix "value") value=source.value elementType="input" rootId=partId }}
+    {{ formField fields.priority name=(concat prefix "priority") value=source.priority
+                 placeholder=defaultPriority rootId=@root.partId }}
+</fieldset>

--- a/templates/effects/effect-changes.hbs
+++ b/templates/effects/effect-changes.hbs
@@ -1,0 +1,59 @@
+<section class="tab scrollable changes {{~#if tab.active}} active{{/if}}" data-group="{{ tab.group }}" data-tab="{{ tab.id }}">
+
+    <section class="itmes-list changes-list">
+        <div class="items-section card">
+            <div class="items-header header">
+                <h3 class="item-name">{{ localize "DND5E.EFFECT.Change.Label" }}</h3>
+                <div class="item-header effect-type">{{ localize "EFFECT.FIELDS.changes.element.type.label" }}</div>
+                <div class="item-header effect-value">{{ localize "DND5E.Value" }}</div>
+                <div class="item-header item-controls"></div>
+            </div>
+            <ol class="item-list changes unlist">
+                {{#each changes}}
+                <li class="item change" data-index="{{ @index }}">
+                    <div class="item-row change-row">
+                        <div class="item-name">
+                            <div class="name name-stacked">
+                                <!-- TODO: Add human-readable name once AE breakout is merged -->
+                                <span class="title">{{ key }}</span>
+                            </div>
+                        </div>
+                        <div class="item-detail effect-type">
+                            <span class="condensed">{{ type }}</span>
+                        </div>
+                        <div class="item-detail effect-value">
+                            <span class="condensed">{{ value }}</span>
+                        </div>
+                        <div class="item-detail item-controls">
+                            {{#if @root.editable}}
+                            {{!-- Editing --}}
+                            <button class="unbutton config-button item-control icon fa-solid fa-pen-to-square"
+                                    type="button" data-action="editChange" data-tooltip
+                                    aria-label="{{ localize 'DND5E.EFFECT.Action.EditChange' }}"></button>
+
+                            {{!-- Deleting --}}
+                            <button class="unbutton config-button item-control icon fa-solid fa-trash"
+                                    type="button" data-action="deleteChange" data-tooltip
+                                    aria-label="{{ localize 'DND5E.EFFECT.Action.DeleteChange' }}"></button>
+                            {{/if}}
+
+                            {{!-- Context Menu --}}
+                            <button class="unbutton config-button item-control always-interactive icon fa-solid
+                                    fa-ellipsis-vertical" type="button" data-context-menu
+                                    aria-label="{{ localize 'DND5E.AdditionalControls' }}"></button>
+                        </div>
+                    </div>
+                </li>
+                {{/each}}
+            </ol>
+        </div>
+    </section>
+
+    {{#if additionalChangesFields.length}}
+    <fieldset>
+        <legend>{{ localize "DND5E.EFFECT.AdditionalChanges" }}</legend>
+        {{> "dnd5e.fieldlist" additionalChangesFields}}
+    </fieldset>
+    {{/if}}
+
+</section>

--- a/templates/effects/effect-changes.hbs
+++ b/templates/effects/effect-changes.hbs
@@ -24,18 +24,18 @@
                         <div class="item-detail item-controls">
                             {{#if @root.editable}}
                             {{!-- Editing --}}
-                            <button class="unbutton config-button item-control icon fa-solid fa-pen-to-square"
+                            <button class="unbutton control-button inline-control icon fa-solid fa-pen-to-square"
                                     type="button" data-action="editChange" data-tooltip
                                     aria-label="{{ localize 'DND5E.EFFECT.Action.EditChange' }}"></button>
 
                             {{!-- Deleting --}}
-                            <button class="unbutton config-button item-control icon fa-solid fa-trash"
+                            <button class="unbutton control-button inline-control icon fa-solid fa-trash"
                                     type="button" data-action="deleteChange" data-tooltip
                                     aria-label="{{ localize 'DND5E.EFFECT.Action.DeleteChange' }}"></button>
                             {{/if}}
 
                             {{!-- Context Menu --}}
-                            <button class="unbutton config-button item-control always-interactive icon fa-solid
+                            <button class="unbutton control-button inline-control always-interactive icon fa-solid
                                     fa-ellipsis-vertical" type="button" data-context-menu
                                     aria-label="{{ localize 'DND5E.AdditionalControls' }}"></button>
                         </div>

--- a/templates/effects/effect-changes.hbs
+++ b/templates/effects/effect-changes.hbs
@@ -14,7 +14,8 @@
                     <div class="item-row change-row">
                         <div class="item-name">
                             <div class="name name-stacked">
-                                <span class="title" data-tooltip="{{ key }}">{{ name }}</span>
+                                <span class="title"
+                                      {{~#unless (eq name key)}} data-tooltip="{{ key }}"{{/unless}}>{{ name }}</span>
                             </div>
                         </div>
                         <div class="item-detail effect-type">

--- a/templates/effects/effect-changes.hbs
+++ b/templates/effects/effect-changes.hbs
@@ -1,6 +1,6 @@
 <section class="tab scrollable changes {{~#if tab.active}} active{{/if}}" data-group="{{ tab.group }}" data-tab="{{ tab.id }}">
 
-    <section class="itmes-list changes-list">
+    <section class="items-list changes-list">
         <div class="items-section card">
             <div class="items-header header">
                 <h3 class="item-name">{{ localize "DND5E.EFFECT.Change.Label" }}</h3>
@@ -10,7 +10,7 @@
             </div>
             <ol class="item-list changes unlist">
                 {{#each changes}}
-                <li class="item change" data-index="{{ @index }}">
+                <li class="item change" data-change-id="{{ id }}" data-index="{{ @index }}">
                     <div class="item-row change-row">
                         <div class="item-name">
                             <div class="name name-stacked">

--- a/templates/effects/effect-changes.hbs
+++ b/templates/effects/effect-changes.hbs
@@ -10,20 +10,17 @@
             </div>
             <ol class="item-list changes unlist">
                 {{#each changes}}
-                <li class="item change" data-change-id="{{ id }}" data-index="{{ @index }}">
+                <li class="item change" data-change-id="{{ _id }}" data-index="{{ @index }}">
                     <div class="item-row change-row">
                         <div class="item-name">
                             <div class="name name-stacked">
-                                <!-- TODO: Add human-readable name once AE breakout is merged -->
-                                <span class="title">{{ key }}</span>
+                                <span class="title" data-tooltip="{{ key }}">{{ name }}</span>
                             </div>
                         </div>
                         <div class="item-detail effect-type">
-                            <span class="condensed">{{ type }}</span>
+                            <span class="condensed">{{ typeLabel }}</span>
                         </div>
-                        <div class="item-detail effect-value">
-                            <span class="condensed">{{ value }}</span>
-                        </div>
+                        {{> "systems/dnd5e/templates/effects/columns/value.hbs" ctx=this }}
                         <div class="item-detail item-controls">
                             {{#if @root.editable}}
                             {{!-- Editing --}}

--- a/templates/effects/effect-details.hbs
+++ b/templates/effects/effect-details.hbs
@@ -1,0 +1,17 @@
+<section class="tab scrollable {{~#if tab.active}} active{{/if}}" data-group="{{ tab.group }}" data-tab="{{ tab.id }}">
+    {{ formGroup fields.tint value=source.tint rootId=rootId placeholder="#ffffff" }}
+    {{ formGroup fields.description value=source.description rootId=rootId }}
+    {{ formGroup fields.disabled value=source.disabled input=inputs.createCheckboxInput rootId=rootId }}
+
+    {{#if isActorEffect}}
+    {{ formGroup fields.origin value=source.origin rootId=rootId disabled=true }}
+    {{else if isItemEffect}}
+    {{ formGroup fields.transfer value=source.transfer input=inputs.createCheckboxInput rootId=rootId }}
+    {{/if}}
+
+    {{#if systemFields.magical}}
+    {{ formGroup systemFields.magical value=source.system.magical input=inputs.createCheckboxInput rootId=partId }}
+    {{/if}}
+    {{ formGroup fields.statuses value=source.statuses options=statuses sort=true rootId=rootId classes="statuses" }}
+    {{ formGroup fields.showIcon value=source.showIcon options=showIconOptions rootId=rootId }}
+</section>

--- a/templates/effects/effect-header.hbs
+++ b/templates/effects/effect-header.hbs
@@ -1,0 +1,7 @@
+<header class="sheet-header img-name">
+    <img class="document-image" src="{{ source.img }}" data-action="editImage" data-edit="img"
+         alt="{{ localize 'EFFECT.FIELDS.img.label' }}">
+    <input name="name" type="text" value="{{source.name}}" class="document-name uninput"
+           placeholder="{{ localize 'EFFECT.FIELDS.name.label' }}"
+           aria-label="{{ localize 'EFFECT.FIELDS.name.label' }}">
+</header>

--- a/templates/effects/parts/effect-change-row.hbs
+++ b/templates/effects/parts/effect-change-row.hbs
@@ -4,7 +4,7 @@
     <div class="change-name item-name" role="button" aria-label="{{ name }}">
 
         <div class="name name-stacked">
-            <span class="title" data-tooltip="{{ key }}">{{ name }}</span>
+            <span class="title" {{~#unless (eq name key)}} data-tooltip="{{ key }}"{{/unless}}>{{ name }}</span>
         </div>
 
     </div>


### PR DESCRIPTION
Creates a new active effect sheet that uses the system's styles. This sheet uses a separate config dialog for editing individual changes rather than doing that inline. This means that the main sheet can submit on change.

<img width="1165" height="869" alt="Active Effect Sheet V2" src="https://github.com/user-attachments/assets/2e4b50ad-31a0-44da-9574-a1eb9c047363" />
