### PR TITLE
5.1 SRD Update: Monsters - Giants

### DIFF
--- a/packs/_source/monsters/giant/cloud-giant.yml
+++ b/packs/_source/monsters/giant/cloud-giant.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,55 +480,8 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
-  - _id: 4xg2sYoD5Z4lRmkT
-    name: Keen Smell
-    type: feat
-    img: icons/creatures/mammals/wolf-howl-moon-forest-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The giant has advantage on Wisdom (Perception) checks that rely on
-          smell.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: keen-smell
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.345'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1749402404311
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!Aw2wmqGIatxe2ImI.4xg2sYoD5Z4lRmkT'
   - _id: WFfPQjdkfYdIIiZT
     name: Innate Spellcasting
     type: feat
@@ -583,7 +533,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -598,8 +548,8 @@ items:
     system:
       description:
         value: >-
-          <p>The giant makes two [[/item .Jr0CfxY8xuFT6hoa]]{morningstar}
-          attacks.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two [[/item
+          .Jr0CfxY8xuFT6hoa]]{Morningstar} attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -613,13 +563,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        95UsNhVD3twhqoZ5:
           type: utility
           activation:
             type: action
@@ -634,15 +583,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -653,7 +603,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -670,7 +621,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 95UsNhVD3twhqoZ5
       enchant: {}
       prerequisites:
         level: null
@@ -684,11 +643,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273655466
+      systemVersion: 6.0.0
+      createdTime: 1781805381920
+      modifiedTime: 1781805385753
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!Aw2wmqGIatxe2ImI.pH1i4SwsZRV3rq3v'
@@ -699,7 +658,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Cloud Giant attacks with its Morningstar.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -763,7 +724,7 @@ items:
         conditions: ''
       properties:
         - rch
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -772,8 +733,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        HQWZhf9d6XWrPvqH:
           type: attack
           activation:
             type: action
@@ -788,10 +748,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -808,7 +769,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -821,24 +783,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: HQWZhf9d6XWrPvqH
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: morningstar
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -848,22 +823,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.dX8AxCh9o0A9CkT3
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107550546
+      systemVersion: 6.0.0
+      createdTime: 1781805027846
+      modifiedTime: 1781805038926
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!Aw2wmqGIatxe2ImI.Jr0CfxY8xuFT6hoa'
   - _id: NXgSHbDNtVbxsItU
     name: Rock
     type: weapon
-    img: icons/magic/earth/projectile-stone-ball-brown.webp
+    img: icons/magic/earth/projectile-boulder-yellow.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Cloud Giant attacks with its Rock.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -926,9 +903,8 @@ items:
         dt: null
         conditions: ''
       properties:
-        - amm
         - thr
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -937,8 +913,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        zmkWHVvAQsGR0LOl:
           type: attack
           activation:
             type: action
@@ -953,10 +928,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -973,7 +949,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -993,17 +970,31 @@ items:
             flat: false
             type:
               value: ranged
-              classification: weapon
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: zmkWHVvAQsGR0LOl
+          name: ''
       attuned: false
-      ammunition: {}
+      ammunition:
+        type: ''
       magicalBonus: null
       identifier: rock
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -1013,11 +1004,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745173385099
+      systemVersion: 6.0.0
+      createdTime: 1781805044389
+      modifiedTime: 1781805216605
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!Aw2wmqGIatxe2ImI.NXgSHbDNtVbxsItU'
@@ -1130,7 +1121,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ghXTfe7sgCbgf1Q8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1247,7 +1238,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.IBJmWjzbQGu7M4UX
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1366,7 +1357,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.Bnn9Nzajixvow9xi
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1488,7 +1479,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.pub0OWVEB71XQx1n
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1612,7 +1603,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.yfbK8gZqESlaoY5t
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1729,7 +1720,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.wqfAVANuQonNBgnL
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1874,7 +1865,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.HQfd7jJyULIoGxrZ
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2052,7 +2043,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ZPd73HtKF3At11jh
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2185,7 +2176,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.2IWiZAJtOGDoKjiz
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2193,6 +2184,59 @@ items:
       lastModifiedBy: null
       exportSource: null
     _key: '!actors.items!Aw2wmqGIatxe2ImI.2IWiZAJtOGDoKjiz'
+  - _id: rbM3ahm1bp8koa8s
+    name: Keen Smell
+    type: feat
+    img: icons/creatures/mammals/wolf-howl-moon-forest-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on Wisdom
+          (Perception) checks that rely on smell.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: keen-smell
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: -100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.oQvORD924obyPdCc.Item.hwviWX3lRj9wqENj
+      duplicateSource: Item.gcfYCrt0yFVt4QF4
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781804999642
+      modifiedTime: 1781804999642
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!Aw2wmqGIatxe2ImI.rbM3ahm1bp8koa8s'
 effects: []
 folder: v8gFGdEluEFQdRQg
 sort: 0
@@ -2201,7 +2245,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171210419

--- a/packs/_source/monsters/giant/ettin.yml
+++ b/packs/_source/monsters/giant/ettin.yml
@@ -54,8 +54,8 @@ system:
     hp:
       value: 85
       max: 85
-      temp: 0
-      tempmax: 0
+      temp: null
+      tempmax: null
       formula: 10d10 + 30
     init:
       ability: ''
@@ -270,7 +270,7 @@ system:
       roll:
         min: null
         max: null
-        mode: 0
+        mode: 1
     prf:
       value: 0
       ability: cha
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,17 +480,21 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: hon1LZGigQRl2jBn
     name: Two Heads
     type: feat
-    img: icons/magic/death/skull-horned-goat-pentagram-red.webp
+    img: icons/creatures/magical/construct-face-stone-pink.webp
     system:
       description:
         value: >-
-          <p>The ettin has advantage on Wisdom (Perception) checks and on saving
-          throws against being blinded, charmed, deafened, frightened, stunned,
-          and knocked unconscious.</p>
+          <p>The [[lookup @name lowercase]]{monster} has advantage on Wisdom
+          (Perception) checks and on saving throws against being
+          &amp;reference[blinded apply=false], &amp;reference[charmed
+          apply=false], &amp;reference[deafened apply=false],
+          &amp;reference[frightened apply=false], &amp;reference[stunned
+          apply=false], and knocked &amp;reference[unconscious apply=false].</p>
         chat: ''
       source:
         custom: ''
@@ -507,10 +508,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -525,23 +527,23 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.gWpp0N06HvS937Go
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1749402426698
+      systemVersion: 6.0.0
+      createdTime: 1781805242210
+      modifiedTime: 1781805290043
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KLCkHep28HBfdsky.hon1LZGigQRl2jBn'
   - _id: 0NvLts9eWaCvcOOn
     name: Wakeful
     type: feat
-    img: icons/creatures/eyes/lizard-single-slit-blue.webp
+    img: icons/creatures/eyes/human-single-blue.webp
     system:
       description:
         value: >-
-          <p>When one of the ettin's heads is asleep, its other head is
-          awake.</p>
+          <p>When one of the [[lookup @name lowercase]]{monster}'s heads is
+          asleep, its other head is awake.</p>
         chat: ''
       source:
         custom: ''
@@ -555,10 +557,11 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
@@ -573,12 +576,12 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.T2gLBBjrHTbLTdGc
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      systemVersion: 6.0.0
+      createdTime: 1781805402074
+      modifiedTime: 1781805415096
+      lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KLCkHep28HBfdsky.0NvLts9eWaCvcOOn'
   - _id: FcbmWHMk3H4MGdxy
@@ -588,9 +591,9 @@ items:
     system:
       description:
         value: >-
-          <p>The ettin makes two attacks: one with its [[/item
-          .T1QQrbvnvnM73eIe]]{battleaxe} and one with its [[/item
-          .5ri5zr7IJKsaZNF7]]{morningstar}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two attacks: one with
+          its [[/item .T1QQrbvnvnM73eIe]]{Battleaxe} and one with its [[/item
+          .5ri5zr7IJKsaZNF7]]{Morningstar}.</p>
         chat: ''
       source:
         custom: ''
@@ -604,13 +607,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        LcrGZKFaGHzyMUUp:
           type: utility
           activation:
             type: action
@@ -625,15 +627,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -644,7 +647,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -661,7 +665,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: LcrGZKFaGHzyMUUp
       enchant: {}
       prerequisites:
         level: null
@@ -675,11 +687,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273655774
+      systemVersion: 6.0.0
+      createdTime: 1781805360268
+      modifiedTime: 1781805368095
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KLCkHep28HBfdsky.FcbmWHMk3H4MGdxy'
@@ -690,7 +702,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ettin attacks with its Battleaxe.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -754,7 +768,7 @@ items:
         conditions: ''
       properties:
         - ver
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -763,8 +777,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        lhhKYuLx7INexKvy:
           type: attack
           activation:
             type: action
@@ -779,10 +792,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -799,7 +813,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -812,24 +827,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: lhhKYuLx7INexKvy
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: battleaxe
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -839,11 +867,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.I0WocDSuNpGJayPb
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107551238
+      systemVersion: 6.0.0
+      createdTime: 1781805311810
+      modifiedTime: 1781805325572
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KLCkHep28HBfdsky.T1QQrbvnvnM73eIe'
@@ -854,7 +882,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ettin attacks with its Morningstar.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -917,7 +947,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -926,8 +956,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        1WIZlTWUCSRIx78G:
           type: attack
           activation:
             type: action
@@ -942,10 +971,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -962,7 +992,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -975,24 +1006,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 1WIZlTWUCSRIx78G
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: morningstar
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -1002,11 +1046,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.dX8AxCh9o0A9CkT3
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107551238
+      systemVersion: 6.0.0
+      createdTime: 1781805332587
+      modifiedTime: 1781805343278
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!KLCkHep28HBfdsky.5ri5zr7IJKsaZNF7'
@@ -1018,11 +1062,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1726171222553
-  modifiedTime: 1726171443186
+  modifiedTime: 1781805305341
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!actors!KLCkHep28HBfdsky'

--- a/packs/_source/monsters/giant/fire-giant.yml
+++ b/packs/_source/monsters/giant/fire-giant.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,6 +480,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
   - _id: P38O0pGKUKXuYgd0
     name: Plate Armor
@@ -554,7 +552,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.OjkIqlW2UpgFcjZa
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -569,8 +567,8 @@ items:
     system:
       description:
         value: >-
-          <p>The giant makes two [[/item .c8b8jy3sM3Z8gxm0]]{greatsword}
-          attacks.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two [[/item
+          .c8b8jy3sM3Z8gxm0]]{Greatsword} attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -584,13 +582,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        EVPB1DSqe2msles1:
           type: utility
           activation:
             type: action
@@ -605,15 +602,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -624,7 +622,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -641,7 +640,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: EVPB1DSqe2msles1
       enchant: {}
       prerequisites:
         level: null
@@ -655,22 +662,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273655054
+      systemVersion: 6.0.0
+      createdTime: 1781805497201
+      modifiedTime: 1781805502841
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!45Z5kogZEhawX1Ey.vgN2DlqQtt77mxKO'
   - _id: c8b8jy3sM3Z8gxm0
     name: Greatsword
     type: weapon
-    img: icons/weapons/swords/greatsword-guard-gem-blue.webp
+    img: icons/weapons/swords/sword-guard-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Fire Giant attacks with its Greatsword.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -736,7 +745,7 @@ items:
         - hvy
         - rch
         - two
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -745,8 +754,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        8i6ZXsc5CRmGDsTJ:
           type: attack
           activation:
             type: action
@@ -761,10 +769,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -781,7 +790,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -794,24 +804,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 8i6ZXsc5CRmGDsTJ
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: greatsword
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -821,22 +844,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.xMkP8BmFzElcsMaR
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107549926
+      systemVersion: 6.0.0
+      createdTime: 1781805463877
+      modifiedTime: 1781805479469
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!45Z5kogZEhawX1Ey.c8b8jy3sM3Z8gxm0'
   - _id: DgNvJ2F0HSMya3hp
     name: Rock
     type: weapon
-    img: icons/magic/earth/projectile-stone-ball-brown.webp
+    img: icons/magic/earth/projectile-boulder-yellow.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Fire Giant attacks with its Rock.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -899,19 +924,17 @@ items:
         dt: null
         conditions: ''
       properties:
-        - hvy
         - thr
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: simpleR
+        value: improv
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        uVvDTCy8C3KVOZv8:
           type: attack
           activation:
             type: action
@@ -926,10 +949,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -946,7 +970,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -966,17 +991,30 @@ items:
             flat: false
             type:
               value: ranged
-              classification: weapon
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: uVvDTCy8C3KVOZv8
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: rock
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -986,11 +1024,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745173384716
+      systemVersion: 6.0.0
+      createdTime: 1781805425692
+      modifiedTime: 1781805451858
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!45Z5kogZEhawX1Ey.DgNvJ2F0HSMya3hp'
@@ -1002,7 +1040,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171201463

--- a/packs/_source/monsters/giant/frost-giant.yml
+++ b/packs/_source/monsters/giant/frost-giant.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,15 +480,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
   - _id: gCi538awNcOfcZf7
     name: Rock
     type: weapon
-    img: icons/magic/earth/projectile-stone-ball-brown.webp
+    img: icons/magic/earth/projectile-boulder-yellow.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Frost Giant attacks with its Rock.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -554,19 +554,17 @@ items:
         dt: null
         conditions: ''
       properties:
-        - hvy
         - thr
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: simpleR
+        value: improv
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        0dD8Nj8Fq2tidVVA:
           type: attack
           activation:
             type: action
@@ -581,10 +579,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -601,7 +600,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -621,31 +621,44 @@ items:
             flat: false
             type:
               value: ranged
-              classification: weapon
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 0dD8Nj8Fq2tidVVA
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: rock
+      mastery: ''
     effects: []
     folder: null
-    sort: 100000
+    sort: 400000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1749402445168
+      systemVersion: 6.0.0
+      createdTime: 1781805510639
+      modifiedTime: 1781805560508
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!Buxe6dDK5Mw7kxe6.gCi538awNcOfcZf7'
@@ -717,7 +730,7 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -732,7 +745,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Frost Giant attacks with its Greataxe.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -797,7 +812,7 @@ items:
       properties:
         - hvy
         - two
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -806,8 +821,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        LIB2QTQLrUHRijgA:
           type: attack
           activation:
             type: action
@@ -822,10 +836,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -842,7 +857,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -855,24 +871,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: LIB2QTQLrUHRijgA
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: greataxe
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -882,11 +911,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.1Lxk6kmoRhG8qQ0u
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1749402445168
+      systemVersion: 6.0.0
+      createdTime: 1781805537468
+      modifiedTime: 1781805545432
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!Buxe6dDK5Mw7kxe6.LVOGKiIm4UTD4fpj'
@@ -897,8 +926,8 @@ items:
     system:
       description:
         value: >-
-          <p>The giant makes two [[/item .LVOGKiIm4UTD4fpj]]{greataxe}
-          attacks.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two [[/item
+          .LVOGKiIm4UTD4fpj]]{Greataxe} attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -912,13 +941,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        jIxf1UrAAXaPflMt:
           type: utility
           activation:
             type: action
@@ -933,15 +961,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -952,7 +981,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -969,7 +999,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: jIxf1UrAAXaPflMt
       enchant: {}
       prerequisites:
         level: null
@@ -983,11 +1021,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1749402446134
+      systemVersion: 6.0.0
+      createdTime: 1781805526345
+      modifiedTime: 1781805531303
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!Buxe6dDK5Mw7kxe6.i49lwJ84vB720EPW'
@@ -999,7 +1037,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171212380

--- a/packs/_source/monsters/giant/hill-giant.yml
+++ b/packs/_source/monsters/giant/hill-giant.yml
@@ -445,9 +445,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -462,7 +459,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -482,6 +479,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
   - _id: 1k58ryEYEYijhYOb
     name: Multiattack
@@ -490,8 +488,8 @@ items:
     system:
       description:
         value: >-
-          <p>The giant makes two [[/item .250gOq5bpqIHb7rw]]{greatclub}
-          attacks.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two [[/item
+          .250gOq5bpqIHb7rw]]{Greatclub} attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -505,13 +503,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        x5py5LR53o68O5vc:
           type: utility
           activation:
             type: action
@@ -526,15 +523,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -545,7 +543,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -562,7 +561,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: x5py5LR53o68O5vc
       enchant: {}
       prerequisites:
         level: null
@@ -576,11 +583,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745273655374
+      systemVersion: 6.0.0
+      createdTime: 1781805641142
+      modifiedTime: 1781805645157
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!9g4N9sjyh8Ql46to.1k58ryEYEYijhYOb'
@@ -591,7 +598,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Hill Giant attacks with its Greatclub.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -655,7 +664,7 @@ items:
         conditions: ''
       properties:
         - rch
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -664,8 +673,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        bgQBDuHrYUhaj8jL:
           type: attack
           activation:
             type: action
@@ -680,10 +688,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -700,7 +709,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -713,24 +723,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: bgQBDuHrYUhaj8jL
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: greatclub
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -740,22 +763,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.QRCsxkCwWNwswL9o
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107550523
+      systemVersion: 6.0.0
+      createdTime: 1781805610030
+      modifiedTime: 1781805621633
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!9g4N9sjyh8Ql46to.250gOq5bpqIHb7rw'
   - _id: lpyNJHYnhFtpLgo9
     name: Rock
     type: weapon
-    img: icons/magic/earth/projectile-stone-ball-brown.webp
+    img: icons/magic/earth/projectile-boulder-yellow.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Hill Giant attacks with its Rock.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -817,18 +842,18 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties: []
-      proficient: 1
+      properties:
+        - thr
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: simpleR
+        value: improv
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        yFkmyqPiCNKIJXLx:
           type: attack
           activation:
             type: action
@@ -843,10 +868,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -863,7 +889,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -883,17 +910,30 @@ items:
             flat: false
             type:
               value: ranged
-              classification: weapon
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 200000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          name: ''
+          _id: yFkmyqPiCNKIJXLx
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: rock
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -903,11 +943,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745173385091
+      systemVersion: 6.0.0
+      createdTime: 1781805583619
+      modifiedTime: 1781805604553
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!9g4N9sjyh8Ql46to.lpyNJHYnhFtpLgo9'
@@ -919,7 +959,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171209241

--- a/packs/_source/monsters/giant/ogre.yml
+++ b/packs/_source/monsters/giant/ogre.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,6 +480,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: 1bqysUVTadmvi8nb
     name: Greatclub
@@ -491,7 +489,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ogre attacks with its Greatclub.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -555,17 +555,16 @@ items:
         conditions: ''
       properties:
         - two
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: simpleM
-        baseItem: club
+        baseItem: greatclub
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        NxiKmM9Atb37CQA0:
           type: attack
           activation:
             type: action
@@ -580,10 +579,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -600,7 +600,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -613,24 +614,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: NxiKmM9Atb37CQA0
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: greatclub
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -640,11 +654,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.QRCsxkCwWNwswL9o
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107552451
+      systemVersion: 6.0.0
+      createdTime: 1781805719620
+      modifiedTime: 1781805731523
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!eIGowKTkEBC9gUzx.1bqysUVTadmvi8nb'
@@ -655,7 +669,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Ogre attacks with its Javelin.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -720,7 +736,7 @@ items:
       properties:
         - thr
         - ver
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -729,8 +745,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        SjWUf9xzfYmBjXDJ:
           type: attack
           activation:
             type: action
@@ -745,10 +760,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -765,7 +781,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -778,24 +795,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: SjWUf9xzfYmBjXDJ
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: javelin
+      mastery: ''
     effects: []
     folder: null
     sort: 0
@@ -805,11 +835,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.DWLMnODrnHn8IbAG
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745173385519
+      systemVersion: 6.0.0
+      createdTime: 1781805654866
+      modifiedTime: 1781805710211
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!eIGowKTkEBC9gUzx.tXgnd9qKOE2b7Wis'
@@ -881,7 +911,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.n1V07puo0RQxPGuF
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -897,7 +927,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171244658

--- a/packs/_source/monsters/giant/oni.yml
+++ b/packs/_source/monsters/giant/oni.yml
@@ -446,9 +446,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -463,7 +460,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -483,6 +480,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: m65uENAa93Pz8lLl
     name: Chain Mail
@@ -553,7 +551,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.rLMflzmxpe8JGTOA
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -569,8 +567,10 @@ items:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]], or [[/damage average
-          activity=aKQQjgpq0XwCcMGK]] damage in Small or Medium form.</p>
-        chat: <p>The Oni attacks with its Glaive.</p>
+          activity=Rev09LWfUvsYkKwA]] damage in Small or Medium form.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -637,7 +637,7 @@ items:
         - mgc
         - rch
         - two
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -646,8 +646,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        gjPjqYhlKAk1tfGh:
           type: attack
           activation:
             type: action
@@ -662,71 +661,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-          duration:
-            concentration: false
             value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '10'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: str
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: melee
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts: []
-          sort: 0
-          name: Attack (large)
-          img: ''
-          appliedEffects: []
-        aKQQjgpq0XwCcMGK:
-          type: attack
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
           duration:
             concentration: false
             value: ''
@@ -747,7 +682,84 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
+            affects:
+              count: ''
+              type: ''
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          attack:
+            ability: ''
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ''
+              classification: ''
+          damage:
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          sort: 100000
+          name: Attack (Large)
+          img: ''
+          flags: {}
+          visibility:
+            identifier: ''
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: gjPjqYhlKAk1tfGh
+        Rev09LWfUvsYkKwA:
+          type: attack
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '10'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -781,14 +793,24 @@ items:
                 bonus: '@mod'
                 types:
                   - slashing
-          sort: 0
-          name: Attack (small)
-          _id: aKQQjgpq0XwCcMGK
+                scaling:
+                  number: 1
+          sort: 200000
+          name: Attack (Small / Medium)
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: Rev09LWfUvsYkKwA
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: glaive
       mastery: ''
     effects: []
@@ -796,30 +818,28 @@ items:
     sort: 100000
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.items.rOG1OM2ihgPjOvFW
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378799817
+      systemVersion: 6.0.0
+      createdTime: 1781806471852
+      modifiedTime: 1781806523459
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!L1w8yBkInMscfJ3F.FC0FNE8O4rnbth8s'
   - _id: q7J7PERrJb2vxtlt
     name: Claw (Oni Form Only)
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-glowing-purple.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Oni attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -883,7 +903,7 @@ items:
         conditions: ''
       properties:
         - mgc
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -892,8 +912,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        g2x5QBL3gFRLCI98:
           type: attack
           activation:
             type: action
@@ -908,10 +927,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -928,7 +948,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -941,23 +962,35 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: g2x5QBL3gFRLCI98
+          name: ''
       attuned: false
       ammunition: {}
-      magicalBonus: null
+      magicalBonus: ''
       identifier: claw-oni-form-only
       mastery: ''
     effects: []
@@ -969,11 +1002,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.350'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: null
-      modifiedTime: 1760378803707
+      systemVersion: 6.0.0
+      createdTime: 1781806542438
+      modifiedTime: 1781806559873
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!L1w8yBkInMscfJ3F.q7J7PERrJb2vxtlt'
@@ -1025,7 +1058,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -1127,7 +1160,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 5.1.0
       createdTime: null
@@ -1142,8 +1175,8 @@ items:
     system:
       description:
         value: >-
-          <p>The oni regains 10 hit points at the start of its turn if it has at
-          least 1 hit point.</p>
+          <p>The [[lookup @name lowercase]]{monster} regains [[/healing]] at the
+          start of its turn if it has at least 1 hit point.</p>
         chat: >-
           <p>The oni regains <strong>10 hit points</strong> at the start of its
           turn.</p>
@@ -1159,13 +1192,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        2fundJLXw6s1SAnf:
           type: heal
           activation:
             type: turnStart
@@ -1180,15 +1213,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1199,10 +1233,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1224,10 +1259,19 @@ items:
               mode: whole
               number: null
               formula: ''
-          sort: 0
-          name: ''
+          sort: 100000
+          name: Regenerate
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 2fundJLXw6s1SAnf
       enchant: {}
       prerequisites:
         level: null
@@ -1237,81 +1281,32 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.Av7H0ymGdPeTsnwV
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1749402468251
+      systemVersion: 6.0.0
+      createdTime: 1781806438284
+      modifiedTime: 1781806450186
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!L1w8yBkInMscfJ3F.8liUuXPhjNLKYMMx'
-  - _id: HJDOmnRX2zQuXraB
-    name: Magic Weapons
-    type: feat
-    img: icons/weapons/swords/sword-runed-glowing.webp
-    system:
-      description:
-        value: <p>The oni's weapon attacks are magical.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: magic-weapons
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.nahRRxck9R5GVVFS
-      duplicateSource: null
-      coreVersion: '13.345'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1749402491378
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!L1w8yBkInMscfJ3F.HJDOmnRX2zQuXraB'
   - _id: QGNzJqfTHnbhjzFN
     name: Change Shape
     type: feat
-    img: icons/magic/control/silhouette-hold-change-blue.webp
+    img: icons/equipment/head/mask-carved-bird-grey-pink.webp
     system:
       description:
         value: >-
-          <p>The oni magically polymorphs into a Small or Medium humanoid, into
-          a Large giant, or back into its true form. Other than its size, its
-          statistics are the same in each form. The only equipment that is
-          transformed is its glaive, which shrinks so that it can be wielded in
-          humanoid form. If the oni dies, it reverts to its true form, and its
-          glaive reverts to its normal size.</p>
+          <p>The [[lookup @name lowercase]]{monster} magically polymorphs into a
+          Small or Medium humanoid, into a Large giant, or back into its true
+          form. Other than its size, its statistics are the same in each form.
+          The only equipment that is transformed is its glaive, which shrinks so
+          that it can be wielded in humanoid form. If the [[lookup @name
+          lowercase]]{monster} dies, it reverts to its true form, and its glaive
+          reverts to its normal size.</p>
         chat: ''
       source:
         custom: ''
@@ -1325,64 +1320,82 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - mgc
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: utility
+        GHwuUudZqOR9Jep5:
+          type: transform
+          name: Transform
+          _id: GHwuUudZqOR9Jep5
+          img: ''
+          sort: 200000
           activation:
             type: action
-            value: 1
-            condition: ''
             override: false
+            condition: ''
           consumption:
-            targets: []
             scaling:
               allowed: false
-              max: ''
             spellSlot: true
+            targets: []
           description:
+            value: ''
             chatFlavor: ''
           duration:
+            units: inst
             concentration: false
-            value: ''
-            units: ''
-            special: ''
             override: false
           effects: []
+          flags: {}
           range:
-            units: ''
-            special: ''
+            units: self
             override: false
+            special: ''
           target:
             template:
-              count: ''
               contiguous: false
+              stationary: false
+              units: ft
               type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
             affects:
-              count: ''
-              type: ''
               choice: false
-              special: ''
-            prompt: true
+              type: ''
             override: false
+            prompt: true
           uses:
             spent: 0
-            max: ''
             recovery: []
-          roll:
-            formula: ''
-            name: ''
-            prompt: false
-            visible: false
-          sort: 0
+            max: ''
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          profiles:
+            - cr: ''
+              name: ''
+              _id: kS9Bcbd3HzOQ0NBC
+              uuid: null
+              sizes:
+                - sm
+                - med
+              types:
+                - humanoid
+              movement: []
+              level:
+                min: null
+                max: null
+          settings: null
+          transform:
+            customize: false
+            mode: cr
+            preset: polymorphSelf
       enchant: {}
       prerequisites:
         level: null
@@ -1396,11 +1409,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.JsAys4RSGi4lN5Jy
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1749402634275
+      systemVersion: 6.0.0
+      createdTime: 1781806592702
+      modifiedTime: 1781806664896
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!L1w8yBkInMscfJ3F.QGNzJqfTHnbhjzFN'
@@ -1516,7 +1529,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.S7VbUetIfVT7B6Eq
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1632,7 +1645,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.1N8dDMMgZ1h1YJ3B
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1760,7 +1773,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.eS7XnnApoxRxYXPs
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1892,7 +1905,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.RpKjTlYASrfqUPVA
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2025,7 +2038,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.2IWiZAJtOGDoKjiz
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2169,7 +2182,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.KhwiSi9fwVfUPtku
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2177,6 +2190,59 @@ items:
       lastModifiedBy: null
       exportSource: null
     _key: '!actors.items!L1w8yBkInMscfJ3F.KhwiSi9fwVfUPtku'
+  - _id: TCJLfMzkArxZePFY
+    name: Magic Weapons
+    ownership:
+      default: 0
+    type: feat
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster}'s weapon attacks are
+          magical.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      properties:
+        - trait
+      identifier: magic-weapons
+      advancement: {}
+      crewed: false
+    flags: {}
+    img: icons/weapons/swords/sword-runed-glowing.webp
+    effects: []
+    folder: null
+    sort: 0
+    _stats:
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781806461106
+      modifiedTime: 1781806461106
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+      compendiumSource: Compendium.dnd5e.monsterfeatures.Item.nahRRxck9R5GVVFS
+    _key: '!actors.items!L1w8yBkInMscfJ3F.TCJLfMzkArxZePFY'
 effects: []
 folder: v8gFGdEluEFQdRQg
 sort: 0
@@ -2185,7 +2251,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171223750

--- a/packs/_source/monsters/giant/stone-giant.yml
+++ b/packs/_source/monsters/giant/stone-giant.yml
@@ -445,9 +445,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -462,7 +459,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -482,6 +479,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
   - _id: Tm2NY0eSI6InRcsa
     name: Greatclub
@@ -490,7 +488,9 @@ items:
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Stone Giant attacks with its Greatclub.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -553,17 +553,16 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
         value: simpleM
-        baseItem: club
+        baseItem: greatclub
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        0KnjXUfqPEAOde4c:
           type: attack
           activation:
             type: action
@@ -578,10 +577,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -598,7 +598,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -611,24 +612,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 0KnjXUfqPEAOde4c
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: greatclub
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -638,11 +652,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.QRCsxkCwWNwswL9o
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1749402670079
+      systemVersion: 6.0.0
+      createdTime: 1781805899735
+      modifiedTime: 1781805910692
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!SOin81NWijHRvXFK.Tm2NY0eSI6InRcsa'
@@ -653,8 +667,8 @@ items:
     system:
       description:
         value: >-
-          <p>The giant makes two [[/item .Tm2NY0eSI6InRcsa]]{greatclub}
-          attacks.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes two [[/item
+          .Tm2NY0eSI6InRcsa]]{Greatclub} attacks.</p>
         chat: ''
       source:
         custom: ''
@@ -668,13 +682,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        29A34ebXGhVGEYGC:
           type: utility
           activation:
             type: action
@@ -689,15 +702,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -708,7 +722,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -725,7 +740,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: 29A34ebXGhVGEYGC
       enchant: {}
       prerequisites:
         level: null
@@ -739,28 +762,28 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1749402670898
+      systemVersion: 6.0.0
+      createdTime: 1781805889161
+      modifiedTime: 1781805895815
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!SOin81NWijHRvXFK.W7aeXkpOJ1TwM0dq'
   - _id: eiNNUlTgJyVFcQkO
     name: Rock
     type: weapon
-    img: icons/magic/earth/projectile-stone-ball-brown.webp
+    img: icons/magic/earth/projectile-boulder-yellow.webp
     system:
       description:
         value: >-
           <p>[[/attack extended]]. [[/damage extended]].</p><p>If the target is
-          a creature, it must succeed on a [[/save]] saving throw or be knocked
-          prone.</p>
+          a creature, it must succeed on a [[/save activity=GOn2YYbOxKVKqvwx]]
+          saving throw or be knocked &amp;reference[prone].</p>
         chat: >-
-          <p>The Stone Giant attacks with its Rock. If the target is a creature,
-          it must make a <strong>Strength</strong> saving throw or be knocked
-          prone.</p>
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. If the target is a creature, it must make a Strength
+          saving throw or be knocked &amp;reference[prone].</p>
       source:
         custom: ''
         book: ''
@@ -822,18 +845,18 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties: []
-      proficient: 1
+      properties:
+        - thr
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: simpleR
+        value: improv
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        GcpJRIWkBXlay5gY:
           type: attack
           activation:
             type: action
@@ -848,69 +871,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
-          duration:
-            concentration: false
             value: ''
-            units: ''
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '60'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          attack:
-            ability: str
-            bonus: ''
-            critical:
-              threshold: null
-            flat: false
-            type:
-              value: ranged
-              classification: weapon
-          damage:
-            critical:
-              bonus: ''
-            includeBase: true
-            parts: []
-          sort: 0
-        dnd5eactivity100:
-          _id: dnd5eactivity100
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
           duration:
             concentration: false
             value: ''
@@ -931,7 +892,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -943,16 +905,109 @@ items:
             spent: 0
             max: ''
             recovery: []
+          attack:
+            ability: str
+            bonus: ''
+            critical:
+              threshold: null
+            flat: false
+            type:
+              value: ranged
+              classification: ''
           damage:
-            onSave: half
+            critical:
+              bonus: ''
+            includeBase: true
+            parts: []
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: GcpJRIWkBXlay5gY
+          name: ''
+        GOn2YYbOxKVKqvwx:
+          type: save
+          activation:
+            type: special
+            value: 1
+            condition: When a creature is hit by this attack.
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: >-
+              <p>If the target is a creature, it must succeed on a [[/save
+              activity=GOn2YYbOxKVKqvwx]] saving throw or be knocked
+              &amp;reference[prone].</p>
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '60'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: ''
+              size: ''
+              width: ''
+              height: ''
+              units: ft
+              stationary: false
+            affects:
+              count: '1'
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: none
             parts: []
           save:
-            ability: str
+            ability:
+              - str
             dc:
               calculation: ''
               formula: '17'
-          sort: 0
-          name: ''
+            visible: true
+            bonus: ''
+          sort: 200000
+          name: Prone Save
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: GOn2YYbOxKVKqvwx
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -967,22 +1022,23 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1749402684645
+      systemVersion: 6.0.0
+      createdTime: 1781805927324
+      modifiedTime: 1781805988057
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!SOin81NWijHRvXFK.eiNNUlTgJyVFcQkO'
   - _id: HxKKuoyc6AYGLsIX
     name: Rock Catching
     type: feat
-    img: icons/skills/melee/unarmed-punch-fist.webp
+    img: icons/skills/social/wave-halt-stop.webp
     system:
       description:
         value: >-
-          <p>If a rock or similar object is hurled at the giant, the giant can,
+          <p>If a rock or similar object is hurled at the [[lookup @name
+          lowercase]]{monster}, the [[lookup @name lowercase]]{monster} can,
           with a successful [[/save]] saving throw, catch the missile and take
           no bludgeoning damage from it.</p>
         chat: >-
@@ -1000,18 +1056,20 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        Uidmvupprj1SWlLG:
           type: save
           activation:
-            type: ''
+            type: special
             value: null
-            condition: ''
+            condition: >-
+              When a rock or similar object is hurled at the [[lookup @name
+              lowercase]]{monster}.
             override: false
           consumption:
             targets: []
@@ -1021,15 +1079,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1040,10 +1099,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1053,14 +1113,29 @@ items:
             max: ''
             recovery: []
           damage:
-            onSave: half
+            onSave: none
             parts: []
           save:
-            ability: dex
+            ability:
+              - dex
             dc:
               calculation: ''
               formula: '10'
-          sort: 0
+            visible: true
+            bonus: ''
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: Uidmvupprj1SWlLG
+          name: Catch Rock
       enchant: {}
       prerequisites:
         level: null
@@ -1074,23 +1149,23 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.BpwXJvMA7MfVQ7i6
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1749402660165
+      systemVersion: 6.0.0
+      createdTime: 1781805767548
+      modifiedTime: 1781805834736
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!SOin81NWijHRvXFK.HxKKuoyc6AYGLsIX'
-  - _id: zqsYu35qYHNNeTWE
+  - _id: e4p65TbhzdVU810V
     name: Stone Camouflage
     type: feat
-    img: icons/magic/nature/stealth-hide-eyes-green.webp
+    img: icons/commodities/stone/ore-pile-gold-orange.webp
     system:
       description:
         value: >-
-          <p>The giant has advantage on Dexterity (Stealth) checks made to hide
-          in rocky terrain.</p>
+          <p>The [[lookup @name lowercase]]{monster} has advantage on Dexterity
+          (Stealth) checks made to &amp;reference[hide] in rocky terrain.</p>
         chat: ''
       source:
         custom: ''
@@ -1104,32 +1179,37 @@ items:
         spent: 0
         recovery: []
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities: {}
       enchant: {}
       prerequisites:
         level: null
+        items: []
+        repeatable: false
       identifier: stone-camouflage
+      advancement: {}
+      crewed: false
     effects: []
     folder: null
-    sort: 0
+    sort: 123438
     ownership:
       default: 0
     flags: {}
     _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.j1cPfWFNvxGoex9Z
-      duplicateSource: null
-      coreVersion: '13.345'
+      compendiumSource: Compendium.dnd5e.monsters.Actor.SOin81NWijHRvXFK.Item.zqsYu35qYHNNeTWE
+      duplicateSource: Item.7T3eyubaB1KmDJ3R
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1749402667767
+      systemVersion: 6.0.0
+      createdTime: 1781821092401
+      modifiedTime: 1781821092401
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
-    _key: '!actors.items!SOin81NWijHRvXFK.zqsYu35qYHNNeTWE'
+    _key: '!actors.items!SOin81NWijHRvXFK.e4p65TbhzdVU810V'
 effects: []
 folder: v8gFGdEluEFQdRQg
 sort: 0
@@ -1138,7 +1218,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171232404

--- a/packs/_source/monsters/giant/storm-giant.yml
+++ b/packs/_source/monsters/giant/storm-giant.yml
@@ -449,9 +449,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -466,7 +463,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -486,6 +483,7 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 3
 items:
   - _id: PMXLrGDWGu9amL2X
     name: Scale Mail
@@ -556,7 +554,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.XmnlF5fgIO3tg6TG
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -564,60 +562,16 @@ items:
       lastModifiedBy: null
       exportSource: null
     _key: '!actors.items!68bAMIpe4jvDeR9G.PMXLrGDWGu9amL2X'
-  - _id: 3vDo83oAycRGB85G
-    name: Amphibious
-    type: feat
-    img: icons/environment/creatures/frog-spotted-green.webp
-    system:
-      description:
-        value: <p>The giant can breathe air and water.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: amphibious
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: Compendium.dnd5e.monsterfeatures.4Fap14HgvAwTAZuD
-      duplicateSource: null
-      coreVersion: '13.344'
-      systemId: dnd5e
-      systemVersion: 4.0.0
-      createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
-      exportSource: null
-    _key: '!actors.items!68bAMIpe4jvDeR9G.3vDo83oAycRGB85G'
   - _id: iwN0z7f5LF9AAbRJ
     name: Greatsword
     type: weapon
-    img: icons/weapons/swords/greatsword-guard-gem-blue.webp
+    img: icons/weapons/swords/greatsword-guard-gold-worn.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Storm Giant attacks with its Greatsword.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -680,7 +634,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -689,8 +643,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        E2i5pPsf2Ob2O2bq:
           type: attack
           activation:
             type: action
@@ -705,10 +658,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -725,7 +679,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -738,24 +693,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: E2i5pPsf2Ob2O2bq
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: greatsword
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -765,11 +733,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.items.xMkP8BmFzElcsMaR
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745107550034
+      systemVersion: 6.0.0
+      createdTime: 1781806160228
+      modifiedTime: 1781806173518
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!68bAMIpe4jvDeR9G.iwN0z7f5LF9AAbRJ'
@@ -814,198 +782,21 @@ items:
       identifier: innate-spellcasting
     effects: []
     folder: null
-    sort: 0
+    sort: 300000
     ownership:
       default: 0
     flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.hkmTEk6klT6QL4K4
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745447015542
+      createdTime: 1781806407423
+      modifiedTime: 1781806407423
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!68bAMIpe4jvDeR9G.2tzFjiAiXJLEpuCn'
-  - _id: k0g8uqoYdJ4LVxcn
-    name: Lightning Strike
-    type: weapon
-    img: icons/magic/lightning/bolt-forked-blue-yellow.webp
-    system:
-      description:
-        value: >-
-          <p>The giant hurls a magical lightning bolt at a point it can see
-          within 500 feet of it.</p><p>Each creature within 10 feet of that
-          point must make a [[/save]] saving throw, taking [[/damage average]]
-          damage on a failed save, or half as much damage on a successful
-          one.</p>
-        chat: >-
-          <p>The Storm Giant attacks with its Lightning Strike. Each creature
-          within 10 feet of that point must make a <strong>Dexterity</strong>
-          saving throw.</p>
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      quantity: 1
-      weight:
-        value: 0
-        units: lb
-      price:
-        value: 0
-        denomination: gp
-      attunement: ''
-      equipped: true
-      rarity: ''
-      identified: true
-      cover: null
-      range:
-        value: 500
-        long: null
-        units: ft
-        reach: null
-      uses:
-        max: ''
-        recovery: []
-        spent: 0
-      damage:
-        versatile:
-          number: null
-          denomination: null
-          bonus: ''
-          types: []
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-        base:
-          number: 12
-          denomination: 8
-          bonus: ''
-          types:
-            - lightning
-          custom:
-            enabled: false
-            formula: ''
-          scaling:
-            mode: ''
-            number: null
-            formula: ''
-      armor:
-        value: 10
-      hp:
-        value: 0
-        max: 0
-        dt: null
-        conditions: ''
-      properties: []
-      proficient: 1
-      unidentified:
-        description: ''
-      type:
-        value: natural
-        baseItem: ''
-      container: null
-      crewed: false
-      activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
-          type: save
-          activation:
-            type: action
-            value: 1
-            condition: ''
-            override: false
-          consumption:
-            targets: []
-            scaling:
-              allowed: false
-              max: ''
-            spellSlot: true
-          description:
-            chatFlavor: ''
-          duration:
-            concentration: false
-            value: ''
-            units: inst
-            special: ''
-            override: false
-          effects: []
-          range:
-            value: '500'
-            units: ft
-            special: ''
-            override: false
-          target:
-            template:
-              count: ''
-              contiguous: false
-              type: ''
-              size: ''
-              width: ''
-              height: ''
-              units: ''
-            affects:
-              count: ''
-              type: ''
-              choice: false
-              special: ''
-            prompt: true
-            override: false
-          uses:
-            spent: 0
-            max: ''
-            recovery: []
-          damage:
-            onSave: half
-            parts:
-              - custom:
-                  enabled: false
-                  formula: ''
-                number: 12
-                denomination: 8
-                bonus: ''
-                types:
-                  - lightning
-                scaling:
-                  number: 1
-          save:
-            ability: dex
-            dc:
-              calculation: ''
-              formula: '17'
-          sort: 0
-          name: ''
-      attuned: false
-      ammunition: {}
-      magicalBonus: null
-      mastery: ''
-      identifier: lightning-strike
-    effects: []
-    folder: null
-    sort: 350000
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.345'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1749402719371
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!68bAMIpe4jvDeR9G.k0g8uqoYdJ4LVxcn'
   - _id: KUffpBEiNWnVK3W6
     name: Multiattack
     type: feat
@@ -1099,7 +890,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.4.0
       createdTime: null
@@ -1110,11 +901,13 @@ items:
   - _id: bRdk2uZ6iTuNGUIL
     name: Rock
     type: weapon
-    img: icons/magic/earth/projectile-stone-ball-brown.webp
+    img: icons/magic/earth/projectile-boulder-yellow.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Storm Giant attacks with its Rock.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -1176,18 +969,18 @@ items:
         max: 0
         dt: null
         conditions: ''
-      properties: []
-      proficient: 1
+      properties:
+        - thr
+      proficient: null
       unidentified:
         description: ''
       type:
-        value: simpleR
+        value: improv
         baseItem: ''
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        GShPalhZWLUwJGyZ:
           type: attack
           activation:
             type: action
@@ -1202,10 +995,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -1222,7 +1016,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -1235,20 +1030,32 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: ranged
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: GShPalhZWLUwJGyZ
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
@@ -1263,11 +1070,11 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1745173384919
+      systemVersion: 6.0.0
+      createdTime: 1781806180850
+      modifiedTime: 1781806194517
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!68bAMIpe4jvDeR9G.bRdk2uZ6iTuNGUIL'
@@ -1380,7 +1187,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ghXTfe7sgCbgf1Q8
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1494,7 +1301,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.pub0OWVEB71XQx1n
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1622,7 +1429,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.MRxldJd6C4bsBo3O
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1741,7 +1548,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.Bnn9Nzajixvow9xi
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -1919,7 +1726,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.ZPd73HtKF3At11jh
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2041,7 +1848,7 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.spells.13uVuBQP6VaiSPvC
       duplicateSource: null
-      coreVersion: '13.344'
+      coreVersion: '14.361'
       systemId: dnd5e
       systemVersion: 4.0.0
       createdTime: null
@@ -2049,6 +1856,199 @@ items:
       lastModifiedBy: null
       exportSource: null
     _key: '!actors.items!68bAMIpe4jvDeR9G.13uVuBQP6VaiSPvC'
+  - name: Lightning Strike
+    type: feat
+    _id: 0JPMyUkBeRw3elVe
+    img: icons/magic/lightning/bolt-strike-sparks-teal.webp
+    system:
+      activities:
+        Y2GMAvtp4yB0QcvH:
+          type: save
+          activation:
+            type: action
+            value: 1
+            condition: ''
+            override: false
+          consumption:
+            targets: []
+            scaling:
+              allowed: false
+              max: ''
+            spellSlot: true
+          description:
+            chatFlavor: ''
+            value: ''
+          duration:
+            concentration: false
+            value: ''
+            units: inst
+            special: ''
+            override: false
+          effects: []
+          range:
+            value: '500'
+            units: ft
+            special: ''
+            override: false
+          target:
+            template:
+              count: ''
+              contiguous: false
+              type: radius
+              size: '10'
+              width: ''
+              height: ''
+              units: ft
+              stationary: true
+            affects:
+              count: ''
+              type: creature
+              choice: false
+              special: ''
+            prompt: true
+            override: false
+          uses:
+            spent: 0
+            max: ''
+            recovery: []
+          damage:
+            onSave: half
+            parts:
+              - custom:
+                  enabled: false
+                  formula: ''
+                number: 12
+                denomination: 8
+                bonus: ''
+                types:
+                  - lightning
+                scaling:
+                  number: 1
+          save:
+            ability:
+              - dex
+            dc:
+              calculation: ''
+              formula: '17'
+            visible: true
+            bonus: ''
+          sort: 0
+          name: Hurl Lightning
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: true
+            identifier: ''
+          _id: Y2GMAvtp4yB0QcvH
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      advancement: {}
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} hurls a magical lightning
+          bolt at a point it can see within [[lookup @labels.description.range
+          activity=Y2GMAvtp4yB0QcvH]] of it.</p><p>Each creature within [[lookup
+          @target.template.size activity=Y2GMAvtp4yB0QcvH]] feet of that point
+          must make a [[/save]] saving throw, taking [[/damage average]] damage
+          on a failed save, or half as much damage on a successful one.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]]. Each creature within [[lookup @target.template.size
+          activity=Y2GMAvtp4yB0QcvH]] feet of that point must make a Dexterity
+          saving throw.</p>
+      identifier: lightning-strike
+      source:
+        revision: 1
+        rules: '2014'
+      crewed: false
+      enchant: {}
+      prerequisites:
+        items: []
+        repeatable: false
+        level: null
+      properties:
+        - mgc
+      requirements: ''
+      type:
+        value: monster
+        subtype: ''
+    effects: []
+    folder: null
+    sort: 325000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781806236279
+      modifiedTime: 1781806396620
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!actors.items!68bAMIpe4jvDeR9G.0JPMyUkBeRw3elVe'
+  - _id: cO04gKkMlOPTSz11
+    name: Amphibious
+    type: feat
+    img: icons/creatures/amphibians/treefrog-underneath-teal.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} can breathe air and
+          water.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        spent: 0
+        recovery: []
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: amphibious
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: 5cwqjeuI64dkrUa8
+    sort: 175000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.8RgUhb31VvjUNZU1.Item.ciz8wAZjqxPnu5Pe
+      duplicateSource: Item.pV30uzlB7Apma9GE
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781825755399
+      modifiedTime: 1781825755399
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!68bAMIpe4jvDeR9G.cO04gKkMlOPTSz11'
 effects: []
 folder: v8gFGdEluEFQdRQg
 sort: 0
@@ -2057,7 +2057,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171204245

--- a/packs/_source/monsters/giant/troll.yml
+++ b/packs/_source/monsters/giant/troll.yml
@@ -445,9 +445,6 @@ prototypeToken:
     tint: '#ffffff'
     scaleX: 1
     scaleY: 1
-    offsetX: 0
-    offsetY: 0
-    rotation: 0
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -462,7 +459,7 @@ prototypeToken:
     attenuation: 0.1
     saturation: 0
     contrast: 0
-  detectionModes: []
+  detectionModes: {}
   appendNumber: false
   prependAdjective: false
   occludable:
@@ -482,15 +479,18 @@ prototypeToken:
     src: null
     disposition: false
   movementAction: null
+  depth: 2
 items:
   - _id: R7DpgLP3aFNmAgOc
     name: Bite
     type: weapon
-    img: icons/creatures/abilities/mouth-teeth-long-red.webp
+    img: icons/creatures/abilities/mouth-teeth-rows-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Troll attacks with its Bite.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -553,7 +553,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -562,8 +562,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        njRxaQdS20BD1xbB:
           type: attack
           activation:
             type: action
@@ -578,10 +577,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -598,7 +598,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -611,24 +612,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: njRxaQdS20BD1xbB
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: bite
+      mastery: ''
     effects: []
     folder: null
     sort: 100000
@@ -638,22 +652,24 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.WdpSeGqhZpptz37y
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1749402732213
+      systemVersion: 6.0.0
+      createdTime: 1781806111077
+      modifiedTime: 1781806123540
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZHAFrnCwCz17dmLc.R7DpgLP3aFNmAgOc'
   - _id: ahGwFmyt6nItUOAK
     name: Claw
     type: weapon
-    img: icons/skills/melee/strike-slashes-red.webp
+    img: icons/creatures/claws/claw-talons-yellow-red.webp
     system:
       description:
         value: <p>[[/attack extended]]. [[/damage extended]].</p>
-        chat: <p>The Troll attacks with its Claw.</p>
+        chat: >-
+          <p>The [[lookup @name]]{monster} attacks with its [[lookup
+          @item.name]].</p>
       source:
         custom: ''
         book: ''
@@ -716,7 +732,7 @@ items:
         dt: null
         conditions: ''
       properties: []
-      proficient: 1
+      proficient: null
       unidentified:
         description: ''
       type:
@@ -725,8 +741,7 @@ items:
       container: null
       crewed: false
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        l0vkYRXP4wQzne0M:
           type: attack
           activation:
             type: action
@@ -741,10 +756,11 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
@@ -761,7 +777,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -774,24 +791,37 @@ items:
             max: ''
             recovery: []
           attack:
-            ability: str
+            ability: ''
             bonus: ''
             critical:
               threshold: null
             flat: false
             type:
-              value: melee
-              classification: weapon
+              value: ''
+              classification: ''
           damage:
             critical:
               bonus: ''
             includeBase: true
             parts: []
-          sort: 0
+          sort: 100000
+          img: ''
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: l0vkYRXP4wQzne0M
+          name: ''
       attuned: false
       ammunition: {}
       magicalBonus: null
       identifier: claw
+      mastery: ''
     effects: []
     folder: null
     sort: 300000
@@ -801,62 +831,14 @@ items:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1749402732213
+      systemVersion: 6.0.0
+      createdTime: 1781806132954
+      modifiedTime: 1781806148372
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZHAFrnCwCz17dmLc.ahGwFmyt6nItUOAK'
-  - _id: N3vrbUmlL4FEARJ8
-    name: Keen Smell
-    type: feat
-    img: icons/creatures/mammals/wolf-howl-moon-forest-blue.webp
-    system:
-      description:
-        value: >-
-          <p>The troll has advantage on Wisdom (Perception) checks that rely on
-          smell.</p>
-        chat: ''
-      source:
-        custom: ''
-        book: ''
-        page: ''
-        license: CC-BY-4.0
-        rules: '2014'
-        revision: 1
-      uses:
-        max: ''
-        spent: 0
-        recovery: []
-      type:
-        value: ''
-        subtype: ''
-      requirements: ''
-      properties: []
-      activities: {}
-      enchant: {}
-      prerequisites:
-        level: null
-      identifier: keen-smell
-    effects: []
-    folder: null
-    sort: 0
-    ownership:
-      default: 0
-    flags: {}
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '13.345'
-      systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1749402737095
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    _key: '!actors.items!ZHAFrnCwCz17dmLc.N3vrbUmlL4FEARJ8'
   - _id: BA9WmovILanbvacP
     name: Multiattack
     type: feat
@@ -864,9 +846,9 @@ items:
     system:
       description:
         value: >-
-          <p>The troll makes three attacks: one with its [[/item
-          .R7DpgLP3aFNmAgOc]]{bite} and two with its [[/item
-          .ahGwFmyt6nItUOAK]]{claws}.</p>
+          <p>The [[lookup @name lowercase]]{monster} makes three attacks: one
+          with its [[/item .R7DpgLP3aFNmAgOc]]{Bite} and two with its [[/item
+          .ahGwFmyt6nItUOAK]]{Claws}.</p>
         chat: ''
       source:
         custom: ''
@@ -880,13 +862,12 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
       properties: []
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        PB51rSLaQCsi3BW9:
           type: utility
           activation:
             type: action
@@ -901,15 +882,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -920,7 +902,8 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -937,7 +920,15 @@ items:
             name: ''
             prompt: false
             visible: false
-          sort: 0
+          sort: 100000
+          img: null
+          flags: {}
+          visibility:
+            level: {}
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+          _id: PB51rSLaQCsi3BW9
       enchant: {}
       prerequisites:
         level: null
@@ -951,11 +942,11 @@ items:
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.EqoLg8T8EHvhJgKE
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 4.4.0
-      createdTime: null
-      modifiedTime: 1749402733017
+      systemVersion: 6.0.0
+      createdTime: 1781806088392
+      modifiedTime: 1781806106983
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZHAFrnCwCz17dmLc.BA9WmovILanbvacP'
@@ -966,10 +957,12 @@ items:
     system:
       description:
         value: >-
-          <p>The troll regains 10 hit points at the start of its turn. If the
-          troll takes acid or fire damage, this trait doesn't function at the
-          start of the troll's next turn. The troll dies only if it starts its
-          turn with 0 hit points and doesn't regenerate.</p>
+          <p>The [[lookup @name lowercase]] regains [[/healing]] at the start of
+          its turn. If the [[lookup @name lowercase]]{monster} takes acid or
+          fire damage, this trait doesn't function at the start of the [[lookup
+          @name lowercase]]{monster}'s next turn. The [[lookup @name
+          lowercase]]{monster} dies only if it starts its turn with 0 hit points
+          and doesn't regenerate.</p>
         chat: >-
           <p>The troll regains <strong>10 hit points</strong> at the start of
           its turn.</p>
@@ -985,13 +978,13 @@ items:
         recovery: []
         spent: 0
       type:
-        value: ''
+        value: monster
         subtype: ''
       requirements: ''
-      properties: []
+      properties:
+        - trait
       activities:
-        dnd5eactivity000:
-          _id: dnd5eactivity000
+        4B0Ot7waDVbBk3LJ:
           type: heal
           activation:
             type: turnStart
@@ -1006,15 +999,16 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             concentration: false
             value: ''
-            units: ''
+            units: inst
             special: ''
             override: false
           effects: []
           range:
-            units: ''
+            units: self
             special: ''
             override: false
           target:
@@ -1025,10 +1019,11 @@ items:
               size: ''
               width: ''
               height: ''
-              units: ''
+              units: ft
+              stationary: false
             affects:
               count: ''
-              type: ''
+              type: self
               choice: false
               special: ''
             prompt: true
@@ -1050,10 +1045,19 @@ items:
               mode: whole
               number: null
               formula: ''
-          sort: 0
-          name: ''
+          sort: 100000
+          name: Regenerate
           img: ''
-          appliedEffects: []
+          flags: {}
+          visibility:
+            level:
+              min: null
+              max: null
+            requireAttunement: false
+            requireIdentification: false
+            requireMagic: false
+            identifier: ''
+          _id: 4B0Ot7waDVbBk3LJ
       enchant: {}
       prerequisites:
         level: null
@@ -1063,22 +1067,71 @@ items:
     sort: 0
     ownership:
       default: 0
-    flags:
-      dnd5e:
-        riders:
-          activity: []
-          effect: []
+    flags: {}
     _stats:
       compendiumSource: Compendium.dnd5e.monsterfeatures.Av7H0ymGdPeTsnwV
       duplicateSource: null
-      coreVersion: '13.345'
+      coreVersion: '14.361'
       systemId: dnd5e
-      systemVersion: 5.1.0
-      createdTime: null
-      modifiedTime: 1749402751614
+      systemVersion: 6.0.0
+      createdTime: 1781806057438
+      modifiedTime: 1781806078985
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     _key: '!actors.items!ZHAFrnCwCz17dmLc.yWYB2iyRA61AjcVJ'
+  - _id: tHnuysAmPnrL2jpA
+    name: Keen Smell
+    type: feat
+    img: icons/creatures/mammals/wolf-howl-moon-forest-blue.webp
+    system:
+      description:
+        value: >-
+          <p>The [[lookup @name lowercase]]{monster} has advantage on Wisdom
+          (Perception) checks that rely on smell.</p>
+        chat: ''
+      source:
+        custom: ''
+        book: ''
+        page: ''
+        license: CC-BY-4.0
+        rules: '2014'
+        revision: 1
+      uses:
+        max: ''
+        recovery: []
+        spent: 0
+      type:
+        value: monster
+        subtype: ''
+      requirements: ''
+      properties:
+        - trait
+      activities: {}
+      enchant: {}
+      prerequisites:
+        level: null
+        items: []
+        repeatable: false
+      identifier: keen-smell
+      advancement: {}
+      crewed: false
+    effects: []
+    folder: UIqfXYMLB6oOsW3Z
+    sort: -100000
+    ownership:
+      default: 0
+    flags: {}
+    _stats:
+      compendiumSource: Compendium.dnd5e.monsters.Actor.oQvORD924obyPdCc.Item.hwviWX3lRj9wqENj
+      duplicateSource: Item.gcfYCrt0yFVt4QF4
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781806007773
+      modifiedTime: 1781806007773
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    _key: '!actors.items!ZHAFrnCwCz17dmLc.tHnuysAmPnrL2jpA'
 effects: []
 folder: v8gFGdEluEFQdRQg
 sort: 0
@@ -1087,7 +1140,7 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.0.0
   createdTime: 1726171238805


### PR DESCRIPTION
Updated the 5.1 SRD Giants to current system standards. Included enrichers and lookups where I could.

Does not currently touch spells or spellcasting traits, will handle that in future PR when spells are updated.

Related #6712