### PR TITLE
5.1 SRD Update: Monsters - Fey

### DIFF
--- a/packs/_source/monsters/fey/blink-dog.yml
+++ b/packs/_source/monsters/fey/blink-dog.yml
@@ -444,9 +444,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -461,7 +458,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -481,63 +478,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
-  - _id: BNRcaqutWC30200X
-    name: Keen Hearing and Smell
-    type: feat
-    img: icons/creatures/mammals/wolf-howl-moon-forest-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dog has advantage on Wisdom (Perception) checks that rely on
-          hearing or smell.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: keen-hearing-and-smell
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955785129
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!jOANE6M0My6UJF4e.BNRcaqutWC30200X'
   - _id: DcZYdK2iycSJzamK
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Blink Dog attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -600,7 +552,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -609,8 +561,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        qiImXJJsMeaPuIwD:
           type: attack
           activation:
             type: action
@@ -625,10 +576,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -645,7 +597,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -659,23 +612,36 @@ items:
             recovery: []
           attack:
             ability: str
-            bonus: ''
+            bonus: '1'
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: qiImXJJsMeaPuIwD
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -685,24 +651,27 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107552951
+      systemVersion: 6.0.0
+      createdTime: 1781806778792
+      modifiedTime: 1781806816734
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!jOANE6M0My6UJF4e.DcZYdK2iycSJzamK'
   - _id: 1IE8rHcJIihDWCda
     name: Teleport
     type: feat
-    img: icons/magic/symbols/runes-star-pentagon-magenta.webp
+    img: icons/magic/symbols/ring-circle-smoke-blue.webp
     system:
       description:
         value: >-
-          <p>The dog magically teleports, along with any equipment it is wearing
-          or carrying, up to 40 ft. to an unoccupied space it can see. Before or
-          after teleporting, the dog can make one bite attack.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically teleports, along
+          with any equipment it is wearing or carrying, up to [[lookup
+          @labels.description.range activity=SxPANomeaxHZmpVZ]] to an unoccupied
+          space it can see. Before or after teleporting, the [[lookup @name
+          lowercase]]{monster} can make one [[/item .DcZYdK2iycSJzamK]]{Bite}
+          attack.</p>
         chat: ''
       source:
         custom: ''
@@ -719,13 +688,13 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        SxPANomeaxHZmpVZ:
           type: utility
           activation:
             type: action
@@ -735,21 +704,20 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -766,10 +734,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: space
               choice: false
               special: ''
             prompt: true
@@ -783,7 +752,19 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: SxPANomeaxHZmpVZ
+          name: Reposition
       enchant: {}
       prerequisites:
         level: null
@@ -797,14 +778,67 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.PPzVD90vab60FqCt
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781806702090
+      modifiedTime: 1781806770128
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!jOANE6M0My6UJF4e.1IE8rHcJIihDWCda'
+  - _id: 8e44me0h2e9Q6sk0
+    name: Keen Hearing and Smell
+    type: feat
+    img: icons/creatures/mammals/wolf-howl-moon-forest-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on Wisdom
+          (Perception) checks that rely on hearing or smell.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: keen-hearing-and-smell
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: -250000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.yawTeS8u2FCfzzZH.Item.z1WFJdHb8OXvW2yy
+      duplicateSource: Item.UgdVWHzrwE598r6T
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781806830016
+      modifiedTime: 1781806830016
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!jOANE6M0My6UJF4e.8e44me0h2e9Q6sk0'
 effects: []
 folder: 5TSd0wOZe1L5I3eJ
 sort: 0
@@ -813,7 +847,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171251834

--- a/packs/_source/monsters/fey/dryad.yml
+++ b/packs/_source/monsters/fey/dryad.yml
@@ -1661,12 +1661,8 @@ items:
         type: base
         system:
           changes:
-            - key: system.attributes.ac.formula
+            - key: system.attributes.ac.min
               value: 16
-              priority: null
-              type: override
-            - key: system.attributes.ac.calc
-              value: custom
               priority: null
               type: override
         sort: 0

--- a/packs/_source/monsters/fey/dryad.yml
+++ b/packs/_source/monsters/fey/dryad.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,6 +480,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: Wkv8laBNYgkdA7lL
     name: Innate Spellcasting
@@ -581,78 +579,30 @@ items:
       identifier: innate-spellcasting
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745447015696
+      createdTime: 1781806847833
+      modifiedTime: 1781806847833
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KOHVWl5RU9XBR8Jb.Wkv8laBNYgkdA7lL'
-  - _id: JExoadfmCtQH6vsK
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The dryad has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!KOHVWl5RU9XBR8Jb.JExoadfmCtQH6vsK'
   - _id: beL4bLUcyTb1Sxgz
     name: Speak with Beasts and Plants
     type: feat
-    img: icons/commodities/currency/coin-engraved-sun-smile-copper.webp
+    img: icons/creatures/mammals/elk-moose-marked-green.webp
     system:
       description:
         value: >-
-          <p>The dryad can communicate with beasts and plants as if they shared
-          a language.</p>
+          <p>The [[lookup @name lowercase]]{monster} can communicate with beasts
+          and plants as if they shared a language.</p>
         chat: ''
       source:
         custom: ''
@@ -666,10 +616,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -677,19 +628,19 @@ items:
       identifier: speak-with-beasts-and-plants
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.59DUUDZet1J4PIlA
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781806847833
+      modifiedTime: 1781809137849
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KOHVWl5RU9XBR8Jb.beL4bLUcyTb1Sxgz'
   - _id: wwQTeXOmFLO2MW0Y
@@ -699,11 +650,12 @@ items:
     system:
       description:
         value: >-
-          <p>Once on her turn, the dryad can use 10 feet of her movement to step
-          magically into one living tree within her reach and emerge from a
-          second living tree within 60 feet of the first tree, appearing in an
-          unoccupied space within 5 feet of the second tree. Both trees must be
-          Large or bigger.</p>
+          <p>Once on her turn, the [[lookup @name lowercase]]{monster} can use
+          10 feet of her movement to step magically into one living tree within
+          her reach and emerge from a second living tree within [[lookup
+          @labels.description.range activity=KG74eACNUkh6t3ZJ]] of the first
+          tree, appearing in an unoccupied space within 5 feet of the second
+          tree. Both trees must be Large or bigger.</p>
         chat: ''
       source:
         custom: ''
@@ -713,34 +665,101 @@ items:
         rules: '2014'
         revision: 1
       uses:
-        max: ''
+        max: '1'
         spent: 0
-        recovery: []
+        recovery:
+          - period: turnStart
+            type: recoverAll
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
-      activities: {}
+      properties:
+        - mgc
+        - trait
+      activities:
+        KG74eACNUkh6t3ZJ:
+          type: utility
+          name: Step Through Tree
+          _id: KG74eACNUkh6t3ZJ
+          img: ''
+          sort: 0
+          activation:
+            type: special
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: ft
+            override: false
+            special: ''
+            value: '60'
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: space
+              count: '1'
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
       enchant: {}
       prerequisites:
         level: null
       identifier: tree-stride
     effects: []
     folder: null
-    sort: 0
+    sort: 500000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.g4V02wJbEstUpwi9
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781806847833
+      modifiedTime: 1781806977102
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KOHVWl5RU9XBR8Jb.wwQTeXOmFLO2MW0Y'
   - _id: DNPx6Myd5rHTGu4a
@@ -753,7 +772,9 @@ items:
           <p><em>Melee Weapon Attack:</em> [[/attack]] (or [[/attack +6]] with
           shillelagh), reach 5 ft., one target. [[/damage extended]], or
           [[/damage 1d8 + 4 bludgeoning average]] with shillelagh.</p>
-        chat: <p>The Dryad attacks with its Club.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -817,7 +838,7 @@ items:
         conditions: ''
       properties:
         - lgt
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -826,8 +847,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        a5YT8023lDdWL8SM:
           type: attack
           activation:
             type: action
@@ -842,6 +862,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -862,7 +883,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -881,17 +903,26 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: a5YT8023lDdWL8SM
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -902,19 +933,15 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.items.nfIRTECQIG81CvM4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745174477994
+      systemVersion: 6.0.0
+      createdTime: 1781809148973
+      modifiedTime: 1781809486221
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KOHVWl5RU9XBR8Jb.DNPx6Myd5rHTGu4a'
@@ -925,20 +952,25 @@ items:
     system:
       description:
         value: >-
-          <p>The dryad targets one humanoid or beast that she can see within 30
-          feet of her. If the target can see the dryad, it must succeed on a
-          [[/save]] saving throw or be magically
-          &amp;Reference[charmed].</p><p>The charmed creature regards the dryad
-          as a trusted friend to be heeded and protected. Although the target
-          isn't under the dryad's control, it takes the dryad's requests or
-          actions in the most favorable way it can.Each time the dryad or its
+          <p>The [[lookup @name lowercase]]{monster} targets one humanoid or
+          beast that she can see within [[lookup @labels.description.range
+          activity=dDlrfAXYYcXdTANa]] of her. If the target can see the [[lookup
+          @name lowercase]]{monster}, it must succeed on a [[/save]] saving
+          throw or be magically &amp;Reference[charmed].</p><p>The charmed
+          creature regards the [[lookup @name lowercase]]{monster} as a trusted
+          friend to be heeded and protected. Although the target isn't under the
+          [[lookup @name lowercase]]{monster}'s control, it takes the [[lookup
+          @name lowercase]]{monster}'s requests or actions in the most favorable
+          way it can. Each time the [[lookup @name lowercase]]{monster} or its
           allies do anything harmful to the target, it can repeat the saving
           throw, ending the effect on itself on a success. Otherwise, the effect
-          lasts 24 hours or until the dryad dies, is on a different plane of
-          existence from the target, or ends the effect as a bonus action. If a
-          target's saving throw is successful, the target is immune to the
-          dryad's Fey Charm for the next 24 hours.The dryad can have no more
-          than one humanoid and up to three beasts charmed at a time.</p>
+          lasts [[lookup @labels.duration activity=dDlrfAXYYcXdTANa]] or until
+          the [[lookup @name lowercase]]{monster} dies, is on a different plane
+          of existence from the target, or ends the effect as a bonus action. If
+          a target's saving throw is successful, the target is immune to the
+          [[lookup @name lowercase]]{monster}'s [[lookup @item.name]] for the
+          next 24 hours. The [[lookup @name lowercase]]{monster} can have no
+          more than one humanoid and up to three beasts charmed at a time.</p>
         chat: >-
           <p>The dryad targets one humanoid or beast that she can see within 30
           feet of her. If the target can see the dryad, it must make a
@@ -957,72 +989,18 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
-          activation:
-            type: action
-            value: 1
-            condition: one humanoid or beast
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: '24'
-            units: hour
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '30'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: spec
-            affects:
-              count: '1'
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+        dDlrfAXYYcXdTANa:
           type: save
           activation:
             type: action
             value: 1
-            condition: one humanoid or beast
+            condition: ''
             override: false
           consumption:
             targets: []
@@ -1032,13 +1010,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '24'
             units: hour
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: j31eZQRAcnPXW1pQ
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '30'
             units: ft
@@ -1053,11 +1037,12 @@ items:
               width: ''
               height: ''
               units: spec
+              stationary: false
             affects:
               count: '1'
-              type: ''
+              type: creature
               choice: false
-              special: ''
+              special: a humanoid or beast
             prompt: true
             override: false
           uses:
@@ -1065,19 +1050,81 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
               calculation: ''
               formula: '14'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: dDlrfAXYYcXdTANa
+          name: Charm Creature
       enchant: {}
       prerequisites:
         level: null
       identifier: fey-charm
-    effects: []
+    effects:
+      - name: Fey Charm
+        img: icons/consumables/plants/leaf-veins-glowing-green.webp
+        origin: Compendium.dnd5e.monsters.Actor.KOHVWl5RU9XBR8Jb.Item.OdzhvEDeD06BWsZS
+        transfer: false
+        _id: j31eZQRAcnPXW1pQ
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 24
+          units: hours
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[charmed apply=false] by the
+          dryad.</p><p>While charmed, you regard the dryad as a trusted friend
+          to be heeded and protected. Although you are not under the dryad's
+          control, you take the dryad's requests or actions in the most
+          favorable way you can.</p><p>Each time the dryad or its allies do
+          anything harmful to you, you can repeat the saving throw, ending the
+          effect on yourself on a success. Otherwise, the effect lasts for the
+          duration or until the dryad dies, is on a different plane of existence
+          from you, or they end the effect as a bonus action.</p>
+        tint: '#ffffff'
+        statuses:
+          - charmed
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781809280986
+          modifiedTime: 1781809425249
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!KOHVWl5RU9XBR8Jb.OdzhvEDeD06BWsZS.j31eZQRAcnPXW1pQ
     folder: null
     sort: 0
     ownership:
@@ -1086,11 +1133,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.SGgVxdZbmsStfeGB
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955825097
+      systemVersion: 6.0.0
+      createdTime: 1781809208061
+      modifiedTime: 1781809468326
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KOHVWl5RU9XBR8Jb.OdzhvEDeD06BWsZS'
@@ -1215,7 +1262,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.gMrWeG8fMDPRFiVe
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1344,7 +1391,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.SbSvZKkJASyk8jKo
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1473,7 +1520,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.Qf6CAZkc7ms4ZY3e
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1588,24 +1635,12 @@ items:
     effects:
       - _id: uM6rgctYpcbCVSkn
         flags: {}
-        changes:
-          - key: system.attributes.ac.formula
-            value: '16'
-            mode: 5
-            priority: null
-          - key: system.attributes.ac.calc
-            value: custom
-            mode: 5
-            priority: null
         disabled: true
         duration:
-          startTime: null
-          seconds: 3600
-          combat: null
-          rounds: null
-          turns: null
-          startRound: null
-          startTurn: null
+          value: 3600
+          units: seconds
+          expiry: turnStart
+          expired: false
         origin: Item.VQMKMnQDw5rzL0zp
         tint: '#ffffff'
         transfer: false
@@ -1615,7 +1650,7 @@ items:
         _stats:
           compendiumSource: null
           duplicateSource: null
-          coreVersion: '13.344'
+          coreVersion: '14.361'
           systemId: dnd5e
           systemVersion: 4.0.0
           createdTime: null
@@ -1624,8 +1659,20 @@ items:
           exportSource: null
         img: icons/magic/defensive/shield-barrier-flaming-diamond-orange.webp
         type: base
-        system: {}
+        system:
+          changes:
+            - key: system.attributes.ac.formula
+              value: 16
+              priority: null
+              type: override
+            - key: system.attributes.ac.calc
+              value: custom
+              priority: null
+              type: override
         sort: 0
+        start: null
+        showIcon: 1
+        folder: null
         _key: >-
           !actors.items.effects!KOHVWl5RU9XBR8Jb.JPwIEfgUPVebr5AH.uM6rgctYpcbCVSkn
     folder: null
@@ -1636,7 +1683,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.JPwIEfgUPVebr5AH
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1760,7 +1807,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.pRMvmknwLf2tdMTj
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1895,7 +1942,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.VzgFzcmocr1X1cp4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1903,6 +1950,59 @@ items:
       lastModifiedBy: null
       exportSource: null
     _key: '!actors.items!KOHVWl5RU9XBR8Jb.VzgFzcmocr1X1cp4'
+  - _id: gK5fX5pMH745LgCa
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 250000
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781806845501
+      modifiedTime: 1781806848746
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!KOHVWl5RU9XBR8Jb.gK5fX5pMH745LgCa'
 effects: []
 folder: 5TSd0wOZe1L5I3eJ
 sort: 0
@@ -1911,7 +2011,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171222835

--- a/packs/_source/monsters/fey/green-hag.yml
+++ b/packs/_source/monsters/fey/green-hag.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,53 +481,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
-  - _id: TwdKEVj1NjVefyq9
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The hag can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!saq6WM959pKHuaqP.TwdKEVj1NjVefyq9'
   - _id: 9HX1VdEInbRUnBVL
     name: Innate Spellcasting
     type: feat
@@ -569,18 +521,18 @@ items:
       identifier: innate-spellcasting
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745447015973
+      createdTime: 1781811115103
+      modifiedTime: 1781811115103
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!saq6WM959pKHuaqP.9HX1VdEInbRUnBVL'
@@ -591,9 +543,9 @@ items:
     system:
       description:
         value: >-
-          <p>The hag can mimic animal sounds and humanoid voices. A creature
-          that hears the sounds can tell they are imitations with a successful
-          [[/check]] check.</p>
+          <p>The [[lookup @name lowercase]]{monster} can mimic animal sounds and
+          humanoid voices. A creature that hears the sounds can tell they are
+          imitations with a successful [[/check]] check.</p>
         chat: >-
           <p>The hag can mimic animal sounds and humanoid voices. A creature
           that hears the sounds can tell they are imitations with a successful
@@ -610,10 +562,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
         0eU0qHrzuJTbqxUP:
           type: check
@@ -669,7 +622,7 @@ items:
       identifier: mimicry
     effects: []
     folder: null
-    sort: 0
+    sort: 400000
     ownership:
       default: 0
     flags:
@@ -680,22 +633,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.zZkNtL97hn1P6OJC
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955871763
+      systemVersion: 6.0.0
+      createdTime: 1781811115103
+      modifiedTime: 1781811268275
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!saq6WM959pKHuaqP.C2ZJ3Oe30dyU2o7E'
   - _id: gtixTr9i63RtsSCv
     name: Claws
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-glowing-orange.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Green Hag attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -758,7 +713,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -767,8 +722,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        uEdUVUQ62x0Da5Vd:
           type: attack
           activation:
             type: action
@@ -783,10 +737,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -803,7 +758,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -816,24 +772,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: uEdUVUQ62x0Da5Vd
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -843,32 +812,32 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107553825
+      systemVersion: 6.0.0
+      createdTime: 1781810731630
+      modifiedTime: 1781810754151
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!saq6WM959pKHuaqP.gtixTr9i63RtsSCv'
   - _id: cvdyEyn0s7hKwIcN
     name: Illusory Appearance
     type: feat
-    img: icons/creatures/mammals/humanoid-cat-skulking-teal.webp
+    img: icons/equipment/head/hood-cloth-trimmed-pink-gold.webp
     system:
       description:
         value: >-
-          <p>The hag covers herself and anything she is wearing or carrying with
-          a magical illusion that makes her look like another creature of her
-          general size and humanoid shape. The illusion ends if the hag takes a
-          bonus action to end it or if she dies.</p>
-
-          <p>The changes wrought by this effect fail to hold up to physical
-          inspection. For example, the hag could appear to have smooth skin, but
-          someone touching her would feel her rough flesh. Otherwise, a creature
-          must take an action to visually inspect the illusion and succeed on a
-          DC 20 Intelligence (Investigation) check to discern that the hag is
-          disguised.</p>
+          <p>The [[lookup @name lowercase]]{monster} covers herself and anything
+          she is wearing or carrying with a magical illusion that makes her look
+          like another creature of her general size and humanoid shape. The
+          illusion ends if the [[lookup @name lowercase]]{monster} takes a bonus
+          action to end it or if she dies.</p><p>The changes wrought by this
+          effect fail to hold up to physical inspection. For example, the
+          [[lookup @name lowercase]]{monster} could appear to have smooth skin,
+          but someone touching her would feel her rough flesh. Otherwise, a
+          creature must take an action to visually inspect the illusion and
+          succeed on a [[/check activity=kV9ZxzkLNTRogVW9]] check to discern
+          that the [[lookup @name lowercase]]{monster} is disguised.</p>
         chat: ''
       source:
         custom: ''
@@ -882,64 +851,143 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        ZZU7Do4OA9sFFQb1:
+          type: transform
+          name: Don Illusory Appearance
+          img: ''
+          sort: 100000
           activation:
             type: action
-            value: 1
-            condition: ''
             override: false
+            condition: ''
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: dstr
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
-              special: ''
-            prompt: true
+              type: ''
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: ''
+              name: ''
+              _id: lX8J7ULrjRnWCHF6
+              uuid: null
+              sizes:
+                - med
+              types:
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings: null
+          transform:
+            customize: false
+            mode: cr
+            preset: polymorphSelf
+          _id: ZZU7Do4OA9sFFQb1
+        kV9ZxzkLNTRogVW9:
+          type: check
+          name: Investigate
+          img: ''
+          sort: 200000
+          activation:
+            type: ''
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: spec
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              count: '1'
+              type: ''
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - inv
+            dc:
+              calculation: ''
+              formula: '20'
+            visible: true
+            ability: ''
+            bonus: ''
+          _id: kV9ZxzkLNTRogVW9
       enchant: {}
       prerequisites:
         level: null
@@ -953,12 +1001,12 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.s7kqggp9VLDb39nu
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781810777459
+      modifiedTime: 1781811323347
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!saq6WM959pKHuaqP.cvdyEyn0s7hKwIcN'
   - _id: Cdis1lnjFvqfoScV
@@ -968,11 +1016,12 @@ items:
     system:
       description:
         value: >-
-          <p>The hag magically turns invisible until she attacks or casts a
-          spell, or until her concentration ends (as if concentrating on a
-          spell). While invisible, she leaves no physical evidence of her
-          passage, so she can be tracked only by magic. Any equipment she wears
-          or carries is invisible with her.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically turns
+          &amp;reference[invisible] until she attacks or casts a spell, or until
+          her concentration ends (as if concentrating on a spell). While
+          invisible, she leaves no physical evidence of her passage, so she can
+          be tracked only by magic. Any equipment she wears or carries is
+          invisible with her.</p>
         chat: >-
           <p>The hag magically turns invisible. Any equipment she wears or
           carries is invisible with her.</p>
@@ -988,10 +1037,11 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
@@ -1015,7 +1065,11 @@ items:
             units: ''
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: M15UoRAnmUX21B5N
+              level:
+                min: null
+                max: null
           range:
             units: ''
             special: ''
@@ -1031,7 +1085,7 @@ items:
               units: ''
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1046,11 +1100,62 @@ items:
             prompt: false
             visible: false
           sort: 0
+          name: Become Invisible
+          img: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+            requireMagic: true
       enchant: {}
       prerequisites:
         level: null
       identifier: invisible-passage
-    effects: []
+    effects:
+      - name: Invisible Passage
+        img: icons/magic/perception/silhouette-stealth-shadow.webp
+        origin: Compendium.dnd5e.monsters.Actor.saq6WM959pKHuaqP.Item.Cdis1lnjFvqfoScV
+        transfer: false
+        _id: M15UoRAnmUX21B5N
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are &amp;reference[invisible apply=false] until you attack,
+          cast a spell, or until your concentration ends (as if concentrating on
+          a spell). While invisible, you leave no physical evidence of your
+          passage, so you can be tracked only by magic. Any equipment you are
+          wearing or carrying becomes invisible with you.</p>
+        tint: '#ffffff'
+        statuses:
+          - invisible
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781811151205
+          modifiedTime: 1781811235515
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!saq6WM959pKHuaqP.Cdis1lnjFvqfoScV.M15UoRAnmUX21B5N
     folder: null
     sort: 0
     ownership:
@@ -1059,11 +1164,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.FRIASnssihfMTZ7q
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.2.0
-      createdTime: null
-      modifiedTime: 1736804676755
+      systemVersion: 6.0.0
+      createdTime: 1781811140345
+      modifiedTime: 1781811246951
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!saq6WM959pKHuaqP.Cdis1lnjFvqfoScV'
@@ -1177,7 +1282,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.CAxSzHWizrafT033
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1303,7 +1408,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.oIzA2MEHwxhtQneU
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1433,7 +1538,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.cdrYKaFi98YWaBMw
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1441,6 +1546,59 @@ items:
       lastModifiedBy: null
       exportSource: null
     _key: '!actors.items!saq6WM959pKHuaqP.cdrYKaFi98YWaBMw'
+  - _id: v7WLd38u9z94vJXR
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 175000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781825771606
+      modifiedTime: 1781825771606
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!saq6WM959pKHuaqP.v7WLd38u9z94vJXR'
 effects: []
 folder: 5TSd0wOZe1L5I3eJ
 sort: 0
@@ -1449,7 +1607,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171262458

--- a/packs/_source/monsters/fey/satyr.yml
+++ b/packs/_source/monsters/fey/satyr.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,15 +481,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: bAm4BNi3o137SAmd
     name: Shortbow
     type: weapon
-    img: icons/weapons/bows/shortbow-recurve.webp
+    img: icons/weapons/bows/longbow-leather-green.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]]</p>
-        chat: ''
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -557,7 +557,7 @@ items:
       properties:
         - amm
         - two
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -566,8 +566,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        NA4y3N9TbB7KheN3:
           type: attack
           activation:
             type: action
@@ -582,10 +581,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -602,7 +602,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -621,14 +622,26 @@ items:
               threshold: null
             flat: false
             type:
-              value: ranged
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: NA4y3N9TbB7KheN3
+          name: ''
       attuned: false
       ammunition:
         type: ''
@@ -644,22 +657,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.GJv6WkD7D2J6rP6M
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955907453
+      systemVersion: 6.0.0
+      createdTime: 1781810041431
+      modifiedTime: 1781810055694
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!8xhuJXYMnlQD7LF6.bAm4BNi3o137SAmd'
   - _id: 198fJNFbhjGeZ8UZ
     name: Shortsword
     type: weapon
-    img: icons/weapons/swords/sword-guard-brown.webp
+    img: icons/weapons/swords/sword-guard-worn-brown.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]]</p>
-        chat: ''
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -724,7 +739,7 @@ items:
       properties:
         - fin
         - lgt
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -733,8 +748,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4uxDwQTsYFRGJX6K:
           type: attack
           activation:
             type: action
@@ -749,10 +763,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -769,7 +784,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -788,14 +804,26 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4uxDwQTsYFRGJX6K
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -810,11 +838,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.osLzOwQdPtrK3rQH
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955914510
+      systemVersion: 6.0.0
+      createdTime: 1781810070038
+      modifiedTime: 1781810081946
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!8xhuJXYMnlQD7LF6.198fJNFbhjGeZ8UZ'
@@ -886,7 +914,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.WwdpHLXGX5r8uZu5
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -894,62 +922,16 @@ items:
       lastModifiedBy: null
       exportSource: null
     _key: '!actors.items!8xhuJXYMnlQD7LF6.vd2pvVVxaLhqrWqe'
-  - _id: jgHhzAjFiPXlluVM
-    name: Magic Resistance
-    type: feat
-    img: icons/magic/defensive/shield-barrier-glowing-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The satyr has advantage on saving throws against spells and other
-          magical effects.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-resistance
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.Hc6MqLQhPTI1KOvm
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955887805
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!8xhuJXYMnlQD7LF6.jgHhzAjFiPXlluVM'
   - _id: 2btvWgv8WIkadZjh
     name: Ram
     type: weapon
-    img: icons/creatures/mammals/ox-bull-horned-glowing-orange.webp
+    img: icons/commodities/bones/horn-antler-brown-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Satyr attacks with its Ram.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1012,7 +994,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1021,8 +1003,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        BZwInSYPvXr43jJy:
           type: attack
           activation:
             type: action
@@ -1037,15 +1018,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1056,7 +1038,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1075,18 +1058,31 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: BZwInSYPvXr43jJy
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: ram
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -1096,14 +1092,67 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107550515
+      systemVersion: 6.0.0
+      createdTime: 1781810012091
+      modifiedTime: 1781810031916
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!8xhuJXYMnlQD7LF6.2btvWgv8WIkadZjh'
+  - _id: Wo0UWMSUsVVfavZT
+    name: Magic Resistance
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on saving
+          throws against spells and other magical effects.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-resistance
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/magic/defensive/barrier-shield-dome-pink.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781809999697
+      modifiedTime: 1781809999697
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.Hc6MqLQhPTI1KOvm
+    _key: '!actors.items!8xhuJXYMnlQD7LF6.Wo0UWMSUsVVfavZT'
 effects: []
 folder: 5TSd0wOZe1L5I3eJ
 sort: 0
@@ -1112,7 +1161,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171208870

--- a/packs/_source/monsters/fey/sea-hag.yml
+++ b/packs/_source/monsters/fey/sea-hag.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,72 +481,32 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
-  - _id: VlvfR7YD6twoSRhg
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The hag can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!OQqybZoMeDFn5AFD.VlvfR7YD6twoSRhg'
   - _id: XeAyeJsNjKZKPWEN
     name: Horrific Appearance
     type: feat
-    img: icons/creatures/unholy/demon-winged-cyclops-drooling.webp
+    img: icons/magic/control/fear-fright-monster-grin-purple-blue.webp
     system:
       description:
         value: >-
-          <p>Any humanoid that starts its turn within 30 feet of the hag and can
-          see the hag's true form must make a [[/save]] saving throw. On a
-          failed save, the creature is &amp;Reference[frightened] for 1 minute.
-          A creature can repeat the saving throw at the end of each of its
-          turns, with disadvantage if the hag is within line of sight, ending
-          the effect on itself on a success.</p><p>If a creature's saving throw
-          is successful or the effect ends for it, the creature is immune to the
-          hag's Horrific Appearance for the next 24 hours. Unless the target is
-          surprised or the revelation of the hag's true form is sudden, the
-          target can avert its eyes and avoid making the initial saving throw.
-          Until the start of its next turn, a creature that averts its eyes has
-          disadvantage on attack rolls against the hag.</p>
+          <p>Any humanoid that starts its turn within [[lookup
+          @target.template.size activity=krnijW9ix8K2d3wp]] feet of the [[lookup
+          @name lowercase]]{monster} and can see the [[lookup @name
+          lowercase]]{monster}'s true form must make a [[/save]] saving throw.
+          On a failed save, the creature is &amp;Reference[frightened] for
+          [[lookup @labels.duration activity=krnijW9ix8K2d3wp]]. A creature can
+          repeat the saving throw at the end of each of its turns, with
+          disadvantage if the [[lookup @name lowercase]]{monster} is within line
+          of sight, ending the effect on itself on a success.</p><p>If a
+          creature's saving throw is successful or the effect ends for it, the
+          creature is immune to the [[lookup @name lowercase]]{monster}'s
+          [[lookup @item.name]] for the next 24 hours. Unless the target is
+          &amp;reference[surprise]{Surprised} or the revelation of the [[lookup
+          @name lowercase]]{monster}'s true form is sudden, the target can avert
+          its eyes and avoid making the initial saving throw. Until the start of
+          its next turn, a creature that averts its eyes has disadvantage on
+          attack rolls against the [[lookup @name lowercase]]{monster}.</p>
         chat: >-
           <p>Any humanoid that starts its turn <strong>within 30 feet</strong>
           of the hag and can see the hag's true form must make a
@@ -566,18 +523,20 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        krnijW9ix8K2d3wp:
           type: save
           activation:
-            type: ''
+            type: special
             value: null
-            condition: ''
+            condition: >-
+              When a creature starts its turn within 30 feet of the [[lookup
+              @name lowercase]]{monster} and can see the [[lookup @name
+              lowercase]]{monster}'s true form.
             override: false
           consumption:
             targets: []
@@ -587,13 +546,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
-            value: ''
-            units: inst
+            value: '1'
+            units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: fmzFys2MSAKRtUIS
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '30'
             units: self
@@ -608,9 +573,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -620,44 +586,102 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
               calculation: ''
               formula: '11'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Revealed True Form Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: krnijW9ix8K2d3wp
       enchant: {}
       prerequisites:
         level: null
       identifier: horrific-appearance
-    effects: []
+    effects:
+      - name: Horrified
+        img: icons/magic/control/fear-fright-monster-grin-purple-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.OQqybZoMeDFn5AFD.Item.XeAyeJsNjKZKPWEN
+        transfer: false
+        _id: fmzFys2MSAKRtUIS
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[frightened apply=false] for the duration.
+          You can repeat the saving throw at the end of each of your turns, with
+          disadvantage if the sea hag is within line of sight, ending the effect
+          on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses:
+          - frightened
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781810324887
+          modifiedTime: 1781810384702
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!OQqybZoMeDFn5AFD.XeAyeJsNjKZKPWEN.fmzFys2MSAKRtUIS
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.YShGyidij4sLpyzF
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955938735
+      systemVersion: 6.0.0
+      createdTime: 1781810096314
+      modifiedTime: 1781810481979
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!OQqybZoMeDFn5AFD.XeAyeJsNjKZKPWEN'
   - _id: a75Ba80yp6Y28AJQ
     name: Claws
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-glowing-purple.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Sea Hag attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -720,7 +744,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -729,8 +753,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        7k7bQjTq1tlTh85N:
           type: attack
           activation:
             type: action
@@ -745,10 +768,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -765,7 +789,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -778,24 +803,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 7k7bQjTq1tlTh85N
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -805,24 +843,27 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107551622
+      systemVersion: 6.0.0
+      createdTime: 1781810105032
+      modifiedTime: 1781810120234
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!OQqybZoMeDFn5AFD.a75Ba80yp6Y28AJQ'
   - _id: 7AGmP2dRLYmORUX7
     name: Death Glare
     type: feat
-    img: icons/magic/death/skull-humanoid-worn-teal.webp
+    img: icons/magic/death/skull-humanoid-white-blue.webp
     system:
       description:
         value: >-
-          <p>The hag targets one frightened creature she can see within 30 ft.
-          of her. If the target can see the hag, it must succeed on a [[/save]]
-          saving throw against this magic or drop to 0 hit points.</p>
+          <p>The [[lookup @name lowercase]]{monster} targets one
+          &amp;reference[frightened apply=false] creature she can see within
+          [[lookup @labels.description.range activity=bkCJcO9MdO88ON0n]] of her.
+          If the target can see the [[lookup @name lowercase]]{monster}, it must
+          succeed on a [[/save]] saving throw against this magic or drop to 0
+          hit points.</p>
         chat: >-
           <p>The hag targets one frightened creature she can see within 30 ft.
           of her. If the target can see the hag, it must make a
@@ -839,13 +880,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bkCJcO9MdO88ON0n:
           type: save
           activation:
             type: action
@@ -860,6 +901,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -880,10 +922,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -893,15 +936,29 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: wis
+            ability:
+              - wis
             dc:
               calculation: ''
               formula: '11'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Focus Gaze
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: bkCJcO9MdO88ON0n
       enchant: {}
       prerequisites:
         level: null
@@ -915,32 +972,32 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.o8G8BNPJOWoCKzR5
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955961924
+      systemVersion: 6.0.0
+      createdTime: 1781810164569
+      modifiedTime: 1781810223709
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!OQqybZoMeDFn5AFD.7AGmP2dRLYmORUX7'
   - _id: 8s0lGEYZGFEpwt12
     name: Illusory Appearance
     type: feat
-    img: icons/magic/unholy/silhouette-robe-evil-power.webp
+    img: icons/equipment/head/hood-cloth-trimmed-pink-gold.webp
     system:
       description:
         value: >-
-          <p>The hag covers herself and anything she is wearing or carrying with
-          a magical illusion that makes her look like an ugly creature of her
-          general size and humanoid shape. The effect ends if the hag takes a
-          bonus action to end it or if she dies.</p>
-
-          <p>The changes wrought by this effect fail to hold up to physical
-          inspection. For example, the hag could appear to have no claws, but
+          <p>The [[lookup @name lowercase]]{monster} covers herself and anything
+          she is wearing or carrying with a magical illusion that makes her look
+          like an ugly creature of her general size and humanoid shape. The
+          effect ends if the [[lookup @name lowercase]]{monster} takes a bonus
+          action to end it or if she dies.</p><p>The changes wrought by this
+          effect fail to hold up to physical inspection. For example, the
+          [[lookup @name lowercase]]{monster} could appear to have no claws, but
           someone touching her hand might feel the claws. Otherwise, a creature
           must take an action to visually inspect the illusion and succeed on a
-          DC 16 Intelligence (Investigation) check to discern that the hag is
-          disguised.</p>
+          [[/check activity=qwatGWOoJRpKLNtR]] check to discern that the
+          [[lookup @name lowercase]]{monster} is disguised.</p>
         chat: ''
       source:
         custom: ''
@@ -954,64 +1011,143 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        qwatGWOoJRpKLNtR:
+          type: check
+          name: Investigate
+          _id: qwatGWOoJRpKLNtR
+          img: ''
+          sort: 500000
           activation:
-            type: action
-            value: 1
-            condition: ''
+            type: ''
             override: false
+            condition: ''
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: spec
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
+              type: ''
               special: ''
-            prompt: true
+              count: '1'
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          check:
+            associated:
+              - inv
+            dc:
+              calculation: ''
+              formula: '16'
+            visible: true
+            ability: ''
+            bonus: ''
+        AnnOjQ8xoMu57URu:
+          type: transform
+          name: Don Illusory Appearance
+          _id: AnnOjQ8xoMu57URu
+          img: ''
+          sort: 400000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: dstr
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: ''
+              name: ''
+              _id: lX8J7ULrjRnWCHF6
+              uuid: null
+              sizes:
+                - med
+              types:
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings: null
+          transform:
+            customize: false
+            mode: cr
+            preset: polymorphSelf
       enchant: {}
       prerequisites:
         level: null
@@ -1025,14 +1161,67 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.s7kqggp9VLDb39nu
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781810498413
+      modifiedTime: 1781811333589
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!OQqybZoMeDFn5AFD.8s0lGEYZGFEpwt12'
+  - _id: mu6H0PnN6ZcY0JMl
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 175000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781825766258
+      modifiedTime: 1781825766258
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!OQqybZoMeDFn5AFD.mu6H0PnN6ZcY0JMl'
 effects: []
 folder: 5TSd0wOZe1L5I3eJ
 sort: 0
@@ -1041,7 +1230,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171228511

--- a/packs/_source/monsters/fey/sprite.yml
+++ b/packs/_source/monsters/fey/sprite.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,6 +481,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 0.5
 items:
   - _id: qlTIjSkjmEDQTj1x
     name: Leather Armor (tiny)
@@ -553,7 +551,7 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -564,17 +562,19 @@ items:
   - _id: YN8cO9SCNOIFJcmw
     name: Shortbow
     type: weapon
-    img: icons/weapons/bows/shortbow-recurve.webp
+    img: icons/weapons/bows/shortbow-recurve-leather.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]], and the target must
           succeed on a [[/save]] saving throw or become &amp;Reference[poisoned]
-          for 1 minute. If its saving throw result is 5 or lower, the poisoned
-          target falls &amp;Reference[unconscious] for the same duration, or
-          until it takes damage or another creature takes an action to shake it
-          awake.</p>
-        chat: <p>The Sprite attacks with its Shortbow.</p>
+          for [[lookup @labels.duration activity=vMfBrhdjnxaKy0Wn]]. If its
+          saving throw result is 5 or lower, the poisoned target falls
+          &amp;Reference[unconscious] for the same duration, or until it takes
+          damage or another creature takes an action to shake it awake.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -637,7 +637,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -646,8 +646,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        CSPHSvLsdzkanbSC:
           type: attack
           activation:
             type: action
@@ -662,6 +661,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
@@ -682,7 +682,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -701,21 +702,32 @@ items:
               threshold: null
             flat: false
             type:
-              value: ranged
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: CSPHSvLsdzkanbSC
+          name: ''
+        vMfBrhdjnxaKy0Wn:
           type: save
           activation:
-            type: action
+            type: special
             value: 1
-            condition: ''
+            condition: When a creature is hit by this attack.
             override: false
           consumption:
             targets: []
@@ -725,13 +737,30 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: >-
+              <p>The target must succeed on a [[/save]] saving throw or become
+              &amp;Reference[poisoned] for 1 minute. If its saving throw result
+              is 5 or lower, the poisoned target falls
+              &amp;Reference[unconscious] for the same duration, or until it
+              takes damage or another creature takes an action to shake it
+              awake.</p>
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: ncfr9hbuEu2mr5kI
+              onSave: false
+              level:
+                min: null
+                max: null
+            - _id: pw6HjjLVGg9RII4U
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '40'
             units: ft
@@ -745,10 +774,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -758,37 +788,129 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: spellcasting
               formula: '10'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: vMfBrhdjnxaKy0Wn
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: shortbow
       mastery: ''
-    effects: []
+    effects:
+      - name: Sprite's Poison
+        img: icons/skills/toxins/symbol-poison-drop-skull-green.webp
+        origin: Compendium.dnd5e.monsters.Actor.MUpBNDoJEr09bLaO.Item.YN8cO9SCNOIFJcmw
+        transfer: false
+        _id: ncfr9hbuEu2mr5kI
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: <p>You are &amp;reference[poisoned apply=false] for the duration.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781809574710
+          modifiedTime: 1781809628388
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!MUpBNDoJEr09bLaO.YN8cO9SCNOIFJcmw.ncfr9hbuEu2mr5kI
+      - name: Sprite's Sleeping Poison
+        img: icons/skills/toxins/symbol-poison-drop-skull-green.webp
+        origin: Compendium.dnd5e.monsters.Actor.MUpBNDoJEr09bLaO.Item.YN8cO9SCNOIFJcmw
+        transfer: false
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[poisoned apply=false] for the duration.
+          While poisoned in this way, you fall &amp;reference[unconscious
+          apply=false] for the same duration, or until you take damage or
+          another creature takes an action to shake you awake.</p>
+        tint: '#ffffff'
+        statuses:
+          - poisoned
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses:
+                - unconscious
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781809632106
+          modifiedTime: 1781809744147
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _id: pw6HjjLVGg9RII4U
+        _key: >-
+          !actors.items.effects!MUpBNDoJEr09bLaO.YN8cO9SCNOIFJcmw.pw6HjjLVGg9RII4U
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.items.GJv6WkD7D2J6rP6M
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745174638780
+      systemVersion: 6.0.0
+      createdTime: 1781809539822
+      modifiedTime: 1781809794125
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MUpBNDoJEr09bLaO.YN8cO9SCNOIFJcmw'
@@ -799,7 +921,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Sprite attacks with its Longsword.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -862,7 +986,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -871,8 +995,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        FRX8H4ZTJBdkplcX:
           type: attack
           activation:
             type: action
@@ -887,6 +1010,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -895,7 +1019,7 @@ items:
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -906,7 +1030,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -925,17 +1050,26 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: FRX8H4ZTJBdkplcX
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -946,33 +1080,30 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.items.10ZP2Bu3vnCuYMIB
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745174681869
+      systemVersion: 6.0.0
+      createdTime: 1781809813769
+      modifiedTime: 1781809837560
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MUpBNDoJEr09bLaO.mT8SL7VHsG6qY5G7'
   - _id: qLd01BTjVwH6NUfH
     name: Invisibility
     type: feat
-    img: icons/creatures/webs/webthin-blue.webp
+    img: icons/creatures/magical/spirit-undead-ghost-blue.webp
     system:
       description:
         value: >-
-          <p>The sprite magically turns invisible until it attacks or casts a
-          spell, or until its concentration ends (as if concentrating on a
-          spell). Any equipment the sprite wears or carries is invisible with
-          it.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically turns
+          &amp;reference[invisible] until it attacks or casts a spell, or until
+          its concentration ends (as if concentrating on a spell). Any equipment
+          the [[lookup @name lowercase]]{monster} wears or carries is invisible
+          with it.</p>
         chat: >-
           <p>The sprite magically turns invisible. Any equipment the sprite
           wears or carries is invisible with it.</p>
@@ -988,13 +1119,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        KoAbPzGOJ6vf7w7p:
           type: utility
           activation:
             type: action
@@ -1009,15 +1140,20 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: woi3Je0nZ2KaHaJq
+              level:
+                min: null
+                max: null
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1028,10 +1164,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1045,12 +1182,66 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: KoAbPzGOJ6vf7w7p
+          name: Become Invisible
       enchant: {}
       prerequisites:
         level: null
       identifier: invisibility
-    effects: []
+    effects:
+      - name: Invisibility
+        img: icons/creatures/magical/spirit-undead-ghost-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.MUpBNDoJEr09bLaO.Item.qLd01BTjVwH6NUfH
+        transfer: false
+        _id: woi3Je0nZ2KaHaJq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are &amp;reference[invisible] until you attack, cast a spell,
+          or until your concentration ends (as if concentrating on a spell). Any
+          equipment you are wearing or carrying is invisible as well.</p>
+        tint: '#ffffff'
+        statuses:
+          - invisible
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781809939617
+          modifiedTime: 1781809971038
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: >-
+            Compendium.dnd5e.monsters.Actor.dLQiESMsfsXijD5c.Item.ABjkKWIBbRYp2fy5.ActiveEffect.dJA0IOGziAr9Onj9
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!MUpBNDoJEr09bLaO.qLd01BTjVwH6NUfH.woi3Je0nZ2KaHaJq
     folder: null
     sort: 0
     ownership:
@@ -1059,24 +1250,25 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.dA5X2eQuOtHywpQF
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.2.0
-      createdTime: null
-      modifiedTime: 1736804676890
+      systemVersion: 6.0.0
+      createdTime: 1781809906531
+      modifiedTime: 1781809982979
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MUpBNDoJEr09bLaO.qLd01BTjVwH6NUfH'
   - _id: qJHrH8Q3q1JB5xe5
     name: Heart Sight
     type: feat
-    img: icons/magic/control/hypnosis-mesmerism-eye.webp
+    img: icons/magic/life/heart-pink.webp
     system:
       description:
         value: >-
-          <p>The sprite touches a creature and magically knows the creature's
-          current emotional state.</p><p>If the target fails a [[/save]] saving
-          throw, the sprite also knows the creature's alignment. Celestials,
+          <p>The [[lookup @name lowercase]]{monster} touches a creature and
+          magically knows the creature's current emotional state.</p><p>If the
+          target fails a [[/save]] saving throw, the [[lookup @name
+          lowercase]]{monster} also knows the creature's alignment. Celestials,
           fiends, and undead automatically fail the saving throw.</p>
         chat: >-
           <p>The sprite touches a creature. target must make a
@@ -1093,13 +1285,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        WgvJpjzeNyJLFBHm:
           type: save
           activation:
             type: action
@@ -1114,6 +1306,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1133,7 +1326,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1146,15 +1340,29 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: cha
+            ability:
+              - cha
             dc:
               calculation: ''
               formula: '10'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Peer into Heart
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: WgvJpjzeNyJLFBHm
       enchant: {}
       prerequisites:
         level: null
@@ -1168,11 +1376,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.iCae1IDxHvRmjEgi
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955988926
+      systemVersion: 6.0.0
+      createdTime: 1781809846059
+      modifiedTime: 1781809878325
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!MUpBNDoJEr09bLaO.qJHrH8Q3q1JB5xe5'
@@ -1184,7 +1392,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171225738


### PR DESCRIPTION
Updated the 5.1 SRD Fey creatures to current system standards. Included AEs, enrichers, and lookups where I could.

Does not currently touch spells or spellcasting traits, will handle that in future PR when spells are updated.

Related #6712