### PR TITLE
5.1 SRD Update: Monsters - Elementals

### DIFF
--- a/packs/_source/monsters/elemental/air-elemental.yml
+++ b/packs/_source/monsters/elemental/air-elemental.yml
@@ -460,9 +460,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -477,7 +474,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -497,17 +494,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: 8FHVwYBJY7dxIv9D
     name: Air Form
     type: feat
-    img: icons/magic/control/debuff-energy-hold-levitate-yellow.webp
+    img: icons/magic/air/air-wave-gust-blue.webp
     system:
       description:
         value: >-
-          <p>The elemental can enter a hostile creature's space and stop there.
-          It can move through a space as narrow as 1 inch wide without
-          squeezing.</p>
+          <p>The [[lookup @name lowercase]]{monster} can enter a hostile
+          creature's space and stop there. It can move through a space as narrow
+          as 1 inch wide without &amp;reference[squeezing]{Squeezing}.</p>
         chat: ''
       source:
         custom: ''
@@ -521,16 +519,58 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
         level: null
       identifier: air-form
-    effects: []
+    effects:
+      - name: Air Form
+        img: icons/magic/air/air-wave-gust-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.banHjKDMCegbUwYE.Item.8FHVwYBJY7dxIv9D
+        type: base
+        _id: vpfm0NeYtG6CcTKD
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You can enter a hostile creature's space and stop there. You can
+          move through a space as narrow as 1 inch wide without
+          &amp;reference[squeezing]{Squeezing}.</p>
+        tint: '#ffffff'
+        transfer: true
+        statuses:
+          - ethereal
+        showIcon: 0
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781811427623
+          modifiedTime: 1781811451971
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!banHjKDMCegbUwYE.8FHVwYBJY7dxIv9D.vpfm0NeYtG6CcTKD
     folder: null
     sort: 0
     ownership:
@@ -539,12 +579,12 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.TyDSfYTJeKv7c8lB
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781811399051
+      modifiedTime: 1781811455340
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!banHjKDMCegbUwYE.8FHVwYBJY7dxIv9D'
   - _id: IyR3c30mCbL8VMCo
@@ -554,8 +594,8 @@ items:
     system:
       description:
         value: >-
-          <p>The elemental makes two [[/item .qzLZFBO75loU77TZ]]{slam}
-          attacks.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two [[/item
+          .qzLZFBO75loU77TZ]]{Slam} attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -569,13 +609,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        zI6bS5K8ChereaUx:
           type: utility
           activation:
             type: action
@@ -590,15 +629,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -609,7 +649,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -626,7 +667,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: zI6bS5K8ChereaUx
       enchant: {}
       prerequisites:
         level: null
@@ -640,22 +689,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273656473
+      systemVersion: 6.0.0
+      createdTime: 1781811468994
+      modifiedTime: 1781811476192
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!banHjKDMCegbUwYE.IyR3c30mCbL8VMCo'
   - _id: qzLZFBO75loU77TZ
     name: Slam
     type: weapon
-    img: icons/skills/melee/unarmed-punch-fist-yellow-red.webp
+    img: icons/magic/air/air-pressure-shield-blue.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Air Elemental attacks with its Slam.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -717,9 +768,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - fin
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -728,8 +778,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        3mDZxjv6zjBnFhP1:
           type: attack
           activation:
             type: action
@@ -744,10 +793,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -764,7 +814,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -777,24 +828,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 3mDZxjv6zjBnFhP1
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: slam
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -804,11 +868,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107552342
+      systemVersion: 6.0.0
+      createdTime: 1781811491009
+      modifiedTime: 1781811508236
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!banHjKDMCegbUwYE.qzLZFBO75loU77TZ'
@@ -819,23 +883,26 @@ items:
     system:
       description:
         value: >-
-          <p>Each creature in the elemental's space must make a [[/save]] saving
-          throw. On a failure, a target takes [[/damage average]] damage and is
-          flung up 20 feet away from the elemental in a random direction and
-          knocked prone.</p><p>If a thrown target strikes an object, such as a
-          wall or floor, the target takes [[/damage activity=dnd5eactivity000
-          average]] damage for every 10 feet it was thrown. If the target is
-          thrown at another creature, that creature must succeed on a [[/save
-          activity=k9fqQYuxbnT3pwT3]] saving throw or take the same damage and
-          be knocked prone. If the saving throw is successful, the target takes
-          half the bludgeoning damage and isn't flung away or knocked prone.</p>
+          <p>Each creature in the [[lookup @name lowercase]]{monster}'s space
+          must make a [[/save activity=O0oP6dlhQ4kdTAGU]] saving throw. On a
+          failure, a target takes [[/damage average activity=O0oP6dlhQ4kdTAGU]]
+          damage and is flung up 20 feet away from the [[lookup @name
+          lowercase]]{monster} in a random direction and knocked
+          &amp;reference[prone].</p><p>If a thrown target strikes an object,
+          such as a wall or floor, the target takes [[/damage
+          activity=dnd5eactivity000 average]] damage for every 10 feet it was
+          thrown. If the target is thrown at another creature, that creature
+          must succeed on a [[/save activity=k9fqQYuxbnT3pwT3]] saving throw or
+          take the same damage and be knocked &amp;reference[prone]. If the
+          saving throw is successful, the target takes half the bludgeoning
+          damage and isn't flung away or knocked prone.</p>
         chat: >-
-          <p>Each creature in the elemental's space must make a
-          <strong>Strength</strong> saving throw. On a failure, a target is
-          flung up 20 feet away from the elemental in a random direction and
-          knocked prone. If the target is thrown at another creature, that
-          creature must make a <strong>Dexterity</strong> saving throw or take
-          the same damage and be knocked prone.</p>
+          <p>Each creature in the [[lookup @name]]{monster}'s space must make a
+          Strength saving throw. On a failure, a target is flung up 20 feet away
+          from the [[lookup @name]]{monster} in a random direction and knocked
+          &amp;reference[prone]. If the target is thrown at another creature,
+          that creature must make a Dexterity saving throw or take the same
+          damage and be knocked &amp;reference[prone].</p>
       source:
         custom: ''
         book: ''
@@ -851,13 +918,168 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        k9fqQYuxbnT3pwT3:
+          type: save
+          name: Creature Collision Save
+          _id: k9fqQYuxbnT3pwT3
+          sort: 300000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: true
+              max: '2'
+            spellSlot: true
+            targets: []
+          description:
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: creature
+              count: '1'
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          damage:
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
+                denomination: 8
+                bonus: ''
+                types:
+                  - bludgeoning
+                scaling:
+                  mode: whole
+                  number: 1
+            onSave: half
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: ''
+              formula: '13'
+            bonus: ''
+          img: ''
+          appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+        O0oP6dlhQ4kdTAGU:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets:
+              - type: itemUses
+                value: '1'
+                target: ''
+                scaling: {}
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            units: self
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 3
+                denomination: 8
+                bonus: ''
+                types:
+                  - bludgeoning
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - str
+            dc:
+              calculation: ''
+              formula: '13'
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Whirlwind Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: O0oP6dlhQ4kdTAGU
+        NrSJOK3Mb0qPtERy:
           type: damage
           activation:
             type: action
@@ -872,15 +1094,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -891,7 +1114,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -918,130 +1142,21 @@ items:
                   - bludgeoning
                 scaling:
                   mode: whole
-          sort: 200000
-          name: Object Damage
-          img: ''
-          appliedEffects: []
-        dnd5eactivity100:
-          _id: dnd5eactivity100
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                value: '1'
-                target: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: none
-            parts:
-              - custom:
-                  enabled: false
+                  number: 1
                   formula: ''
-                number: 3
-                denomination: 8
-                bonus: ''
-                types:
-                  - bludgeoning
-          save:
-            ability: str
-            dc:
-              calculation: ''
-              formula: '13'
-          sort: 100000
-          name: ''
+          sort: 250000
+          name: Object Collision Damage
           img: ''
-          appliedEffects: []
-        k9fqQYuxbnT3pwT3:
-          type: save
-          name: Creature Save
-          _id: k9fqQYuxbnT3pwT3
-          sort: 300000
-          activation:
-            type: action
-            override: false
-            condition: ''
-          consumption:
-            scaling:
-              allowed: false
-            spellSlot: true
-            targets: []
-          description:
-            chatFlavor: ''
-          duration:
-            units: inst
-            concentration: false
-            override: false
-          effects: []
-          range:
-            units: self
-            override: false
-            special: ''
-          target:
-            template:
-              contiguous: false
-              units: ft
-              type: ''
-            affects:
-              choice: false
-              type: ''
-            override: false
-            prompt: true
-          uses:
-            spent: 0
-            recovery: []
-            max: ''
-          damage:
-            parts: []
-            onSave: half
-          save:
-            ability:
-              - dex
-            dc:
-              calculation: ''
-              formula: '13'
-          img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: NrSJOK3Mb0qPtERy
       enchant: {}
       prerequisites:
         level: null
@@ -1051,19 +1166,15 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.ocmSrMY2NX3e43uN
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747954564495
+      systemVersion: 6.0.0
+      createdTime: 1781811546059
+      modifiedTime: 1781819793917
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!banHjKDMCegbUwYE.PVdWTEQBuiAglD7l'
@@ -1075,7 +1186,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171241306

--- a/packs/_source/monsters/elemental/azer.yml
+++ b/packs/_source/monsters/elemental/azer.yml
@@ -444,7 +444,7 @@ prototypeToken:
     negative: false
     priority: 0
   texture:
-    src: systems/dnd5e/tokens/elemental/Azer.webp
+    src: null
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1

--- a/packs/_source/monsters/elemental/azer.yml
+++ b/packs/_source/monsters/elemental/azer.yml
@@ -422,7 +422,7 @@ prototypeToken:
   randomImg: false
   alpha: 1
   light:
-    alpha: 1
+    alpha: 0.75
     angle: 360
     bright: 10
     coloration: 1
@@ -432,25 +432,22 @@ prototypeToken:
     contrast: 0
     shadows: 0
     animation:
-      speed: 5
-      intensity: 5
-      type: null
+      speed: 1
+      intensity: 1
+      type: flame
       reverse: false
     darkness:
       min: 0
       max: 1
-    attenuation: 0.5
-    color: null
+    attenuation: 0.6
+    color: '#601806'
     negative: false
     priority: 0
   texture:
-    src: null
+    src: systems/dnd5e/tokens/elemental/Azer.webp
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -465,7 +462,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -475,7 +472,7 @@ prototypeToken:
     colors:
       ring: null
       background: null
-    effects: 1
+    effects: 0
     subject:
       scale: 1
       texture: null
@@ -485,6 +482,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: sSs3hSzkKBMNBgTs
     name: Shield
@@ -554,7 +552,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.yHcr3vlkmtInELj2
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -565,12 +563,13 @@ items:
   - _id: P0pbiook7Q79UYqQ
     name: Heated Body
     type: feat
-    img: icons/magic/earth/volcano-explosion-lava-yellow.webp
+    img: icons/tools/smithing/furnace-fire-metal-orange.webp
     system:
       description:
         value: >-
-          <p>A creature that touches the azer or hits it with a melee attack
-          while within 5 feet of it takes [[/damage average]] damage.</p>
+          <p>A creature that touches the [[lookup @name lowercase]]{monster} or
+          hits it with a melee attack while within 5 feet of it takes [[/damage
+          average]] damage.</p>
         chat: ''
       source:
         custom: ''
@@ -584,18 +583,21 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
         dnd5eactivity000:
           _id: dnd5eactivity000
           type: damage
           activation:
-            type: ''
+            type: special
             value: null
-            condition: ''
+            condition: >-
+              When a creature touches the [[lookup @name lowercase]]{monster} or
+              hits it with a melee attack while within 5 feet of it.
             override: false
           consumption:
             targets: []
@@ -627,7 +629,7 @@ items:
               height: ''
               units: any
             affects:
-              count: ''
+              count: '1'
               type: creature
               choice: false
               special: ''
@@ -651,9 +653,14 @@ items:
                 types:
                   - fire
           sort: 0
-          name: ''
+          name: Contact Damage
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
       enchant: {}
       prerequisites:
         level: null
@@ -663,34 +670,31 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.iFNpsEMJT66eLoat
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747954647728
+      systemVersion: 6.0.0
+      createdTime: 1781811689853
+      modifiedTime: 1781811760167
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!IiEDPMWqBlzkggYD.P0pbiook7Q79UYqQ'
   - _id: WRygAnkpMeaqiw70
     name: Heated Weapons
     type: feat
-    img: icons/skills/melee/strike-sword-blood-red.webp
+    img: icons/tools/smithing/crucible-round.webp
     system:
       description:
         value: >-
-          <p>When the azer hits with a metal melee weapon, it deals an extra 3
-          (1d6) fire damage (included in the attack).</p>
+          <p>When the [[lookup @name lowercase]]{monster} hits with a metal
+          melee weapon, it deals an extra 3 (1d6) fire damage (included in the
+          attack).</p>
         chat: >-
-          <p>When the azer hits with a metal melee weapon, it deals extra
-          <em>fire damage</em> (included in the attack).</p>
+          <p>When the [[lookup @name]]{monster} hits with a metal melee weapon,
+          it deals extra fire damage (included in the attack).</p>
       source:
         custom: ''
         book: ''
@@ -703,10 +707,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -725,23 +730,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.i3viKtKcSVeWLJFJ
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747954613222
+      systemVersion: 6.0.0
+      createdTime: 1781811774820
+      modifiedTime: 1781819750529
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!IiEDPMWqBlzkggYD.WRygAnkpMeaqiw70'
   - _id: oPddwb4BScCEDanp
     name: Illumination
     type: feat
-    img: icons/magic/light/explosion-star-glow-blue-purple.webp
+    img: icons/magic/light/explosion-glow-spiral-yellow.webp
     system:
       description:
         value: >-
-          <p>The azer sheds bright light in a 10-foot radius and dim light for
-          an additional 10 ft.</p>
+          <p>The [[lookup @name lowercase]]{monster} sheds &amp;reference[bright
+          light] in a 10-foot radius and &amp;reference[dim light] for an
+          additional 10 feet.</p>
         chat: ''
       source:
         custom: ''
@@ -755,10 +761,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -773,12 +780,12 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.F3gzBbCW7U14zkBF
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781811797361
+      modifiedTime: 1781811828822
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!IiEDPMWqBlzkggYD.oPddwb4BScCEDanp'
   - _id: YvzdCGQeCV1XOcUt
@@ -792,14 +799,8 @@ items:
           attackMode=twoHanded]] if used with two hands to make a melee
           attack.</p>
         chat: >-
-          <section>
-
-
-          </section>
-
-          <p>A heavy metal hammer capable of being wielded with a single hand
-          with a shield or in two hands to deliver crushing concussive
-          blows.</p>
+          <section></section><p>The [[lookup @name]]{monster} attacks with its
+          [[lookup @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -863,7 +864,7 @@ items:
         conditions: ''
       properties:
         - ver
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -872,8 +873,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        MJsxrM9HuebosAr9:
           type: attack
           activation:
             type: action
@@ -888,10 +888,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -908,7 +909,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -921,32 +923,42 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: MJsxrM9HuebosAr9
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -961,11 +973,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.F0Df164Xv1gWcYt0
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747954692108
+      systemVersion: 6.0.0
+      createdTime: 1781811838275
+      modifiedTime: 1781811852950
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!IiEDPMWqBlzkggYD.YvzdCGQeCV1XOcUt'
@@ -977,11 +989,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171219763
-  modifiedTime: 1726171442629
+  modifiedTime: 1781811954963
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!IiEDPMWqBlzkggYD'

--- a/packs/_source/monsters/elemental/djinni.yml
+++ b/packs/_source/monsters/elemental/djinni.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,16 +481,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: fL3AlIo9kQ591fz5
     name: Elemental Demise
     type: feat
-    img: icons/magic/air/air-wave-gust-smoke-yellow.webp
+    img: icons/magic/air/wind-vortex-swirl-red.webp
     system:
       description:
         value: >-
-          <p>If the djinni dies, its body disintegrates into a warm breeze,
-          leaving behind only equipment the djinni was wearing or carrying.</p>
+          <p>If the [[lookup @name lowercase]]{monster} dies, its body
+          disintegrates into a warm breeze, leaving behind only equipment the
+          [[lookup @name lowercase]]{monster} was wearing or carrying.</p>
         chat: ''
       source:
         custom: ''
@@ -507,10 +506,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -525,12 +525,12 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WbaKH3NLA3mvylfM
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781811996988
+      modifiedTime: 1781812012096
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!5P1VGAZQwOilwZQf.fL3AlIo9kQ591fz5'
   - _id: PvddSEYCJ3fSHEOr
@@ -588,7 +588,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -603,8 +603,8 @@ items:
     system:
       description:
         value: >-
-          <p>The djinni makes three [[/item .DGP7lnAJT1cv8SA4]]{scimitar}
-          attacks.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three [[/item
+          .DGP7lnAJT1cv8SA4]]{Scimitar} attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -618,13 +618,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        pEmXboaD4KnLYEvS:
           type: utility
           activation:
             type: action
@@ -639,15 +638,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -658,7 +658,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -675,7 +676,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: pEmXboaD4KnLYEvS
       enchant: {}
       prerequisites:
         level: null
@@ -689,18 +698,18 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273655071
+      systemVersion: 6.0.0
+      createdTime: 1781812614726
+      modifiedTime: 1781812618986
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!5P1VGAZQwOilwZQf.Q7JcaZkLaYQq4CE5'
   - _id: DGP7lnAJT1cv8SA4
     name: Scimitar
     type: weapon
-    img: icons/weapons/swords/sword-katana.webp
+    img: icons/weapons/swords/scimitar-guard-gold.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]] (djinni's choice).</p>
@@ -767,17 +776,16 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: simpleM
-        baseItem: ''
+        value: martialM
+        baseItem: scimitar
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        9uVMnJt6VcQmQLbp:
           type: attack
           activation:
             type: action
@@ -792,6 +800,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -812,7 +821,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -825,14 +835,14 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
@@ -842,15 +852,26 @@ items:
                   enabled: false
                   formula: ''
                 number: 1
-                denomination: '6'
+                denomination: 6
                 bonus: ''
                 types:
                   - lightning
                   - thunder
-          sort: 0
+                scaling:
+                  number: 1
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 9uVMnJt6VcQmQLbp
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -861,19 +882,15 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.items.fbC0Mg1a73wdFbqO
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745173840296
+      systemVersion: 6.0.0
+      createdTime: 1781812022060
+      modifiedTime: 1781812051724
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!5P1VGAZQwOilwZQf.DGP7lnAJT1cv8SA4'
@@ -884,29 +901,34 @@ items:
     system:
       description:
         value: >-
-          <p>A 5-foot-radius, 30-foot-tall cylinder of swirling air magically
-          forms on a point the djinni can see within 120 feet of it. The
-          whirlwind lasts as long as the djinni maintains concentration (as if
-          concentrating on a spell).</p><p>Any creature but the djinni that
+          <p>A [[lookup @labels.description.template activity=5QSOnuuVfbhaFcH4]]
+          of swirling air magically forms on a point the djinni can see within
+          [[lookup @labels.description.range activity=5QSOnuuVfbhaFcH4]] of it.
+          The whirlwind lasts as long as the djinni maintains concentration (as
+          if concentrating on a spell).</p><p>Any creature but the djinni that
           enters the whirlwind must succeed on a [[/save]] saving throw or be
-          restrained by it. The djinni can move the whirlwind up to 60 feet as
-          an action, and creatures restrained by the whirlwind move with it. The
-          whirlwind ends if the djinni loses sight of it.</p><p>A creature can
-          use its action to free a creature restrained by the whirlwind,
-          including itself, by succeeding on a [[/check]] check. If the check
-          succeeds, the creature is no longer restrained and moves to the
-          nearest space outside the whirlwind.</p>
+          restrained by it. The djinni can move the whirlwind up to [[lookup
+          @labels.description.range activity=gtStP2vVpkp7MMw5]] as an action,
+          and creatures restrained by the whirlwind move with it. The whirlwind
+          ends if the djinni loses sight of it.</p><p>A creature can use its
+          action to free a creature restrained by the whirlwind, including
+          itself, by succeeding on a [[/check activity=LlBHDTeLFiSXeSPL]] check.
+          If the check succeeds, the creature is no longer restrained and moves
+          to the nearest space outside the whirlwind.</p>
         chat: >-
-          <p>A 5-foot-radius, 30-foot-tall cylinder of swirling air magically
-          forms on a point the djinni can see within 120 feet of it. Any
-          creature but the djinni that enters the whirlwind must make a
-          <strong>Strength</strong> saving throw or be restrained by it. The
-          djinni can move the whirlwind up to 60 feet as an action, and
-          creatures restrained by the whirlwind move with it. A creature can use
-          its action to free a creature restrained by the whirlwind, including
-          itself, by succeeding on a Strength check. If the check succeeds, the
-          creature is no longer restrained and moves to the nearest space
-          outside the whirlwind.</p>
+          <p>A [[lookup @labels.description.template activity=5QSOnuuVfbhaFcH4]]
+          of swirling air magically forms on a point the [[lookup
+          @name]]{monster} can see within [[lookup @labels.description.range
+          activity=5QSOnuuVfbhaFcH4]] of it. Any creature but the [[lookup
+          @name]]{monster} that enters the whirlwind must make a Strength saving
+          throw or be &amp;reference[restrained] by it. The [[lookup
+          @name]]{monster} can move the whirlwind up to [[lookup
+          @labels.description.range activity=gtStP2vVpkp7MMw5]] as an action,
+          and creatures restrained by the whirlwind move with it.</p><p>A
+          creature can use its action to free a creature restrained by the
+          whirlwind, including itself, by succeeding on a Strength check. If the
+          check succeeds, the creature is no longer restrained and moves to the
+          nearest space outside the whirlwind.</p>
       source:
         custom: ''
         book: ''
@@ -919,18 +941,20 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        HFesW3NEjtAzAnz1:
           type: save
           activation:
-            type: action
+            type: special
             value: 1
-            condition: ''
+            condition: >-
+              When a creature other than the [[lookup @name lowercase]]{monster}
+              enters the whirlwind.
             override: false
           consumption:
             targets: []
@@ -940,58 +964,78 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: true
             value: ''
             units: spec
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: 4oc8HfRHypael6Rq
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
-            value: '120'
-            units: ft
+            value: ''
+            units: spec
             special: ''
             override: false
           target:
             template:
               count: ''
               contiguous: false
-              type: cylinder
+              type: ''
               size: '5'
               width: ''
               height: '30'
               units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
-            prompt: true
+            prompt: false
             override: false
           uses:
             spent: 0
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: str
+            ability:
+              - str
             dc:
               calculation: ''
               formula: '18'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Whirlwind Save
           img: ''
-          appliedEffects: []
-        hUuMAYQYtO7oHptY:
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: HFesW3NEjtAzAnz1
+        LlBHDTeLFiSXeSPL:
           type: check
-          _id: hUuMAYQYtO7oHptY
-          sort: 0
+          sort: 400000
           activation:
-            type: action
+            type: special
             override: false
-            condition: ''
+            condition: >-
+              When a creature takes an action to try to free itself or another
+              creature &reference[restrained apply=false] by the whirlwind.
           consumption:
             scaling:
               allowed: false
@@ -999,13 +1043,14 @@ items:
             targets: []
           description:
             chatFlavor: ''
+            value: ''
           duration:
             units: inst
             concentration: false
             override: false
           effects: []
           range:
-            units: self
+            units: touch
             override: false
             special: ''
           target:
@@ -1013,11 +1058,14 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
-              type: ''
+              type: creature
+              count: '1'
+              special: ''
             override: false
-            prompt: true
+            prompt: false
           uses:
             spent: 0
             recovery: []
@@ -1028,31 +1076,203 @@ items:
               calculation: ''
               formula: '18'
             ability: str
-          name: Escape
+            visible: true
+            bonus: ''
+          name: Escape Whirlwind
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: LlBHDTeLFiSXeSPL
+        5QSOnuuVfbhaFcH4:
+          type: utility
+          name: Conjure Whirlwind
+          _id: 5QSOnuuVfbhaFcH4
+          img: ''
+          sort: 0
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: ft
+            override: false
+            special: ''
+            value: '120'
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: cylinder
+              size: '5'
+              height: '30'
+              count: '1'
+            affects:
+              choice: false
+              type: creature
+              count: ''
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
+        gtStP2vVpkp7MMw5:
+          type: utility
+          name: Move Whirlwind
+          _id: gtStP2vVpkp7MMw5
+          img: ''
+          sort: 300000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: >-
+              <p>The djinni can move the whirlwind up to 60 feet as an action,
+              and creatures restrained by the whirlwind move with it. The
+              whirlwind ends if the djinni loses sight of it.</p>
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: ft
+            override: false
+            special: ''
+            value: '60'
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: ''
+            override: false
+            prompt: false
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
       enchant: {}
       prerequisites:
         level: null
       identifier: create-whirlwind
-    effects: []
+    effects:
+      - name: Restrained by Whirlwind
+        img: icons/magic/air/wind-tornado-cyclone-white.webp
+        origin: Compendium.dnd5e.monsters.Actor.5P1VGAZQwOilwZQf.Item.nE7YNnVM7srBcdfl
+        transfer: false
+        _id: 4oc8HfRHypael6Rq
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are &amp;reference[restrained apply=false] by the whirlwind,
+          and move with it.</p><p>You or another creature can use an action to
+          free yourself from the whirlwind by succeeding on a [[/check 18 str]]
+          check. If the check succeeds, you are no longer restrained and move to
+          the enarest space outside the whirlwind.</p>
+        tint: '#ffffff'
+        statuses:
+          - restrained
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781812288750
+          modifiedTime: 1781812384876
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!5P1VGAZQwOilwZQf.nE7YNnVM7srBcdfl.4oc8HfRHypael6Rq
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.1XeF2VMMPw7QYffo
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747954813245
+      systemVersion: 6.0.0
+      createdTime: 1781812065348
+      modifiedTime: 1781812599869
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!5P1VGAZQwOilwZQf.nE7YNnVM7srBcdfl'
@@ -1170,7 +1390,7 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1286,7 +1506,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.Mzh95utKDPIrjiH8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1403,7 +1623,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ghXTfe7sgCbgf1Q8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1537,7 +1757,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.WTbOQBsarsL1LuXJ
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1658,7 +1878,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.BV0mpbHh29IbbIj5
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1778,7 +1998,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.gopnZvS0c2jD5FP8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1906,7 +2126,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.8PJAsHmbu6UgDHC0
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2026,7 +2246,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.lnaGnxMzpYnbw1uU
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2159,7 +2379,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.2IWiZAJtOGDoKjiz
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2283,7 +2503,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.1N8dDMMgZ1h1YJ3B
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2427,7 +2647,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.nslx2nT3p4lNkmdp
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2623,7 +2843,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.J6Jpw5XzB5aTeqnz
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2639,7 +2859,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171203084

--- a/packs/_source/monsters/elemental/dust-mephit.yml
+++ b/packs/_source/monsters/elemental/dust-mephit.yml
@@ -449,9 +449,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -466,7 +463,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -486,19 +483,22 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: v3i1DaUS4Bkc8Ser
     name: Death Burst
     type: feat
-    img: icons/magic/light/explosion-star-glow-yellow.webp
+    img: icons/magic/earth/projectile-stone-landslide.webp
     system:
       description:
         value: >-
-          <p>When the mephit dies, it explodes in a burst of dust. Each creature
-          within 5 ft. of it must then succeed on a [[/save]] saving throw or be
-          &amp;Reference[blinded] for 1 minute. A blinded creature can repeat
-          the saving throw on each of its turns, ending the effect on itself on
-          a success.</p>
+          <p>When the [[lookup @name lowercase]]{monster} dies, it explodes in a
+          burst of dust. Each creature within [[lookup @target.template.size
+          activity=xWXsJ4iFhpxEMroK]] feet of it must then succeed on a
+          [[/save]] saving throw or be &amp;Reference[blinded] for [[lookup
+          @labels.duration activity=xWXsJ4iFhpxEMroK]]. A blinded creature can
+          repeat the saving throw on each of its turns, ending the effect on
+          itself on a success.</p>
         chat: >-
           <p>When the mephit dies, it explodes in a burst of dust. Each creature
           within <strong>5 ft.</strong> of it must make a
@@ -515,18 +515,18 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+        xWXsJ4iFhpxEMroK:
           type: save
           activation:
-            type: ''
+            type: special
             value: null
-            condition: on death
+            condition: When the [[lookup @name lowercase]]{monster} dies.
             override: false
           consumption:
             targets: []
@@ -536,13 +536,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: wXabuU5S24Jh5Hu7
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '5'
             units: self
@@ -557,6 +563,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: true
             affects:
               count: ''
               type: creature
@@ -569,39 +576,88 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: con
+            ability:
+              - con
             dc:
               calculation: ''
               formula: '10'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Explode
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: xWXsJ4iFhpxEMroK
       enchant: {}
       prerequisites:
         level: null
       identifier: death-burst
-    effects: []
+    effects:
+      - name: Blinded by Dust
+        img: icons/magic/earth/projectile-stone-landslide.webp
+        origin: Compendium.dnd5e.monsters.Actor.BUCfQ7ihaXX75Vai.Item.v3i1DaUS4Bkc8Ser
+        transfer: false
+        _id: wXabuU5S24Jh5Hu7
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[blinded apply=false] for the
+          duration.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses:
+          - blinded
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781812719376
+          modifiedTime: 1781812905733
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!BUCfQ7ihaXX75Vai.v3i1DaUS4Bkc8Ser.wXabuU5S24Jh5Hu7
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.net3yBKQoxl8bZ4r
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955042559
+      systemVersion: 6.0.0
+      createdTime: 1781812636064
+      modifiedTime: 1781812770104
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!BUCfQ7ihaXX75Vai.v3i1DaUS4Bkc8Ser'
@@ -646,7 +702,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -657,11 +713,13 @@ items:
   - _id: lazTMrXNUpGCrKdR
     name: Claws
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-glowing-orange.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Dust Mephit attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -723,9 +781,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - fin
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -734,8 +791,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        mX5a4MPdd5V4r59r:
           type: attack
           activation:
             type: action
@@ -750,10 +806,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -770,7 +827,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -783,24 +841,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: mX5a4MPdd5V4r59r
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -810,26 +881,28 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107550638
+      systemVersion: 6.0.0
+      createdTime: 1781812780203
+      modifiedTime: 1781812794044
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!BUCfQ7ihaXX75Vai.lazTMrXNUpGCrKdR'
   - _id: RTpPc5fs27dBqDuj
     name: Blinding Breath
     type: feat
-    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
+    img: icons/magic/air/fog-gas-smoke-dense-brown.webp
     system:
       description:
         value: >-
-          <p>The mephit exhales a 15-foot cone of blinding dust. Each creature
-          in that area must succeed on a [[/save]] saving throw or be
-          &amp;Referrence[blinded] for 1 minute. A creature can repeat the
-          saving throw at the end of each of its turns, ending the effect on
-          itself on a success.</p>
+          <p>The mephit exhales a [[lookup @labels.description.template
+          activity=DkJgrFw9xkTp7btO]] of blinding dust. Each creature in that
+          area must succeed on a [[/save]] saving throw or be
+          &amp;reference[blinded] for [[lookup @labels.duration
+          activity=DkJgrFw9xkTp7btO]]. A creature can repeat the saving throw at
+          the end of each of its turns, ending the effect on itself on a
+          success.</p>
         chat: >-
           <p>The mephit exhales a 15-foot cone of blinding dust. Each creature
           in that area must make a <strong>Dexterity</strong> saving throw. A
@@ -850,13 +923,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+        DkJgrFw9xkTp7btO:
           type: save
           activation:
             type: action
@@ -868,19 +940,26 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: '1'
             units: minute
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: lEgTG8ExKmOG0sIW
+              onSave: false
+              level:
+                min: null
+                max: null
           range:
             value: '15'
             units: ft
@@ -895,6 +974,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -907,39 +987,89 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '10'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Exhale Dust
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: DkJgrFw9xkTp7btO
       enchant: {}
       prerequisites:
         level: null
       identifier: blinding-breath
-    effects: []
+    effects:
+      - name: Blinded by Dust
+        img: icons/magic/earth/projectile-stone-landslide.webp
+        origin: Compendium.dnd5e.monsters.Actor.BUCfQ7ihaXX75Vai.Item.RTpPc5fs27dBqDuj
+        transfer: false
+        _id: lEgTG8ExKmOG0sIW
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: minutes
+          expiry: turnStart
+          expired: false
+        description: >-
+          <p>You are &amp;reference[blinded apply=false] for the
+          duration.</p><p>You can repeat the saving throw at the end of each of
+          your turns, ending the effect on yourself on a success.</p>
+        tint: '#ffffff'
+        statuses:
+          - blinded
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781812863129
+          modifiedTime: 1781812887385
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: >-
+            Compendium.dnd5e.monsters.Actor.BUCfQ7ihaXX75Vai.Item.v3i1DaUS4Bkc8Ser.ActiveEffect.wXabuU5S24Jh5Hu7
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!BUCfQ7ihaXX75Vai.RTpPc5fs27dBqDuj.lEgTG8ExKmOG0sIW
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.tHvaJB8tXSriVXRm
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955063473
+      systemVersion: 6.0.0
+      createdTime: 1781812804704
+      modifiedTime: 1781812894246
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!BUCfQ7ihaXX75Vai.RTpPc5fs27dBqDuj'
@@ -1079,7 +1209,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.KhwiSi9fwVfUPtku
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1095,7 +1225,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171212022

--- a/packs/_source/monsters/elemental/earth-elemental.yml
+++ b/packs/_source/monsters/elemental/earth-elemental.yml
@@ -456,9 +456,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -473,7 +470,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -493,17 +490,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: Ctnlm397G5vkwWA4
     name: Earth Glide
     type: feat
-    img: icons/environment/wilderness/cave-entrance-mountain-blue.webp
+    img: icons/environment/wilderness/terrain-rocks-brown.webp
     system:
       description:
         value: >-
-          <p>The elemental can burrow through nonmagical, unworked earth and
-          stone. While doing so, the elemental doesn't disturb the material it
-          moves through.</p>
+          <p>The [[lookup @name lowercase]]{monster} can burrow through
+          nonmagical, unworked earth and stone. While doing so, the elemental
+          doesn't disturb the material it moves through.</p>
         chat: ''
       source:
         custom: ''
@@ -517,10 +515,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -535,60 +534,14 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.yrpqazOHqI4BrYW4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781814039213
+      modifiedTime: 1781814045010
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!sApYLZj9PTZ40wJr.Ctnlm397G5vkwWA4'
-  - _id: 1fGoFeub69Dueemk
-    name: Siege Monster
-    type: feat
-    img: icons/creatures/magical/construct-iron-stomping-yellow.webp
-    system:
-      description:
-        value: <p>The elemental deals double damage to objects and structures.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: siege-monster
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.cSA0EbjlxCbst4gJ
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!sApYLZj9PTZ40wJr.1fGoFeub69Dueemk'
   - _id: A8nxS57cG2yZpu1m
     name: Multiattack
     type: feat
@@ -596,8 +549,8 @@ items:
     system:
       description:
         value: >-
-          <p>The elemental makes two [[/item .2AD5aTLMPDmQFhGZ]]{slam}
-          attacks.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two [[/item
+          .2AD5aTLMPDmQFhGZ]]{Slam} attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -611,13 +564,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        TuozAnLN5eNHClhX:
           type: utility
           activation:
             type: action
@@ -632,15 +584,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -651,7 +604,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -668,7 +622,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: TuozAnLN5eNHClhX
       enchant: {}
       prerequisites:
         level: null
@@ -682,22 +644,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273657452
+      systemVersion: 6.0.0
+      createdTime: 1781814090392
+      modifiedTime: 1781814095766
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!sApYLZj9PTZ40wJr.A8nxS57cG2yZpu1m'
   - _id: 2AD5aTLMPDmQFhGZ
     name: Slam
     type: weapon
-    img: icons/skills/melee/unarmed-punch-fist-yellow-red.webp
+    img: icons/magic/earth/strike-fist-stone-gray.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Earth Elemental attacks with its Slam.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -721,7 +685,7 @@ items:
         value: null
         long: null
         units: ft
-        reach: null
+        reach: 10
       uses:
         max: ''
         recovery: []
@@ -759,9 +723,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -770,8 +733,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        17587DWsLJYTcguE:
           type: attack
           activation:
             type: action
@@ -786,10 +748,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -806,7 +769,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -819,24 +783,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 17587DWsLJYTcguE
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: slam
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -846,14 +823,67 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107553747
+      systemVersion: 6.0.0
+      createdTime: 1781814111069
+      modifiedTime: 1781814136626
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!sApYLZj9PTZ40wJr.2AD5aTLMPDmQFhGZ'
+  - _id: k8x76Y7EMOOH2VM0
+    name: Siege Monster
+    type: feat
+    img: icons/creatures/magical/construct-iron-stomping-yellow.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} deals double damage to
+          objects and structures.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: siege-monster
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 175000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.sApYLZj9PTZ40wJr.Item.C8gw10xhvdECJgkp
+      duplicateSource: Item.JGpJ3LDL8rfjLwVa
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781814078822
+      modifiedTime: 1781814078822
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!sApYLZj9PTZ40wJr.k8x76Y7EMOOH2VM0'
 effects: []
 folder: IB448xVSBvtqitzs
 sort: 0
@@ -862,7 +892,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171262061

--- a/packs/_source/monsters/elemental/efreeti.yml
+++ b/packs/_source/monsters/elemental/efreeti.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,16 +480,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: Fr77Z90cITQsMV3N
     name: Elemental Demise
     type: feat
-    img: icons/magic/air/air-wave-gust-smoke-yellow.webp
+    img: icons/magic/air/wind-vortex-swirl-red.webp
     system:
       description:
         value: >-
-          <p>If the efreeti dies, its body disintegrates in a flash of fire and
-          puff of smoke, leaving behind only equipment the djinni was wearing or
+          <p>If the [[lookup @name lowercase]]{monster} dies, its body
+          disintegrates in a flash of fire and puff of smoke, leaving behind
+          only equipment the [[lookup @name lowercase]]{monster} was wearing or
           carrying.</p>
         chat: ''
       source:
@@ -507,10 +506,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -525,12 +525,12 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WbaKH3NLA3mvylfM
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781814166791
+      modifiedTime: 1781814190803
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!LTomFUTBrkRi0Pj5.Fr77Z90cITQsMV3N'
   - _id: gb5HcbKlmYUvLAsk
@@ -587,7 +587,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -707,7 +707,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.1LkZvINag7KqBmDR
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -722,8 +722,9 @@ items:
     system:
       description:
         value: >-
-          <p>The efreeti makes two [[/item .tR7JGJjIz6H1oerb]]{scimitar} attacks
-          or uses its [[/item .9D7vAr8iJbSa4g5N]]{Hurl Flame} twice.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two [[/item
+          .tR7JGJjIz6H1oerb]]{Scimitar} attacks or uses its [[/item
+          .9D7vAr8iJbSa4g5N]]{Hurl Flame} twice.</p>
         chat: ''
       source:
         custom: ''
@@ -737,13 +738,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        3840CMo9USqVnMeJ:
           type: utility
           activation:
             type: action
@@ -758,15 +758,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -777,7 +778,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -794,7 +796,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 3840CMo9USqVnMeJ
       enchant: {}
       prerequisites:
         level: null
@@ -808,22 +818,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273655861
+      systemVersion: 6.0.0
+      createdTime: 1781814279783
+      modifiedTime: 1781814284021
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!LTomFUTBrkRi0Pj5.2NzoIyouATBfPgdc'
   - _id: tR7JGJjIz6H1oerb
     name: Scimitar
     type: weapon
-    img: icons/weapons/swords/sword-katana.webp
+    img: icons/weapons/swords/scimitar-guard-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Efreeti attacks with its Scimitar.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -888,7 +900,7 @@ items:
       properties:
         - fin
         - lgt
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -897,8 +909,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4hJpASbmoD3v4PYe:
           type: attack
           activation:
             type: action
@@ -913,10 +924,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -933,7 +945,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -946,36 +959,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4hJpASbmoD3v4PYe
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: scimitar
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -985,22 +1009,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.fbC0Mg1a73wdFbqO
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107551338
+      systemVersion: 6.0.0
+      createdTime: 1781814200763
+      modifiedTime: 1781814224683
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!LTomFUTBrkRi0Pj5.tR7JGJjIz6H1oerb'
   - _id: 9D7vAr8iJbSa4g5N
     name: Hurl Flame
     type: weapon
-    img: icons/magic/fire/blast-jet-stream-splash.webp
+    img: icons/magic/fire/projectile-fireball-orange-yellow.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Efreeti attacks with its Hurl Flame.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1062,9 +1088,8 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - thr
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1073,8 +1098,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        xZJ09WeLSyJnsSrB:
           type: attack
           activation:
             type: action
@@ -1089,6 +1113,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1109,7 +1134,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '1'
               type: creature
@@ -1122,8 +1148,8 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: none
-            bonus: '@abilities.cha.mod'
+            ability: cha
+            bonus: ''
             critical:
               threshold: null
             flat: false
@@ -1135,10 +1161,19 @@ items:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: xZJ09WeLSyJnsSrB
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1149,19 +1184,15 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745174515941
+      systemVersion: 6.0.0
+      createdTime: 1781814234007
+      modifiedTime: 1781814289536
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!LTomFUTBrkRi0Pj5.9D7vAr8iJbSa4g5N'
@@ -1274,7 +1305,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ghXTfe7sgCbgf1Q8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1420,7 +1451,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.WahI41a3goVUg0x1
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1540,7 +1571,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.gopnZvS0c2jD5FP8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1673,7 +1704,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.2IWiZAJtOGDoKjiz
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1797,7 +1828,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.1N8dDMMgZ1h1YJ3B
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1941,7 +1972,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.nslx2nT3p4lNkmdp
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2137,7 +2168,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.J6Jpw5XzB5aTeqnz
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2285,7 +2316,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.X3DrXgxjwI2dvkD6
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2301,7 +2332,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171224294

--- a/packs/_source/monsters/elemental/fire-elemental.yml
+++ b/packs/_source/monsters/elemental/fire-elemental.yml
@@ -433,35 +433,32 @@ prototypeToken:
   randomImg: false
   alpha: 1
   light:
-    alpha: 1
+    alpha: 0.75
     angle: 360
-    bright: 0
+    bright: 30
     coloration: 1
-    dim: 0
+    dim: 60
     luminosity: 0.5
     saturation: 0
     contrast: 0
     shadows: 0
     animation:
-      speed: 5
-      intensity: 5
-      type: null
+      speed: 1
+      intensity: 2
+      type: flame
       reverse: false
     darkness:
       min: 0
       max: 1
-    attenuation: 0.5
-    color: null
+    attenuation: 0.6
+    color: '#601806'
     negative: false
     priority: 0
   texture:
-    src: null
+    src: systems/dnd5e/tokens/elemental/FireElemental.webp
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -476,7 +473,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -486,7 +483,7 @@ prototypeToken:
     colors:
       ring: null
       background: null
-    effects: 1
+    effects: 0
     subject:
       scale: 1
       texture: null
@@ -496,31 +493,35 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: yud1cnEVQ9KxbmWc
     name: Fire Form
     type: feat
-    img: icons/magic/earth/lava-explosion-orange.webp
+    img: icons/magic/fire/elemental-fire-flying.webp
     system:
       description:
         value: >-
-          <p>The elemental can move through a space as narrow as 1 inch wide
-          without squeezing. A creature that touches the elemental or hits it
-          with a melee attack while within 5 ft. of it takes [[/damage average]]
-          damage.</p><p>In addition, the elemental can enter a hostile
-          creature's space and stop there. The first time it enters a creature's
-          space on a turn, that creature takes [[/damage average]] damage and
-          catches fire; until someone takes an action to douse the fire, the
-          creature takes [[/damage average]] damage at the start of each of its
-          turns.</p>
+          <p>The [[lookup @name lowercase]]{monster} can move through a space as
+          narrow as 1 inch wide without &amp;reference[squeezing]{Squeezing}. A
+          creature that touches the [[lookup @name lowercase]]{monster} or hits
+          it with a melee attack while within [[lookup @labels.description.range
+          activity=3xh7g2u2KGcjZSe4]] of it takes [[/damage average]]
+          damage.</p><p>In addition, the [[lookup @name lowercase]]{monster} can
+          enter a hostile creature's space and stop there. The first time it
+          enters a creature's space on a turn, that creature takes [[/damage
+          average]] damage and catches fire; until someone takes an action to
+          douse the fire, the creature takes [[/damage average]] damage at the
+          start of each of its turns.</p>
         chat: >-
-          <p>A creature that touches the elemental or hits it with a melee
-          attack while within 5 ft. of it takes <em>fire damage</em>. In
-          addition, the elemental can enter a hostile creature's space and stop
-          there. The first time it enters a creature's space on a turn, that
-          creature takes <em>fire damage</em> and catches fire; until someone
-          takes an action to douse the fire, the creature takes <em>fire
-          damage</em> at the start of each of its turns.</p>
+          <p>A creature that touches the [[lookup @name]]{monster} or hits it
+          with a melee attack while within [[lookup @labels.description.range
+          activity=3xh7g2u2KGcjZSe4]] feet of it takes fire damage. In addition,
+          the [[lookup @name]]{monster} can enter a hostile creature's space and
+          stop there. The first time it enters a creature's space on a turn,
+          that creature takes fire damage and catches fire; until someone takes
+          an action to douse the fire, the creature takes fire damage at the
+          start of each of its turns.</p>
       source:
         custom: ''
         book: ''
@@ -533,18 +534,20 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        3xh7g2u2KGcjZSe4:
           type: damage
           activation:
-            type: ''
+            type: special
             value: null
-            condition: ''
+            condition: >-
+              When a creature touches the [[lookup @name lowercase]]{monster} or
+              hits it with a emelee attack while within 5 feet of it.
             override: false
           consumption:
             targets: []
@@ -554,17 +557,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: ft
             special: ''
             override: false
+            value: '5'
           target:
             template:
               count: ''
@@ -573,10 +578,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -590,24 +596,186 @@ items:
               allow: false
               bonus: ''
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 10
                 bonus: ''
                 types:
                   - fire
-                custom:
+                scaling:
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 3xh7g2u2KGcjZSe4
+          name: Contact Damage
+        rFzeGndbzECvRuv8:
+          type: damage
+          name: Ignite Creature
+          _id: rFzeGndbzECvRuv8
+          img: ''
+          sort: 200000
+          activation:
+            type: special
+            override: false
+            condition: >-
+              The first time the [[lookup @name lowercase]]{monster} enters a
+              creature's space on a turn.
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: JaPKJu7WX0QierHn
+              level: {}
+          flags: {}
+          range:
+            units: touch
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: creature
+              count: '1'
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          damage:
+            critical:
+              allow: false
+            parts:
+              - custom:
                   enabled: false
                   formula: ''
+                number: 1
+                denomination: 10
+                bonus: ''
+                types:
+                  - fire
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
       enchant: {}
       prerequisites:
         level: null
       identifier: fire-form
-    effects: []
+    effects:
+      - name: Ignited
+        img: icons/magic/fire/flame-burning-skull-orange.webp
+        origin: Compendium.dnd5e.monsters.Actor.8SMQl75HLjhuSeau.Item.yud1cnEVQ9KxbmWc
+        transfer: false
+        _id: JaPKJu7WX0QierHn
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are on fire. Until someone takes an action to douse the fire,
+          you take [[/damage average 1d10 fire]] damage at the start of each of
+          your turns.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781814480955
+          modifiedTime: 1781814523059
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!8SMQl75HLjhuSeau.yud1cnEVQ9KxbmWc.JaPKJu7WX0QierHn
+      - name: Fire Form
+        img: icons/magic/fire/elemental-fire-flying.webp
+        origin: Compendium.dnd5e.monsters.Actor.8SMQl75HLjhuSeau.Item.yud1cnEVQ9KxbmWc
+        type: base
+        _id: PoqGwdVp6MQTpIOh
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You can move through a space as narrow as 1 inch wide without
+          &amp;reference[squeezing]{Squeezing}.</p><p>In addition, you can enter
+          a hostile creature's space and stop there.</p>
+        tint: '#ffffff'
+        transfer: true
+        statuses:
+          - ethereal
+        showIcon: 0
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781817636924
+          modifiedTime: 1781817669403
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!8SMQl75HLjhuSeau.yud1cnEVQ9KxbmWc.PoqGwdVp6MQTpIOh
     folder: null
     sort: 0
     ownership:
@@ -616,23 +784,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.0YuGSS8E8ElHLRyb
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955111165
+      systemVersion: 6.0.0
+      createdTime: 1781814313585
+      modifiedTime: 1781819705394
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!8SMQl75HLjhuSeau.yud1cnEVQ9KxbmWc'
   - _id: iQt3J3ZnHDoeaEIR
     name: Illumination
     type: feat
-    img: icons/magic/light/explosion-star-glow-blue-purple.webp
+    img: icons/magic/light/explosion-glow-spiral-yellow.webp
     system:
       description:
         value: >-
-          <p>The elemental sheds bright light in a 30-foot radius and dim light
-          in an additional 30 ft..</p>
+          <p>The [[lookup @name lowercase]]{monster} sheds &amp;reference[bright
+          light] in a 30-foot radius and &amp;reference[dim light] in an
+          additional 30 feet.</p>
         chat: ''
       source:
         custom: ''
@@ -646,10 +815,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -664,23 +834,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.F3gzBbCW7U14zkBF
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955121194
+      systemVersion: 6.0.0
+      createdTime: 1781814539248
+      modifiedTime: 1781814564167
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!8SMQl75HLjhuSeau.iQt3J3ZnHDoeaEIR'
   - _id: AW3qP6nJk45lOHe3
     name: Water Susceptibility
     type: feat
-    img: icons/magic/water/pseudopod-swirl-blue.webp
+    img: icons/magic/water/water-drop-swirl-blue.webp
     system:
       description:
         value: >-
-          <p>For every 5 ft. the elemental moves in water, or for every gallon
-          of water splashed on it, it takes [[/damage]] damage.</p>
+          <p>For every 5 feet the [[lookup @name lowercase]]{monster} moves in
+          water, or for every gallon of water splashed on it, it takes
+          [[/damage]] damage.</p>
         chat: ''
       source:
         custom: ''
@@ -699,21 +870,21 @@ items:
       requirements: ''
       properties: []
       activities:
-        8SEMSOQEd8LaPZGb:
+        xWcWWthJeUTVe8o4:
           type: damage
-          _id: 8SEMSOQEd8LaPZGb
-          sort: 0
+          sort: 100000
           activation:
             type: ''
             override: false
             condition: ''
           consumption:
             scaling:
-              allowed: false
+              allowed: true
             spellSlot: true
             targets: []
           description:
             chatFlavor: ''
+            value: ''
           duration:
             units: inst
             concentration: false
@@ -728,6 +899,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               type: ''
@@ -749,9 +921,20 @@ items:
                 bonus: '1'
                 types:
                   - cold
-          name: ''
+                scaling:
+                  number: 1
+          name: Dousing Water
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: xWcWWthJeUTVe8o4
       enchant: {}
       prerequisites:
         level: null
@@ -761,19 +944,15 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.5V7SCABXvIbnk2Zn
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955152360
+      systemVersion: 6.0.0
+      createdTime: 1781814707097
+      modifiedTime: 1781814734658
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!8SMQl75HLjhuSeau.AW3qP6nJk45lOHe3'
@@ -870,7 +1049,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -881,20 +1060,21 @@ items:
   - _id: fdt2FIirmBRCpRBm
     name: Touch
     type: weapon
-    img: icons/magic/fire/flame-burning-fist-strike.webp
+    img: icons/magic/fire/flame-burning-earth-yellow.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
           a creature or a flammable object, it ignites. Until a creature takes
           an action to douse the fire, the target takes [[/damage
-          activity=t6hyTO2lOgR3OWJQ average]] damage at the start of each of its
+          activity=dFEUCLc4Cmb2DETC average]] damage at the start of each of its
           turns.</p>
         chat: >-
-          <p>The Fire Elemental attacks with its Touch. If the target is a
-          creature or a flammable object, it ignites. Until a creature takes an
-          action to douse the fire, the target takes <em>fire damage</em> at the
-          start of each of its turns.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. If the target is a creature or a flammable object, it
+          ignites. Until a creature takes an action to douse the fire, the
+          target takes <em>fire damage</em> at the start of each of its
+          turns.</p>
       source:
         custom: ''
         book: ''
@@ -957,7 +1137,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -966,8 +1146,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        8AVbNMC2R4WCRU2P:
           type: attack
           activation:
             type: action
@@ -982,13 +1161,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: kMWp6sv06eOgiQ5W
+              level: {}
           range:
             value: '5'
             units: ft
@@ -1002,7 +1184,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1015,28 +1198,41 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
-        t6hyTO2lOgR3OWJQ:
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 8AVbNMC2R4WCRU2P
+          name: ''
+        dFEUCLc4Cmb2DETC:
           type: damage
-          _id: t6hyTO2lOgR3OWJQ
-          sort: 0
+          sort: 200000
           activation:
-            type: ''
+            type: special
             override: false
-            condition: ''
+            condition: >-
+              When a creature the [[lookup @name lowercase]]{monster} has set on
+              fire starts their turn.
           consumption:
             scaling:
               allowed: false
@@ -1044,22 +1240,30 @@ items:
             targets: []
           description:
             chatFlavor: ''
+            value: >-
+              <p>Until a creature takes an action to douse the fire, the target
+              takes [[/damage activity=dFEUCLc4Cmb2DETC average]] damage at the
+              start of each of its turns.</p>
           duration:
             units: inst
             concentration: false
             override: false
           effects: []
           range:
-            units: self
-            override: false
+            units: spec
+            override: true
+            special: ''
           target:
             template:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
-              type: ''
+              type: creature
+              count: '1'
+              special: ''
             override: false
             prompt: true
           uses:
@@ -1078,32 +1282,80 @@ items:
                 bonus: ''
                 types:
                   - fire
-          name: ''
+                scaling:
+                  number: 1
+          name: Start of Turn Burning Damage
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: dFEUCLc4Cmb2DETC
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: touch
       mastery: ''
-    effects: []
+    effects:
+      - name: Ignited
+        img: icons/magic/fire/flame-burning-skull-orange.webp
+        origin: Compendium.dnd5e.monsters.Actor.8SMQl75HLjhuSeau.Item.fdt2FIirmBRCpRBm
+        transfer: false
+        _id: kMWp6sv06eOgiQ5W
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are on fire. Until someone takes an action to douse the fire,
+          you take [[/damage average 1d10 fire]] damage at the start of each of
+          your turns.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781814635318
+          modifiedTime: 1781814635318
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: >-
+            Compendium.dnd5e.monsters.Actor.8SMQl75HLjhuSeau.Item.yud1cnEVQ9KxbmWc.ActiveEffect.JaPKJu7WX0QierHn
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!8SMQl75HLjhuSeau.fdt2FIirmBRCpRBm.kMWp6sv06eOgiQ5W
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955197992
+      systemVersion: 6.0.0
+      createdTime: 1781814572573
+      modifiedTime: 1781814698980
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!8SMQl75HLjhuSeau.fdt2FIirmBRCpRBm'
@@ -1115,11 +1367,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171207981
-  modifiedTime: 1726171440457
+  modifiedTime: 1781814820500
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!8SMQl75HLjhuSeau'

--- a/packs/_source/monsters/elemental/fire-elemental.yml
+++ b/packs/_source/monsters/elemental/fire-elemental.yml
@@ -455,7 +455,7 @@ prototypeToken:
     negative: false
     priority: 0
   texture:
-    src: systems/dnd5e/tokens/elemental/FireElemental.webp
+    src: null
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
@@ -547,7 +547,7 @@ items:
             value: null
             condition: >-
               When a creature touches the [[lookup @name lowercase]]{monster} or
-              hits it with a emelee attack while within 5 feet of it.
+              hits it with a melee attack while within 5 feet of it.
             override: false
           consumption:
             targets: []

--- a/packs/_source/monsters/elemental/gargoyle.yml
+++ b/packs/_source/monsters/elemental/gargoyle.yml
@@ -454,9 +454,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -471,7 +468,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -491,16 +488,17 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: sXPmgYwYgosoytUu
     name: False Appearance
     type: feat
-    img: icons/magic/nature/stealth-hide-eyes-green.webp
+    img: icons/commodities/treasure/statue-bust-stone-grey.webp
     system:
       description:
         value: >-
-          <p>While the gargoyle remains motion less, it is indistinguishable
-          from an inanimate statue.</p>
+          <p>While the [[lookup @name lowercase]]{monster} remains motion less,
+          it is indistinguishable from an inanimate statue.</p>
         chat: ''
       source:
         custom: ''
@@ -514,10 +512,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -532,12 +531,12 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.kyVgQNSa12loxVvr
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781814843751
+      modifiedTime: 1781814854176
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!0m8QyDN52qw9zzOM.sXPmgYwYgosoytUu'
   - _id: yczO5JpGxAk51Gp8
@@ -547,9 +546,9 @@ items:
     system:
       description:
         value: >-
-          <p>The gargoyle makes two attacks: one with its [[/item
-          .A6GBvah75Y7fGjc5]]{bite} and one with its [[/item
-          .ipJwA0j2zfzmq5GW]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two attacks: one with
+          its [[/item .A6GBvah75Y7fGjc5]]{Bite} and one with its [[/item
+          .ipJwA0j2zfzmq5GW]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -563,13 +562,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        BYBBI9VYAaJ5a6KW:
           type: utility
           activation:
             type: action
@@ -584,15 +582,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -603,7 +602,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -620,7 +620,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: BYBBI9VYAaJ5a6KW
       enchant: {}
       prerequisites:
         level: null
@@ -634,22 +642,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273654857
+      systemVersion: 6.0.0
+      createdTime: 1781814868556
+      modifiedTime: 1781814874713
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!0m8QyDN52qw9zzOM.yczO5JpGxAk51Gp8'
   - _id: A6GBvah75Y7fGjc5
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Gargoyle attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -712,7 +722,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -721,8 +731,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        1DCPRqgfjI4oWbOC:
           type: attack
           activation:
             type: action
@@ -737,10 +746,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -757,7 +767,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -776,18 +787,31 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 1DCPRqgfjI4oWbOC
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -797,22 +821,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107549636
+      systemVersion: 6.0.0
+      createdTime: 1781814878762
+      modifiedTime: 1781814891103
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!0m8QyDN52qw9zzOM.A6GBvah75Y7fGjc5'
   - _id: ipJwA0j2zfzmq5GW
     name: Claws
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/commodities/claws/claw-lizard-white-black.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Gargoyle attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -875,7 +901,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -884,8 +910,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        55JRHybjMZkpC1xz:
           type: attack
           activation:
             type: action
@@ -900,10 +925,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -920,7 +946,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -939,18 +966,31 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 55JRHybjMZkpC1xz
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -960,11 +1000,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107549636
+      systemVersion: 6.0.0
+      createdTime: 1781814900727
+      modifiedTime: 1781814912914
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!0m8QyDN52qw9zzOM.ipJwA0j2zfzmq5GW'
@@ -976,7 +1016,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171198010

--- a/packs/_source/monsters/elemental/ice-mephit.yml
+++ b/packs/_source/monsters/elemental/ice-mephit.yml
@@ -451,9 +451,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -468,7 +465,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -488,22 +485,26 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: D4cqlN9pDyQwRvWP
     name: Death Burst
     type: feat
-    img: icons/magic/light/explosion-star-glow-yellow.webp
+    img: icons/magic/water/projectiles-ice-faceted-shard-salvo-gray.webp
     system:
       description:
         value: >-
-          <p>When the mephit dies, it explodes in a burst of jagged ice. Each
-          creature within 5 ft. of it must make a [[/save]] saving throw, taking
-          [[/damage average]] damage on a failed save, or half as much damage on
-          a successful one.</p>
+          <p>When the [[lookup @name lowercase]]{monster} dies, it explodes in a
+          burst of jagged ice. Each creature within [[lookup
+          @target.template.size activity=glG08f8z6ST3xsuh]] feet of it must make
+          a [[/save activity=glG08f8z6ST3xsuh]] saving throw, taking [[/damage
+          average activity=glG08f8z6ST3xsuh]] damage on a failed save, or half
+          as much damage on a successful one.</p>
         chat: >-
-          <p>When the mephit dies, it explodes in a burst of jagged ice. Each
-          creature within 5 ft. of it must make a <strong>Dexterity</strong>
-          saving throw.</p>
+          <p>When the [[lookup @name]]{monster} dies, it explodes in a burst of
+          jagged ice. Each creature within [[lookup @target.template.size
+          activity=glG08f8z6ST3xsuh]] feet of it must make a Dexterity saving
+          throw.</p>
       source:
         custom: ''
         book: ''
@@ -516,18 +517,18 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        glG08f8z6ST3xsuh:
           type: save
           activation:
-            type: ''
+            type: special
             value: null
-            condition: death
+            condition: When the [[lookup @name lowercase]]{monster} dies.
             override: false
           consumption:
             targets: []
@@ -537,10 +538,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -557,6 +559,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: true
             affects:
               count: ''
               type: creature
@@ -579,15 +582,29 @@ items:
                 bonus: ''
                 types:
                   - slashing
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '10'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Explode
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: glG08f8z6ST3xsuh
       enchant: {}
       prerequisites:
         level: null
@@ -597,31 +614,27 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.net3yBKQoxl8bZ4r
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955280715
+      systemVersion: 6.0.0
+      createdTime: 1781819067936
+      modifiedTime: 1781819312020
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ESEm3fGUfSKjzVUc.D4cqlN9pDyQwRvWP'
   - _id: CG9kMpmgbBE0ePpO
     name: False Appearance
     type: feat
-    img: icons/magic/nature/stealth-hide-eyes-green.webp
+    img: icons/magic/water/barrier-ice-crystal-wall-faceted.webp
     system:
       description:
         value: >-
-          <p>While the mephit remains motionless, it is indistinguishable from
-          an ordinary shard of ice.</p>
+          <p>While the [[lookup @name lowercase]]{monster} remains motionless,
+          it is indistinguishable from an ordinary shard of ice.</p>
         chat: ''
       source:
         custom: ''
@@ -635,10 +648,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -653,12 +667,12 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.kyVgQNSa12loxVvr
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781819147883
+      modifiedTime: 1781819164436
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ESEm3fGUfSKjzVUc.CG9kMpmgbBE0ePpO'
   - _id: qSKvifcPZvWEyQwS
@@ -702,7 +716,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -713,11 +727,13 @@ items:
   - _id: YEZPqZegxKiGO0Gq
     name: Claws
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/commodities/claws/claw-lizard-white-black.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ice Mephit attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -780,7 +796,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -789,8 +805,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        FjdDmLMEDA7ApsH0:
           type: attack
           activation:
             type: action
@@ -805,10 +820,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -825,7 +841,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -838,36 +855,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 4
                 bonus: ''
                 types:
                   - cold
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: FjdDmLMEDA7ApsH0
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -877,28 +905,31 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107550842
+      systemVersion: 6.0.0
+      createdTime: 1781819173828
+      modifiedTime: 1781819190471
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ESEm3fGUfSKjzVUc.YEZPqZegxKiGO0Gq'
   - _id: 1mD9NcCf8ZMQtsrU
     name: Frost Breath
     type: feat
-    img: icons/magic/air/wind-tornado-wall-blue.webp
+    img: icons/magic/water/projectile-ice-teardrop.webp
     system:
       description:
         value: >-
-          <p>The mephit exhales a 15-foot cone of cold air. Each creature in
-          that area must succeed on a [[/save]] saving throw, taking [[/damage
-          average]] damage on a failed save, or half as much damage on a
-          successful one.</p>
+          <p>The [[lookup @name lowercase]]{monster} exhales a [[lookup
+          @labels.description.template activity=n9E3Xvi0ovWJpQwN]] of cold air.
+          Each creature in that area must succeed on a [[/save
+          activity=n9E3Xvi0ovWJpQwN]] saving throw, taking [[/damage average
+          activity=n9E3Xvi0ovWJpQwN]] damage on a failed save, or half as much
+          damage on a successful one.</p>
         chat: >-
-          <p>The mephit exhales a 15-foot cone of cold air. Each creature in
-          that area must make a <strong>Dexterity</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} exhales a [[lookup
+          @labels.description.template activity=n9E3Xvi0ovWJpQwN]] of cold air.
+          Each creature in that area must make a Dexterity saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -914,13 +945,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        n9E3Xvi0ovWJpQwN:
           type: save
           activation:
             type: action
@@ -932,21 +962,23 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -958,6 +990,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -980,15 +1013,29 @@ items:
                 bonus: ''
                 types:
                   - cold
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '10'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Exhale Frost
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: n9E3Xvi0ovWJpQwN
       enchant: {}
       prerequisites:
         level: null
@@ -998,19 +1045,15 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.Z7U6z4HD1ORlkTIJ
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955235795
+      systemVersion: 6.0.0
+      createdTime: 1781819205779
+      modifiedTime: 1781819278761
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ESEm3fGUfSKjzVUc.1mD9NcCf8ZMQtsrU'
@@ -1131,7 +1174,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.IBJmWjzbQGu7M4UX
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1147,7 +1190,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171215230

--- a/packs/_source/monsters/elemental/invisible-stalker.yml
+++ b/packs/_source/monsters/elemental/invisible-stalker.yml
@@ -458,9 +458,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -475,7 +472,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -495,21 +492,24 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: VdFnTF9MqUFF7KPQ
     name: Faultless Tracker
     type: feat
-    img: icons/creatures/mammals/wolf-howl-moon-forest-blue.webp
+    img: icons/creatures/mammals/wolf-shadow-black.webp
     system:
       description:
         value: >-
-          <p>The stalker is given a quarry by its summoner. The stalker knows
-          the direction and distance to its quarry as long as the two of them
-          are on the same plane of existence. The stalker also knows the
-          location of its summoner.</p>
+          <p>The [[lookup @name lowercase]]{monster} is given a quarry by its
+          summoner. The [[lookup @name lowercase]]{monster} knows the direction
+          and distance to its quarry as long as the two of them are on the same
+          plane of existence. The [[lookup @name lowercase]]{monster} also knows
+          the location of its summoner.</p>
         chat: >-
-          <p>The stalker knows the direction and distance to its quarry as long
-          as the two of them are on the same plane of existence. </p>
+          <p>The [[lookup @name]]{monster} knows the direction and distance to
+          its quarry as long as the two of them are on the same plane of
+          existence.</p>
       source:
         custom: ''
         book: ''
@@ -522,10 +522,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -540,21 +541,23 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.E8SiDA7Z3Ybd6wt0
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.2.0
-      createdTime: null
-      modifiedTime: 1736804676605
+      systemVersion: 6.0.0
+      createdTime: 1781818901169
+      modifiedTime: 1781819626308
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!oDspGxRQFBhE74L2.VdFnTF9MqUFF7KPQ'
   - _id: UR2TYdvh0VZzLKyO
     name: Invisibility
     type: feat
-    img: icons/creatures/webs/webthin-blue.webp
+    img: icons/creatures/magical/spirit-undead-ghost-blue.webp
     system:
       description:
-        value: <p>The stalker is invisible.</p>
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} is &amp;reference[invisible
+          apply=false].</p>
         chat: ''
       source:
         custom: ''
@@ -568,16 +571,54 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
         level: null
       identifier: invisibility
-    effects: []
+    effects:
+      - name: Invisibility
+        img: icons/creatures/magical/spirit-undead-ghost-blue.webp
+        origin: Compendium.dnd5e.monsters.Actor.oDspGxRQFBhE74L2.Item.UR2TYdvh0VZzLKyO
+        type: base
+        _id: 7AfkQufSSsgkE4MS
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: <p>You are &amp;reference[invisible apply=false].</p>
+        tint: '#ffffff'
+        transfer: true
+        statuses: []
+        showIcon: 0
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781818947385
+          modifiedTime: 1781818960274
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!oDspGxRQFBhE74L2.UR2TYdvh0VZzLKyO.7AfkQufSSsgkE4MS
     folder: null
     sort: 0
     ownership:
@@ -586,12 +627,12 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.dA5X2eQuOtHywpQF
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781818928653
+      modifiedTime: 1781818970972
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!oDspGxRQFBhE74L2.UR2TYdvh0VZzLKyO'
   - _id: bl0mrJpx4dqL9Ub8
@@ -601,8 +642,8 @@ items:
     system:
       description:
         value: >-
-          <p>The stalker makes two [[/item .rpKiEPQVeOZTLwjf]]{slam}
-          attacks.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two [[/item
+          .rpKiEPQVeOZTLwjf]]{Slam} attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -616,13 +657,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        b6RlWb5c2h6YWLPH:
           type: utility
           activation:
             type: action
@@ -637,15 +677,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -656,7 +697,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -673,7 +715,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: b6RlWb5c2h6YWLPH
       enchant: {}
       prerequisites:
         level: null
@@ -687,22 +737,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273657149
+      systemVersion: 6.0.0
+      createdTime: 1781818987671
+      modifiedTime: 1781818993379
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!oDspGxRQFBhE74L2.bl0mrJpx4dqL9Ub8'
   - _id: rpKiEPQVeOZTLwjf
     name: Slam
     type: weapon
-    img: icons/skills/melee/unarmed-punch-fist-yellow-red.webp
+    img: icons/magic/air/air-pressure-shield-blue.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Invisible Stalker attacks with its Slam.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -765,7 +817,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -774,8 +826,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        sNtjR6slxMe2GYJb:
           type: attack
           activation:
             type: action
@@ -790,10 +841,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -810,7 +862,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -829,18 +882,31 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: sNtjR6slxMe2GYJb
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: slam
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -850,11 +916,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107553431
+      systemVersion: 6.0.0
+      createdTime: 1781819005473
+      modifiedTime: 1781819023398
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!oDspGxRQFBhE74L2.rpKiEPQVeOZTLwjf'
@@ -866,7 +932,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171257169

--- a/packs/_source/monsters/elemental/magma-mephit.yml
+++ b/packs/_source/monsters/elemental/magma-mephit.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,6 +481,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: lAwQmCYEd9CtDdTb
     name: Innate Spellcasting
@@ -526,7 +524,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 5.1.0
       createdTime: null
@@ -537,17 +535,20 @@ items:
   - _id: LpYrQPxHA10HPnkl
     name: Death Burst
     type: feat
-    img: icons/magic/light/explosion-star-glow-yellow.webp
+    img: icons/magic/earth/lava-explosion-orange.webp
     system:
       description:
         value: >-
-          <p>When the mephit dies, it explodes in a burst of lava. Each creature
-          within 5 ft. of it must make a [[/save]] saving throw, taking
-          [[/damage average]] damage on a failed save, or half as much damage on
-          a successful one.</p>
+          <p>When the [[lookup @name lowercase]]{monster} dies, it explodes in a
+          burst of lava. Each creature within [[lookup @target.template.size
+          activity=UQfpr7NYbryokaPS]] feet of it must make a [[/save
+          activity=UQfpr7NYbryokaPS]] saving throw, taking [[/damage average
+          activity=UQfpr7NYbryokaPS]] damage on a failed save, or half as much
+          damage on a successful one.</p>
         chat: >-
-          <p>When the mephit dies, it explodes in a burst of lava. Each creature
-          within 5 ft. of it must make a <strong>Dexterity</strong> saving
+          <p>When the [[lookup @name]]{monster} dies, it explodes in a burst of
+          lava. Each creature within [[lookup @target.template.size
+          activity=UQfpr7NYbryokaPS]] feet of it must make a Dexterity saving
           throw.</p>
       source:
         custom: ''
@@ -561,18 +562,18 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        UQfpr7NYbryokaPS:
           type: save
           activation:
-            type: ''
+            type: special
             value: null
-            condition: death
+            condition: When the [[lookup @name lowercse]]{monster}
             override: false
           consumption:
             targets: []
@@ -582,10 +583,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -602,6 +604,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: true
             affects:
               count: ''
               type: creature
@@ -624,15 +627,29 @@ items:
                 bonus: ''
                 types:
                   - fire
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '11'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Explode
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: UQfpr7NYbryokaPS
       enchant: {}
       prerequisites:
         level: null
@@ -642,31 +659,27 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.net3yBKQoxl8bZ4r
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955322141
+      systemVersion: 6.0.0
+      createdTime: 1781818033799
+      modifiedTime: 1781819601000
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!oJCOB9X2BPsBkWW5.LpYrQPxHA10HPnkl'
   - _id: FEdBqpqpIEyjdO2H
     name: False Appearance
     type: feat
-    img: icons/magic/nature/stealth-hide-eyes-green.webp
+    img: icons/magic/earth/explosion-lava-orange.webp
     system:
       description:
         value: >-
-          <p>While the mephit remains motionless, it is indistinguishable from
-          an ordinary mound of magma.</p>
+          <p>While the [[lookup @name lowercase]]{monster} remains motionless,
+          it is indistinguishable from an ordinary mound of magma.</p>
         chat: ''
       source:
         custom: ''
@@ -680,10 +693,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -698,22 +712,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.kyVgQNSa12loxVvr
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781818114571
+      modifiedTime: 1781818126172
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!oJCOB9X2BPsBkWW5.FEdBqpqpIEyjdO2H'
   - _id: BiAfcjq7C9Wf8R9b
     name: Claws
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-glowing-orange.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Magma Mephit attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -776,7 +792,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -785,8 +801,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        TpGzVJkWKWo53CtO:
           type: attack
           activation:
             type: action
@@ -801,6 +816,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -821,7 +837,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: '1'
               type: creature
@@ -834,14 +851,14 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
@@ -851,14 +868,25 @@ items:
                   enabled: false
                   formula: ''
                 number: 1
-                denomination: '4'
+                denomination: 4
                 bonus: ''
                 types:
                   - fire
-          sort: 0
+                scaling:
+                  number: 1
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: TpGzVJkWKWo53CtO
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -869,36 +897,35 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745175546348
+      systemVersion: 6.0.0
+      createdTime: 1781818136873
+      modifiedTime: 1781818540785
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!oJCOB9X2BPsBkWW5.BiAfcjq7C9Wf8R9b'
   - _id: iXhbFt7gCj3FBM2r
     name: Fire Breath
     type: feat
-    img: icons/creatures/abilities/dragon-fire-breath-orange.webp
+    img: icons/magic/fire/flame-burning-earth-orange.webp
     system:
       description:
         value: >-
-          <p>The mephit exhales a 15-foot cone of fire. Each creature in that
-          area must make a [[/save]] saving throw, taking [[/damage average]]
+          <p>The [[lookup @name lowercase]]{monster} exhales a [[lookup
+          @labels.description.template activity=9MCs28rlCi6lgvch]] of fire. Each
+          creature in that area must make a [[/save activity=9MCs28rlCi6lgvch]]
+          saving throw, taking [[/damage average activity=9MCs28rlCi6lgvch]]
           damage on a failed save, or half as much damage on a successful
           one.</p>
         chat: >-
-          <p>The mephit exhales a 15-foot cone of fire. Each creature in that
-          area must make a <strong>Dexterity</strong> saving throw.</p>
+          <p>The [[lookup @name]]{monster} exhales a [[lookup
+          @labels.description.template activity=9MCs28rlCi6lgvch]] of fire. Each
+          creature in that area must make a Dexterity saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -914,13 +941,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        9MCs28rlCi6lgvch:
           type: save
           activation:
             type: action
@@ -930,26 +956,25 @@ items:
           consumption:
             targets:
               - type: itemUses
-                target: ''
                 value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
+                target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -961,9 +986,10 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -975,24 +1001,37 @@ items:
           damage:
             onSave: half
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '11'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 9MCs28rlCi6lgvch
+          name: Exhale Fire
       enchant: {}
       prerequisites:
         level: null
@@ -1006,11 +1045,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.bGSW8IuWURWiWtxr
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955340194
+      systemVersion: 6.0.0
+      createdTime: 1781818551200
+      modifiedTime: 1781819568877
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!oJCOB9X2BPsBkWW5.iXhbFt7gCj3FBM2r'
@@ -1153,7 +1192,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.2yHXEcrRbadZDr5M
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1169,7 +1208,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171257349

--- a/packs/_source/monsters/elemental/magma-mephit.yml
+++ b/packs/_source/monsters/elemental/magma-mephit.yml
@@ -573,7 +573,7 @@ items:
           activation:
             type: special
             value: null
-            condition: When the [[lookup @name lowercse]]{monster}
+            condition: When the [[lookup @name lowercse]]{monster} dies.
             override: false
           consumption:
             targets: []

--- a/packs/_source/monsters/elemental/magmin.yml
+++ b/packs/_source/monsters/elemental/magmin.yml
@@ -447,9 +447,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -464,7 +461,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -484,24 +481,27 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: 0xdLfPJEHYwh8MIT
     name: Death Burst
     type: feat
-    img: icons/magic/light/explosion-star-glow-yellow.webp
+    img: icons/magic/fire/barrier-shield-explosion-yellow.webp
     system:
       description:
         value: >-
-          <p>When the magmin dies, it explodes in a burst of fire and magma.
-          Each creature within 10 ft. of it must make a [[/save]] saving throw,
-          taking [[/damage average]] damage on a failed save, or half as much
-          damage on a successful one. Flammable objects that aren't being worn
-          or carried in that area are ignited.</p>
+          <p>When the [[lookup @name]]{monster} dies, it explodes in a burst of
+          fire and magma. Each creature within [[lookup @target.template.size
+          activity=A8WwxhIVtPyXk0DI]] feet of it must make a [[/save]] saving
+          throw, taking [[/damage average]] damage on a failed save, or half as
+          much damage on a successful one. Flammable objects that aren't being
+          worn or carried in that area are ignited.</p>
         chat: >-
-          <p>When the magmin dies, it explodes in a burst of fire and magma.
-          Each creature within 10 ft. of it must make a
-          <strong>Dexterity</strong> saving throw. Flammable objects that aren't
-          being worn or carried in that area are ignited.</p>
+          <p>When the [[lookup @name]]{monster} dies, it explodes in a burst of
+          fire and magma. Each creature within [[lookup @target.template.size
+          activity=A8WwxhIVtPyXk0DI]] feet of it must make a Dexterity saving
+          throw. Flammable objects that aren't being worn or carried in that
+          area are ignited.</p>
       source:
         custom: ''
         book: ''
@@ -514,18 +514,18 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        A8WwxhIVtPyXk0DI:
           type: save
           activation:
-            type: ''
+            type: special
             value: null
-            condition: death
+            condition: When the [[lookup @name lowercase]]{monster} dies.
             override: false
           consumption:
             targets: []
@@ -535,10 +535,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -555,6 +556,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -577,15 +579,29 @@ items:
                 bonus: ''
                 types:
                   - fire
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '11'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Explode
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: A8WwxhIVtPyXk0DI
       enchant: {}
       prerequisites:
         level: null
@@ -595,32 +611,29 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.net3yBKQoxl8bZ4r
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955366121
+      systemVersion: 6.0.0
+      createdTime: 1781814931647
+      modifiedTime: 1781819536702
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!8MD1vRBTcgSXXk3u.0xdLfPJEHYwh8MIT'
   - _id: rlA41r2MlaqmVjvf
     name: Ignited Illumination
     type: feat
-    img: icons/magic/fire/explosion-mushroom-nuke-orange.webp
+    img: icons/magic/fire/flame-burning-campfire-orange.webp
     system:
       description:
         value: >-
-          <p>As a bonus action, the magmin can set itself ablaze or extinguish
-          its flames. While ablaze, the magmin sheds bright light in a 10-foot
-          radius and dim light for an additional 10 ft.</p>
+          <p>As a bonus action, the [[lookup @name lowercase]]{monster} can set
+          itself ablaze or extinguish its flames. While ablaze, the magmin sheds
+          &amp;reference[bright light] in a 10-foot radius and
+          &amp;reference[dim light] for an additional 10 ft.</p>
         chat: ''
       source:
         custom: ''
@@ -639,92 +652,228 @@ items:
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        y0nBhuvbLEpW7yZg:
+          type: enchant
+          name: Ignite Self
+          _id: y0nBhuvbLEpW7yZg
+          img: ''
+          sort: 100000
           activation:
             type: bonus
-            value: 1
-            condition: ''
             override: false
+            condition: ''
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
-          effects: []
+          effects:
+            - _id: JmovxBTPt2lOxVUC
+              level:
+                min: null
+                max: null
+              riders:
+                activity: []
+                effect:
+                  - Mu9xm262V8kL7QPt
+                item: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
+              type: self
               special: ''
-            prompt: true
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          enchant:
+            self: true
+          restrictions:
+            allowMagical: true
+            categories: []
+            properties: []
+            type: ''
       enchant: {}
       prerequisites:
         level: null
       identifier: ignited-illumination
-    effects: []
+    effects:
+      - type: enchantment
+        name: Ablaze
+        img: icons/magic/fire/flame-burning-campfire-orange.webp
+        disabled: true
+        _id: JmovxBTPt2lOxVUC
+        system:
+          changes:
+            - key: system.activities.y0nBhuvbLEpW7yZg.name
+              type: override
+              value: Extinguish Self
+              phase: initial
+              priority: null
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: <p>You have ignited yourself.</p>
+        origin: null
+        tint: '#ffffff'
+        transfer: true
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781815383396
+          modifiedTime: 1781815640073
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!8MD1vRBTcgSXXk3u.rlA41r2MlaqmVjvf.JmovxBTPt2lOxVUC
+      - name: Ignited Illumination
+        img: icons/magic/fire/flame-burning-campfire-orange.webp
+        origin: Compendium.dnd5e.monsters.Actor.8MD1vRBTcgSXXk3u.Item.rlA41r2MlaqmVjvf
+        type: base
+        _id: Mu9xm262V8kL7QPt
+        system:
+          changes:
+            - key: token.light.dim
+              type: add
+              value: 20
+              phase: initial
+              priority: null
+            - key: token.light.bright
+              type: add
+              value: 10
+              phase: initial
+              priority: null
+            - key: token.light.color
+              type: override
+              value: '#601806'
+              phase: initial
+              priority: null
+            - key: token.light.animation.type
+              type: override
+              value: flame
+              phase: initial
+              priority: null
+            - key: token.light.animation.speed
+              type: override
+              value: 1
+              phase: initial
+              priority: null
+            - key: token.light.animation.intensity
+              type: override
+              value: 2
+              phase: initial
+              priority: null
+            - key: token.light.attenuation
+              type: override
+              value: 0.6
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You have ignited yourself ablaze. While ablaze, you shed
+          &amp;reference[bright light] in a 10-foot radius and
+          &amp;reference[dim light] for an additional 10 feet.</p>
+        tint: '#ffffff'
+        transfer: true
+        statuses: []
+        showIcon: 0
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781815432406
+          modifiedTime: 1781816372808
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!8MD1vRBTcgSXXk3u.rlA41r2MlaqmVjvf.Mu9xm262V8kL7QPt
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders:
+          effect:
+            - Mu9xm262V8kL7QPt
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.Uvy7vla2EhYSfTl0
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955381261
+      systemVersion: 6.0.0
+      createdTime: 1781815342797
+      modifiedTime: 1781815630047
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!8MD1vRBTcgSXXk3u.rlA41r2MlaqmVjvf'
   - _id: th3hfRWQ3PT9f3Gs
     name: Touch
     type: weapon
-    img: icons/magic/fire/flame-burning-fist-strike.webp
+    img: icons/magic/fire/flame-burning-earth-yellow.webp
     system:
       description:
-        value: "<p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is a creature or a flammable object, it ignites. Until\_a creature\_takes an action to\_douse the fire,\_the\_target takes [[/damage average activity=Tv2pWtjFLchLGbMd]] damage at\_the\_end of each of its \_turns.</p>"
+        value: "<p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is a creature or a flammable object, it ignites. Until\_a creature\_takes an action to\_douse the fire,\_the\_target takes [[/damage average activity=OuZcepCj3KXR6GNq]] damage at\_the\_end of each of its \_turns.</p>"
         chat: >-
-          <p>The Magmin attacks with its Touch. If the target is a creature or a
-          flammable object, it ignites. Until a target takes an action to douse
-          the fire, the target takes <strong>3 (1d6) <em>fire
-          damage</em></strong> at the end of each of its turns.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. If the target is a creature or a flammable object, it
+          ignites. Until a target takes an action to douse the fire, the target
+          takes fire <em>damage</em> at the end of each of its turns.</p>
       source:
         custom: ''
         book: ''
@@ -796,8 +945,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        YskO6RC8JaTt3EqY:
           type: attack
           activation:
             type: action
@@ -812,13 +960,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
             units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: 7lyAOWMBqtXvPMQ3
+              level: {}
           range:
             value: '5'
             units: ft
@@ -832,7 +983,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -851,26 +1003,35 @@ items:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
-        Tv2pWtjFLchLGbMd:
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: YskO6RC8JaTt3EqY
+        OuZcepCj3KXR6GNq:
           type: damage
-          _id: Tv2pWtjFLchLGbMd
-          sort: 0
+          sort: 300000
           activation:
-            type: action
-            value: null
+            type: special
             override: false
-            condition: ''
+            condition: >-
+              When a creature the [[lookup @name lowercase]]{monster} has set on
+              fire starts their turn.
           consumption:
             scaling:
               allowed: false
@@ -878,21 +1039,27 @@ items:
             targets: []
           description:
             chatFlavor: ''
+            value: "<p>Until\_a creature\_takes an action to\_douse the fire,\_the\_target takes [[/damage average activity=OuZcepCj3KXR6GNq]] damage at\_the\_end of each of its \_turns.</p>"
           duration:
             units: inst
             concentration: false
             override: false
           effects: []
           range:
-            override: false
+            units: spec
+            override: true
+            special: ''
           target:
             template:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
-              type: ''
+              type: creature
+              count: '1'
+              special: ''
             override: false
             prompt: true
           uses:
@@ -907,35 +1074,84 @@ items:
                   enabled: false
                   formula: ''
                 number: 1
-                denomination: '6'
+                denomination: 6
                 bonus: ''
                 types:
                   - fire
-          name: ''
+                scaling:
+                  number: 1
+          name: Start of Turn Burning Damage
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: OuZcepCj3KXR6GNq
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: touch
-    effects: []
+      mastery: ''
+    effects:
+      - name: On Fire
+        img: icons/magic/fire/flame-burning-skull-orange.webp
+        origin: Compendium.dnd5e.monsters.Actor.8MD1vRBTcgSXXk3u.Item.th3hfRWQ3PT9f3Gs
+        transfer: false
+        _id: 7lyAOWMBqtXvPMQ3
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are on fire. Until someone takes an action to douse the fire,
+          you take [[/damage average 1d6 fire]] damage at the start of each of
+          your turns.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781815039200
+          modifiedTime: 1781815049123
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: >-
+            Compendium.dnd5e.monsters.Actor.8SMQl75HLjhuSeau.Item.yud1cnEVQ9KxbmWc.ActiveEffect.JaPKJu7WX0QierHn
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!8MD1vRBTcgSXXk3u.th3hfRWQ3PT9f3Gs.7lyAOWMBqtXvPMQ3
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107994238
+      systemVersion: 6.0.0
+      createdTime: 1781815004166
+      modifiedTime: 1781815328293
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!8MD1vRBTcgSXXk3u.th3hfRWQ3PT9f3Gs'
@@ -947,7 +1163,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171207472

--- a/packs/_source/monsters/elemental/salamander.yml
+++ b/packs/_source/monsters/elemental/salamander.yml
@@ -451,9 +451,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -468,7 +465,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -488,19 +485,21 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: 2n8ByeQNl7QkjNVA
     name: Heated Body
     type: feat
-    img: icons/creatures/abilities/mouth-teeth-fire-orange.webp
+    img: icons/tools/smithing/furnace-fire-metal-orange.webp
     system:
       description:
         value: >-
-          <p>A creature that touches the salamander or hits it with a melee
-          attack while within 5 ft. of it takes [[/damage average]] damage.</p>
+          <p>A creature that touches the [[lookup @name lowercase]]{monster} or
+          hits it with a melee attack while within 5 feet of it takes [[/damage
+          average]] damage.</p>
         chat: >-
-          <p>A creature that touches the salamander or hits it with a melee
-          attack while within 5 ft. of it takes <em>fire damage</em>.</p>
+          <p>A creature that touches the [[lookup @name]]{monster} or hits it
+          with a melee attack while within 5 feet of it takes fire damage.</p>
       source:
         custom: ''
         book: ''
@@ -513,18 +512,20 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        8xylZIW1hvRj5kB4:
           type: damage
           activation:
-            type: ''
+            type: special
             value: null
-            condition: ''
+            condition: >-
+              When a creature touches the [[lookup @name lowercase]]{monster} or
+              hits it with a melee attack while within 5 feet of it.
             override: false
           consumption:
             targets: []
@@ -534,17 +535,19 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: ft
             special: ''
             override: false
+            value: '5'
           target:
             template:
               count: ''
@@ -553,10 +556,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
-              count: ''
-              type: ''
+              count: '1'
+              type: creature
               choice: false
               special: ''
             prompt: true
@@ -570,90 +574,50 @@ items:
               allow: false
               bonus: ''
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 8xylZIW1hvRj5kB4
+          name: Contact Damage
       enchant: {}
       prerequisites:
         level: null
       identifier: heated-body
     effects: []
     folder: null
-    sort: 0
+    sort: 100000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.iFNpsEMJT66eLoat
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955396739
+      systemVersion: 6.0.0
+      createdTime: 1781816405232
+      modifiedTime: 1781819469274
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!yVNPVJIBpQ2Mp3Xa.2n8ByeQNl7QkjNVA'
-  - _id: 2y0o9wGzCVoBBuDZ
-    name: Heated Weapons
-    type: feat
-    img: icons/skills/melee/strike-weapons-orange.webp
-    system:
-      description:
-        value: >-
-          <p>Any metal melee weapon the salamander wields deals an extra 3 (1d6)
-          fire damage on a hit (included in the attack).</p>
-        chat: >-
-          <p>Any metal melee weapon the salamander wields deals an extra
-          <em>fire damage</em> on a hit (included in the attack).</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: heated-weapons
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.i3viKtKcSVeWLJFJ
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955407863
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!yVNPVJIBpQ2Mp3Xa.2y0o9wGzCVoBBuDZ'
   - _id: H9TCRB3zfkFwk192
     name: Multiattack
     type: feat
@@ -661,9 +625,9 @@ items:
     system:
       description:
         value: >-
-          <p>The salamander makes two attacks: one with its [[/item
-          .SKwOsrThcwqMXCZv]]{spear} and one with its [[/item
-          .rvRy41yt9zowrAr1]]{tail}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two attacks: one with
+          its [[/item .SKwOsrThcwqMXCZv]]{Spear} and one with its [[/item
+          .rvRy41yt9zowrAr1]]{Tail}.</p>
         chat: ''
       source:
         custom: ''
@@ -677,13 +641,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        9hTwmhjrler42wTH:
           type: utility
           activation:
             type: action
@@ -698,15 +661,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -717,7 +681,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -734,7 +699,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 9hTwmhjrler42wTH
       enchant: {}
       prerequisites:
         level: null
@@ -748,31 +721,35 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273657680
+      systemVersion: 6.0.0
+      createdTime: 1781816554705
+      modifiedTime: 1781816559274
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!yVNPVJIBpQ2Mp3Xa.H9TCRB3zfkFwk192'
   - _id: rvRy41yt9zowrAr1
     name: Tail
     type: weapon
-    img: icons/magic/lightning/bolt-strike-smoke-yellow.webp
+    img: icons/creatures/abilities/tail-strike-bone-orange.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]].</p><p>The target is
-          grappled (escape DC 14). Until this grapple ends, the target is
-          restrained, the salamander can automatically hit the target with its
-          tail, and the salamander can't make tail attacks against other
-          targets.</p>
+          &amp;reference[grappled] (escape DC 14). Until this grapple ends, the
+          target is &amp;reference[restrained], the [[lookup @name
+          lowercase]]{monster} can automatically hit the target with its
+          [[lookup @item.name lowercase]], and the [[lookup @name
+          lowercase]]{monster} can't make [[lookup @item.name lowercase]]
+          attacks against other targets.</p>
         chat: >-
-          <p>The Salamander attacks with its Tail. The target is grappled. Until
-          this grapple ends, the target is restrained, the salamander can
-          automatically hit the target with its tail, and the salamander can't
-          make tail attacks against other targets.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. The target is &amp;reference[grappled]. Until this
+          grapple ends, the target is restrained, the [[lookup @name]]{monster}
+          can automatically hit the target with its [[lookup @item.name]], and
+          the [[lookup @name]]{monster} can't make [[lookup @item.name]] attacks
+          against other targets.</p>
       source:
         custom: ''
         book: ''
@@ -834,19 +811,17 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties:
-        - rch
-      proficient: 1
+      properties: []
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: martialR
+        value: natural
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        IxUgO1yBhgDUQRa7:
           type: attack
           activation:
             type: action
@@ -861,13 +836,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
-          effects: []
+          effects:
+            - _id: hEwZP7oYnc1IS0fZ
+              level: {}
           range:
             value: '10'
             units: ft
@@ -881,7 +859,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -894,38 +873,90 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 2
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
                 denomination: 6
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: IxUgO1yBhgDUQRa7
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: salamander-tail
       mastery: ''
-    effects: []
+    effects:
+      - name: Grappled by Tail
+        img: icons/creatures/abilities/tail-strike-bone-orange.webp
+        origin: Compendium.dnd5e.monsters.Actor.yVNPVJIBpQ2Mp3Xa.Item.rvRy41yt9zowrAr1
+        transfer: false
+        _id: hEwZP7oYnc1IS0fZ
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are &amp;reference[grappled apply=false]. (escape DC 14). While
+          grappled in this way, you are also &amp;reference[restrained
+          apply=false].</p>
+        tint: '#ffffff'
+        statuses:
+          - grappled
+          - restrained
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781816667470
+          modifiedTime: 1781816714036
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!yVNPVJIBpQ2Mp3Xa.rvRy41yt9zowrAr1.hEwZP7oYnc1IS0fZ
     folder: null
     sort: 0
     ownership:
@@ -934,25 +965,27 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745108431042
+      systemVersion: 6.0.0
+      createdTime: 1781816566409
+      modifiedTime: 1781816667499
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!yVNPVJIBpQ2Mp3Xa.rvRy41yt9zowrAr1'
   - _id: SKwOsrThcwqMXCZv
     name: Spear
     type: weapon
-    img: icons/magic/fire/projectile-arrow-fire-red-yellow.webp
+    img: icons/magic/fire/projectile-arrow-fire-gem-yellow.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]] or [[/damage average
           attackMode=twoHanded]] if used with two hands to make a melee
           attack.</p>
-        chat: <p>The Salamander attacks with its Spear.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1017,7 +1050,7 @@ items:
       properties:
         - thr
         - ver
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -1026,8 +1059,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        8tb2lFotMNj9wBqm:
           type: attack
           activation:
             type: action
@@ -1042,6 +1074,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -1062,7 +1095,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1075,7 +1109,7 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
@@ -1092,14 +1126,25 @@ items:
                   enabled: false
                   formula: ''
                 number: 1
-                denomination: '6'
+                denomination: 6
                 bonus: ''
                 types:
                   - fire
-          sort: 0
+                scaling:
+                  number: 1
+          sort: 100000
           name: ''
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 8tb2lFotMNj9wBqm
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1110,22 +1155,78 @@ items:
     sort: 0
     ownership:
       default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.items.OG4nBBydvmfWYXIk
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781816728742
+      modifiedTime: 1781816749187
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!yVNPVJIBpQ2Mp3Xa.SKwOsrThcwqMXCZv'
+  - _id: Fq7lbhjMFR5fwEFS
+    name: Heated Weapons
+    type: feat
+    img: icons/tools/smithing/crucible-round.webp
+    system:
+      description:
+        value: >-
+          <p>When the [[lookup @name lowercase]]{monster} hits with a metal
+          melee weapon, it deals an extra 3 (1d6) fire damage (included in the
+          attack).</p>
+        chat: >-
+          <p>When the [[lookup @name]]{monster} hits with a metal melee weapon,
+          it deals extra fire damage (included in the attack).</p>
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: heated-weapons
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: null
+    sort: 200000
+    ownership:
+      default: 0
     flags:
       dnd5e:
         riders:
           activity: []
           effect: []
     _stats:
-      compendiumSource: Compendium.dnd5e.items.OG4nBBydvmfWYXIk
-      duplicateSource: null
-      coreVersion: '13.344'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.IiEDPMWqBlzkggYD.Item.WRygAnkpMeaqiw70
+      duplicateSource: Item.xL60eO1VH0SwtCJP
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745175926415
+      systemVersion: 6.0.0
+      createdTime: 1781816499301
+      modifiedTime: 1781819486016
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!yVNPVJIBpQ2Mp3Xa.SKwOsrThcwqMXCZv'
+    _key: '!actors.items!yVNPVJIBpQ2Mp3Xa.Fq7lbhjMFR5fwEFS'
 effects: []
 folder: IB448xVSBvtqitzs
 sort: 0
@@ -1134,7 +1235,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.4.0
   createdTime: 1726171266675

--- a/packs/_source/monsters/elemental/salamander.yml
+++ b/packs/_source/monsters/elemental/salamander.yml
@@ -931,7 +931,7 @@ items:
           expiry: null
           expired: false
         description: >-
-          <p>You are &amp;reference[grappled apply=false]. (escape DC 14). While
+          <p>You are &amp;reference[grappled apply=false] (escape DC 14). While
           grappled in this way, you are also &amp;reference[restrained
           apply=false].</p>
         tint: '#ffffff'

--- a/packs/_source/monsters/elemental/steam-mephit.yml
+++ b/packs/_source/monsters/elemental/steam-mephit.yml
@@ -449,9 +449,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -466,7 +463,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -486,15 +483,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: QrN7UxINx4UCaPIC
     name: Claws
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/commodities/claws/claw-lizard-white-black.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Steam Mephit attacks with its Claws.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -557,7 +557,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -566,8 +566,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bUdsexKuQoghEm36:
           type: attack
           activation:
             type: action
@@ -582,15 +581,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -601,7 +601,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -614,36 +615,47 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: dex
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts:
-              - number: 1
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 1
                 denomination: 4
                 bonus: ''
                 types:
                   - fire
-                custom:
-                  enabled: false
-                  formula: ''
                 scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          sort: 0
+                  number: 1
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bUdsexKuQoghEm36
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claws
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -653,28 +665,32 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107551952
+      systemVersion: 6.0.0
+      createdTime: 1781818805501
+      modifiedTime: 1781818819859
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!UthHOT7QfZfEIUue.QrN7UxINx4UCaPIC'
   - _id: QWi0q0cSzHEp8VqB
     name: Death Burst
     type: feat
-    img: icons/magic/light/explosion-star-glow-yellow.webp
+    img: icons/magic/air/wind-vortex-swirl-blue-purple.webp
     system:
       description:
         value: >-
-          <p>When the mephit dies, it explodes in a cloud of steam. Each
-          creature within 5 ft. of the mephit must succeed on a [[/save]] saving
-          throw or take [[/damage average]] damage.</p>
+          <p>When the [[lookup @name lowercase]]{monster} dies, it explodes in a
+          cloud of steam. Each creature within [[lookup @target.template.size
+          activity=g2aCIKzYHFlz8nUz]] feet of the [[lookup @name
+          lowercase]]{monster} must succeed on a [[/save
+          activity=g2aCIKzYHFlz8nUz]] saving throw or take [[/damage average
+          activity=g2aCIKzYHFlz8nUz]] damage.</p>
         chat: >-
-          <p>When the mephit dies, it explodes in a cloud of steam. Each
-          creature within 5 ft. of the mephit must make a
-          <strong>Dexterity</strong> saving throw.</p>
+          <p>When the [[lookup @name]]{monster} dies, it explodes in a cloud of
+          steam. Each creature within [[lookup @target.template.size
+          activity=g2aCIKzYHFlz8nUz]] feet of the [[lookup @name]]{monster} must
+          make a Dexterity saving throw.</p>
       source:
         custom: ''
         book: ''
@@ -687,18 +703,18 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity100:
-          _id: dnd5eactivity100
+        g2aCIKzYHFlz8nUz:
           type: save
           activation:
-            type: ''
+            type: special
             value: null
-            condition: on death
+            condition: When the [[lookup @name lowercase]]{monster} dies.
             override: false
           consumption:
             targets: []
@@ -708,10 +724,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -729,6 +746,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: true
             affects:
               count: ''
               type: creature
@@ -751,15 +769,29 @@ items:
                 bonus: ''
                 types:
                   - fire
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '10'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Explode
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: g2aCIKzYHFlz8nUz
       enchant: {}
       prerequisites:
         level: null
@@ -769,19 +801,15 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.net3yBKQoxl8bZ4r
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955474733
+      systemVersion: 6.0.0
+      createdTime: 1781818728736
+      modifiedTime: 1781819409627
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!UthHOT7QfZfEIUue.QWi0q0cSzHEp8VqB'
@@ -826,7 +854,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -841,13 +869,17 @@ items:
     system:
       description:
         value: >-
-          <p>The mephit exhales a 15-foot cone of scalding steam. Each creature
-          in that area must succeed on a [[/save]] saving throw, taking
-          [[/damage average]] damage on a failed save, or half as much damage on
-          a successful one.</p>
+          <p>The [[lookup @name lowercase]]{monster} exhales a [[lookup
+          @labels.description.template activity=oytDXenaNlnZuF5f]] of scalding
+          steam. Each creature in that area must succeed on a [[/save
+          activity=oytDXenaNlnZuF5f]] saving throw, taking [[/damage average
+          activity=oytDXenaNlnZuF5f]] damage on a failed save, or half as much
+          damage on a successful one.</p>
         chat: >-
-          <p>The mephit exhales a 15-foot cone of scalding steam. Each creature
-          in that area must succeed on a Dexterity saving throw.</p>
+          <p>The [[lookup @name lowercase]]{mosnter} exhales a [[lookup
+          @labels.description.template activity=oytDXenaNlnZuF5f]] of scalding
+          steam. Each creature in that area must succeed on a Dexterity saving
+          throw.</p>
       source:
         custom: ''
         book: ''
@@ -863,13 +895,12 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        oytDXenaNlnZuF5f:
           type: save
           activation:
             type: action
@@ -881,12 +912,14 @@ items:
               - type: itemUses
                 value: '1'
                 target: ''
+                scaling: {}
             scaling:
               allowed: false
               max: ''
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
@@ -907,6 +940,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: creature
@@ -929,15 +963,29 @@ items:
                 bonus: ''
                 types:
                   - fire
+                scaling:
+                  number: 1
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '10'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 100000
+          name: Exhale Steam
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: oytDXenaNlnZuF5f
       enchant: {}
       prerequisites:
         level: null
@@ -947,19 +995,15 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.4UuuUKjATTixrZGP
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955542948
+      systemVersion: 6.0.0
+      createdTime: 1781818840562
+      modifiedTime: 1781819439436
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!UthHOT7QfZfEIUue.RnLjEUZ0gBxcH2T3'
@@ -1075,7 +1119,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.UDUnlfPsOAbq2RSE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1091,7 +1135,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171235205

--- a/packs/_source/monsters/elemental/water-elemental.yml
+++ b/packs/_source/monsters/elemental/water-elemental.yml
@@ -459,9 +459,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -476,7 +473,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -496,19 +493,21 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: sZcc3bwnRjaDV9BZ
     name: Freeze
     type: feat
-    img: icons/magic/water/ice-crystal-white.webp
+    img: icons/magic/water/snowflake-ice-purple.webp
     system:
       description:
         value: >-
-          <p>If the elemental takes cold damage, it partially freezes; its speed
-          is reduced by 20 ft. until the end of its next turn.</p>
+          <p>If the [[lookup @name lowercase]]{monster} takes cold damage, it
+          partially freezes; its speed is reduced by 20 feet until the end of
+          its next turn.</p>
         chat: >-
-          <p>If the elemental takes <strong><em>cold damage</em></strong>, it
-          partially freezes.</p>
+          <p>If the [[lookup @name]]{monster} takes cold damage, it partially
+          freezes.</p>
       source:
         custom: ''
         book: ''
@@ -521,16 +520,120 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
-      activities: {}
+      properties:
+        - trait
+      activities:
+        cwJgwjer1IAzApBn:
+          type: utility
+          name: Partially Freeze
+          _id: cwJgwjer1IAzApBn
+          img: ''
+          sort: 0
+          activation:
+            type: special
+            override: false
+            condition: When the [[lookup @name lowercase]]{monste} takes cold damage.
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: turn
+            concentration: false
+            override: false
+            value: '1'
+          effects:
+            - _id: MLHae1WTyr78IIqI
+              level: {}
+          flags: {}
+          range:
+            units: self
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: self
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          roll:
+            prompt: false
+            visible: false
+            name: ''
+            formula: ''
       enchant: {}
       prerequisites:
         level: null
       identifier: freeze
-    effects: []
+    effects:
+      - name: Partially Frozen
+        img: icons/magic/water/snowflake-ice-purple.webp
+        origin: Compendium.dnd5e.monsters.Actor.namJz755U1EhvEJa.Item.sZcc3bwnRjaDV9BZ
+        transfer: false
+        _id: MLHae1WTyr78IIqI
+        type: base
+        system:
+          changes:
+            - key: system.attributes.movement.bonus
+              type: add
+              value: -20
+              phase: initial
+              priority: null
+        disabled: false
+        start: null
+        duration:
+          value: 1
+          units: turns
+          expiry: turnEnd
+          expired: false
+        description: >-
+          <p>You have been partially frozen. Your speed is reduced by 20 feet
+          until the end of your next turn.</p>
+        tint: '#ffffff'
+        statuses: []
+        showIcon: 1
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781817087181
+          modifiedTime: 1781817152577
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!namJz755U1EhvEJa.sZcc3bwnRjaDV9BZ.MLHae1WTyr78IIqI
     folder: null
     sort: 0
     ownership:
@@ -539,24 +642,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.m0FA3UM62hlTPVSA
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955556400
+      systemVersion: 6.0.0
+      createdTime: 1781817025994
+      modifiedTime: 1781819371067
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!namJz755U1EhvEJa.sZcc3bwnRjaDV9BZ'
   - _id: 6AQXZ1FlO8qhnPTR
     name: Water Form
     type: feat
-    img: icons/magic/water/orb-water-bubbles.webp
+    img: icons/magic/water/water-elemental-blue-teeth.webp
     system:
       description:
         value: >-
-          <p>The elemental can enter a hostile creature's space and stop there.
-          It can move through a space as narrow as 1 inch wide without
-          squeezing.</p>
+          <p>The [[lookup @name lowercase]]{monster} can enter a hostile
+          creature's space and stop there. It can move through a space as narrow
+          as 1 inch wide without &amp;reference[squeezing]{Squeezing}.</p>
         chat: ''
       source:
         custom: ''
@@ -570,16 +673,58 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
         level: null
       identifier: water-form
-    effects: []
+    effects:
+      - name: Water Form
+        img: icons/magic/water/water-elemental-blue-teeth.webp
+        origin: Compendium.dnd5e.monsters.Actor.namJz755U1EhvEJa.Item.6AQXZ1FlO8qhnPTR
+        type: base
+        _id: 5X6BAIpB87THEIZe
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You can enter a hostile creature's space and stop there. You can
+          move through a space as narrow as 1 inch wide without
+          &amp;reference[squeezing]{Squeezing}.</p>
+        tint: '#ffffff'
+        transfer: true
+        statuses:
+          - ethereal
+        showIcon: 0
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781817000657
+          modifiedTime: 1781817017883
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!namJz755U1EhvEJa.6AQXZ1FlO8qhnPTR.5X6BAIpB87THEIZe
     folder: null
     sort: 0
     ownership:
@@ -588,12 +733,12 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.AFYR2eZavzQUbZNb
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781816978092
+      modifiedTime: 1781816997836
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!namJz755U1EhvEJa.6AQXZ1FlO8qhnPTR'
   - _id: 9saHudPLoj6va2em
@@ -689,7 +834,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -700,11 +845,13 @@ items:
   - _id: 7xDGPsWicxgP6feT
     name: Slam
     type: weapon
-    img: icons/magic/water/wave-water-blue.webp
+    img: icons/magic/water/tendrils-ice-thorns.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Water Elemental attacks with its Slam.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -767,7 +914,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -776,8 +923,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        FZDeCzSni5i3A4Iw:
           type: attack
           activation:
             type: action
@@ -792,10 +938,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -812,7 +959,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -825,24 +973,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: FZDeCzSni5i3A4Iw
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: slam
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -852,11 +1013,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107553358
+      systemVersion: 6.0.0
+      createdTime: 1781817181973
+      modifiedTime: 1781817198702
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!namJz755U1EhvEJa.7xDGPsWicxgP6feT'
@@ -867,25 +1028,31 @@ items:
     system:
       description:
         value: >-
-          <p>Each creature in the elemental's space must make a [[/save]] saving
-          throw. On a failure, a target takes [[/damage average]] damage. If it
-          is Large or smaller, it is also &amp;Reference[grappled] (escape DC
-          14). Until this grapple ends, the target is &amp;Reference[restrained]
-          and unable to breathe unless it can breathe water.</p><p>If the saving
-          throw is successful, the target is pushed out of the elemental's
-          space.The elemental can grapple one Large creature or up to two Medium
-          or smaller creatures at one time. At the start of each of the
-          elemental's turns, each target grappled by it takes [[/damage
-          average]] damage. A creature within 5 feet of the elemental can pull a
-          creature or object out of it by taking an action to make a [[/check]]
-          check and succeeding.</p>
+          <p>Each creature in the [[lookup @name lowercase]]{monster}'s space
+          must make a [[/save activity=wNdhnTTQQLAgCSv9]] saving throw. On a
+          failure, a target takes [[/damage average activity=wNdhnTTQQLAgCSv9]]
+          damage. If it is Large or smaller, it is also &amp;Reference[grappled]
+          (escape DC 14). Until this grapple ends, the target is
+          &amp;Reference[restrained] and unable to
+          &amp;reference[suffocating]{Breathe} unless it can breathe
+          water.</p><p>If the saving throw is successful, the target is pushed
+          out of the [[lookup @name lowercase]]{monster}'s space.The [[lookup
+          @name lowercase]]{monster} can grapple one Large creature or up to two
+          Medium or smaller creatures at one time. At the start of each of the
+          [[lookup @name lowercase]]{monster}'s turns, each target grappled by
+          it takes [[/damage average activity=3Ed1FjdlOVvPPqS8]] damage. A
+          creature within 5 feet of the [[lookup @name lowercase]]{monster} can
+          pull a creature or object out of it by taking an action to make a
+          [[/check activity=QoSOLmJfjlxffpld]] check and succeeding.</p>
         chat: >-
-          <p>Each creature in the elemental's space must make a
-          <strong>Strength</strong> saving throw. If it is Large or smaller, it
-          is also grappled. Until this grapple ends, the target is restrained
-          and unable to breathe unless it can breathe water. A creature within 5
-          feet of the elemental can pull a creature or object out of it by
-          taking an action to make a Strength check and succeeding.</p>
+          <p>Each creature in the [[lookup @name]]{monster}'s space must make a
+          Strength saving throw. If it is Large or smaller, it is also
+          &amp;reference[grappled]. Until this grapple ends, the target is
+          &amp;reference[restrained] and unable to
+          &amp;reference[suffocating]{Breathe} unless it can breathe water. A
+          creature within 5 feet of the [[lookup @name]]{monster} can pull a
+          creature or object out of it by taking an action to make a Strength
+          check and succeeding.</p>
       source:
         custom: ''
         book: ''
@@ -901,90 +1068,16 @@ items:
             type: recoverAll
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets:
-              - type: itemUses
-                target: ''
-                value: '1'
-                scaling:
-                  mode: ''
-                  formula: ''
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            units: ''
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - number: 2
-                denomination: 8
-                bonus: '@mod'
-                types:
-                  - bludgeoning
-                custom:
-                  enabled: false
-                  formula: ''
-                scaling:
-                  mode: whole
-                  number: null
-                  formula: ''
-          save:
-            ability: str
-            dc:
-              calculation: ''
-              formula: '14'
-          sort: 0
         QoSOLmJfjlxffpld:
           type: check
-          name: Pull Out
+          name: Pull Creature Out
           _id: QoSOLmJfjlxffpld
-          sort: 0
+          sort: 200000
           activation:
             type: ''
             override: false
@@ -1025,30 +1118,230 @@ items:
               calculation: ''
               formula: '14'
             ability: str
+            bonus: ''
           img: ''
           appliedEffects: []
+          visibility:
+            level:
+              min: null
+              max: null
+            identifier: ''
+        wNdhnTTQQLAgCSv9:
+          type: save
+          name: Whelm Creatures
+          _id: wNdhnTTQQLAgCSv9
+          img: ''
+          sort: 100000
+          activation:
+            type: action
+            override: false
+            condition: ''
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets:
+              - type: itemUses
+                value: '1'
+                scaling: {}
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects:
+            - _id: 2Z4OvQKGES6rtmRz
+              level: {}
+              onSave: false
+          flags: {}
+          range:
+            units: ft
+            override: false
+            special: ''
+            value: '0'
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: creature
+              count: ''
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          damage:
+            onSave: none
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
+                denomination: 8
+                bonus: '4'
+                types:
+                  - bludgeoning
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - str
+            dc:
+              calculation: ''
+              formula: '14'
+            visible: true
+            bonus: ''
+        3Ed1FjdlOVvPPqS8:
+          type: damage
+          name: Start of Turn Grapple Damage
+          _id: 3Ed1FjdlOVvPPqS8
+          img: ''
+          sort: 150000
+          activation:
+            type: special
+            override: false
+            condition: >-
+              When the [[lookup @name lowercase]]{mosnter} starts its turn while
+              it has creatures &reference[grappled apply=false] with this
+              ability.
+          consumption:
+            scaling:
+              allowed: false
+            spellSlot: true
+            targets: []
+          description:
+            value: ''
+            chatFlavor: ''
+          duration:
+            units: inst
+            concentration: false
+            override: false
+          effects: []
+          flags: {}
+          range:
+            units: spec
+            override: false
+            special: ''
+          target:
+            template:
+              contiguous: false
+              stationary: false
+              units: ft
+              type: ''
+            affects:
+              choice: false
+              type: creature
+              count: ''
+              special: ''
+            override: false
+            prompt: true
+          uses:
+            spent: 0
+            recovery: []
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          damage:
+            critical:
+              allow: false
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 2
+                denomination: 8
+                bonus: '4'
+                types:
+                  - bludgeoning
+                scaling:
+                  number: 1
       enchant: {}
       prerequisites:
         level: null
       identifier: whelm
-    effects: []
+    effects:
+      - name: Whelmed
+        img: icons/magic/water/vortex-water-whirlpool.webp
+        origin: Compendium.dnd5e.monsters.Actor.namJz755U1EhvEJa.Item.5XUFTldfE6mtRUfd
+        transfer: false
+        _id: 2Z4OvQKGES6rtmRz
+        type: base
+        system:
+          changes: []
+        disabled: false
+        start: null
+        duration:
+          value: null
+          units: seconds
+          expiry: null
+          expired: false
+        description: >-
+          <p>You are &amp;reference[grappled apply=false] (escape DC 14). While
+          grappled in this way, you are &amp;reference[restrained apply=false]
+          and unable to &amp;reference[suffocating]{Breathe} unless you can
+          beathe water.</p><p>At the start of each of the water elemental's
+          turns, you take [[/damage avearge 2d8 + 4 bludgoening]] damage. A
+          creature within 5 feet of the water elemental can pull you out of it
+          by taking an action to make a [[/check 14 str]] check and
+          succeeding.</p>
+        tint: '#ffffff'
+        statuses:
+          - grappled
+          - restrained
+        showIcon: 2
+        folder: null
+        sort: 0
+        flags:
+          dnd5e:
+            riders:
+              statuses: []
+        _stats:
+          coreVersion: '14.361'
+          systemId: dnd5e
+          systemVersion: 6.0.0
+          createdTime: 1781817336908
+          modifiedTime: 1781817465079
+          lastModifiedBy: dnd5ebuilder0000
+          compendiumSource: null
+          duplicateSource: null
+          exportSource: null
+        _key: >-
+          !actors.items.effects!namJz755U1EhvEJa.5XUFTldfE6mtRUfd.2Z4OvQKGES6rtmRz
     folder: null
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.sMgKJtbCLNSX7V80
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955631268
+      systemVersion: 6.0.0
+      createdTime: 1781817232709
+      modifiedTime: 1781819360082
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!namJz755U1EhvEJa.5XUFTldfE6mtRUfd'
@@ -1060,7 +1353,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171256853

--- a/packs/_source/monsters/elemental/xorn.yml
+++ b/packs/_source/monsters/elemental/xorn.yml
@@ -449,9 +449,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -466,7 +463,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -486,15 +483,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 1
 items:
   - _id: ODAa1IROPs40MUI2
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-fire-orange.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Xorn attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -557,7 +557,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -566,8 +566,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        ToWwlIKLPbwuDPzM:
           type: attack
           activation:
             type: action
@@ -582,10 +581,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -602,7 +602,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -615,24 +616,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: ToWwlIKLPbwuDPzM
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -642,22 +656,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747955653942
+      systemVersion: 6.0.0
+      createdTime: 1781816871453
+      modifiedTime: 1781816894969
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!2MZNHeOZweXAYbv1.ODAa1IROPs40MUI2'
   - _id: LRjB7lk0aa4TOd16
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-straight-brown.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Xorn attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -720,7 +736,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -729,8 +745,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        V8AJRmzcYEgQL1Ds:
           type: attack
           activation:
             type: action
@@ -745,10 +760,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -765,7 +781,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -778,24 +795,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: V8AJRmzcYEgQL1Ds
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -805,24 +835,24 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747955653942
+      systemVersion: 6.0.0
+      createdTime: 1781816906382
+      modifiedTime: 1781816918174
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!2MZNHeOZweXAYbv1.LRjB7lk0aa4TOd16'
   - _id: a5CLV8aL4SowIich
     name: Earth Glide
     type: feat
-    img: icons/environment/wilderness/cave-entrance-mountain-blue.webp
+    img: icons/environment/wilderness/terrain-rocks-brown.webp
     system:
       description:
         value: >-
-          <p>The xorn can burrow through nonmagical, unworked earth and stone.
-          While doing so, the xorn doesn't disturb the material it moves
-          through.</p>
+          <p>The [[lookup @name lowercase]]{monster} can burrow through
+          nonmagical, unworked earth and stone. While doing so, the xorn doesn't
+          disturb the material it moves through.</p>
         chat: ''
       source:
         custom: ''
@@ -836,10 +866,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -854,12 +885,12 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.yrpqazOHqI4BrYW4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781816766748
+      modifiedTime: 1781816777807
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!2MZNHeOZweXAYbv1.a5CLV8aL4SowIich'
   - _id: kRGZU8eMwOBt3kVd
@@ -869,8 +900,9 @@ items:
     system:
       description:
         value: >-
-          <p>The xorn makes three [[/item .LRjB7lk0aa4TOd16]]{claw} attacks and
-          one [[/item .ODAa1IROPs40MUI2]]{bite} attack.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three [[/item
+          .LRjB7lk0aa4TOd16]]{Claw} attacks and one [[/item
+          .ODAa1IROPs40MUI2]]{Bite} attack.</p>
         chat: ''
       source:
         custom: ''
@@ -884,13 +916,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        3bw36Uo33m00bLjL:
           type: utility
           activation:
             type: action
@@ -905,15 +936,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -924,7 +956,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -941,7 +974,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 3bw36Uo33m00bLjL
       enchant: {}
       prerequisites:
         level: null
@@ -955,23 +996,23 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1747955654714
+      systemVersion: 6.0.0
+      createdTime: 1781816942060
+      modifiedTime: 1781816946981
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!2MZNHeOZweXAYbv1.kRGZU8eMwOBt3kVd'
   - _id: ryNcNrIgtkYHRKWj
     name: Stone Camouflage
     type: feat
-    img: icons/environment/settlement/stone-stairs.webp
+    img: icons/commodities/stone/stone-cratered-brown.webp
     system:
       description:
         value: >-
-          <p>The xorn has advantage on Dexterity (Stealth) checks made to hide
-          in rocky terrain.</p>
+          <p>The [[lookup @name lowercase]]{monster} has advantage on Dexterity
+          (Stealth) checks made to &amp;reference[hide] in rocky terrain.</p>
         chat: ''
       source:
         custom: ''
@@ -985,10 +1026,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -1003,23 +1045,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.j1cPfWFNvxGoex9Z
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955644495
+      systemVersion: 6.0.0
+      createdTime: 1781816797979
+      modifiedTime: 1781816822867
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!2MZNHeOZweXAYbv1.ryNcNrIgtkYHRKWj'
   - _id: x6Hd2pSXy7TDwgjR
     name: Treasure Sense
     type: feat
-    img: icons/skills/social/theft-pickpocket-bribery-brown.webp
+    img: icons/commodities/currency/coins-plain-stack-gold.webp
     system:
       description:
         value: >-
-          <p>The xorn can pinpoint, by scent, the location of precious metals
-          and stones, such as coins and gems, within 60 ft. of it.</p>
+          <p>The [[lookup @name lowercase]]{monster} can pinpoint, by scent, the
+          location of precious metals and stones, such as coins and gems, within
+          60 feet of it.</p>
         chat: ''
       source:
         custom: ''
@@ -1033,10 +1076,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -1051,11 +1095,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.Enhb3XowXPMsVapw
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1747955650390
+      systemVersion: 6.0.0
+      createdTime: 1781816843960
+      modifiedTime: 1781816865661
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!2MZNHeOZweXAYbv1.x6Hd2pSXy7TDwgjR'
@@ -1067,7 +1111,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171199834


### PR DESCRIPTION
Updated the 5.1 SRD Elementals to current system standards. Included AEs, enrichers, and lookups where I could.

Does not currently touch spells or spellcasting traits, will handle that in future PR when spells are updated.

Related #6712 