### PR TITLE
Separate Concentration Checks per Effect

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -6131,6 +6131,10 @@
       "Hint": "Use the same initiative roll for identical creatures."
     }
   },
+  "ConcentrationPerEffect": {
+    "Name": "Separate Concentration Checks per Effect",
+    "Hint": "When enabled, a character maintaining multiple concentration effects will roll a separate concentration check for each effect when damaged."
+  },
   "CRITICAL": {
     "Name": "Critical Damage",
     "MaxDice": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1758,8 +1758,10 @@
   },
   "Locked": "Locked"
 },
-"DND5E.ConcentrationCheckFor": "Concentration Check for {effect}"
-"DND5E.ConcentratingItemless": "an unknown effect"
+"DND5E.ConcentrationCheckFor": "Concentration Check for {effect}",
+"DND5E.ConcentratingItemless": "an unknown effect",
+"DND5E.ConcentrationMultiPrompt": "Choose a concentration effect to check",
+"DND5E.ConcentrationResultFor": "Concentration check for {effect}",
 "DND5E.ComponentMaterial": "Material",
 "DND5E.ComponentMaterialAbbr": "M",
 "DND5E.ComponentSomatic": "Somatic",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1758,6 +1758,8 @@
   },
   "Locked": "Locked"
 },
+"DND5E.ConcentrationCheckFor": "Concentration Check for {effect}"
+"DND5E.ConcentratingItemless": "an unknown effect"
 "DND5E.ComponentMaterial": "Material",
 "DND5E.ComponentMaterialAbbr": "M",
 "DND5E.ComponentSomatic": "Somatic",

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1113,7 +1113,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const perEffect = game.settings.get("dnd5e", "concentrationPerEffect");
 
     if (perEffect && effects.length > 1) {
-      const messages = [];
+      const promises = [];
       for (const effect of effects) {
         const effectName = effect.name || game.i18n.localize("DND5E.ConcentratingItemless");
         const dataset = {

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1103,11 +1103,50 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @param {object} [options]
    * @param {number} [options.dc]         The target value of the saving throw.
    * @param {string} [options.ability]    An ability to use instead of the default.
-   * @returns {Promise<ChatMessage5e>}    A promise that resolves to the created chat message.
+   * @returns {Promise<ChatMessage5e|ChatMessage5e[]>}    A promise that resolves to the created chat message(s).
    */
   async challengeConcentration({ dc=10, ability=null }={}) {
     const isConcentrating = this.concentration.effects.size > 0;
     if ( !isConcentrating ) return null;
+    const effects = Array.from(this.concentration.effects);
+
+    const perEffect = game.settings.get("dnd5e", "concentrationPerEffect");
+
+    if (perEffect && effects.length > 1) {
+      const messages = [];
+      for (const effect of effects) {
+        const effectName = effect.name || game.i18n.localize("DND5E.ConcentratingItemless");
+        const dataset = {
+          action: "concentration",
+          dc: dc,
+          effectId: effect.id  
+        };
+        if ( ability in CONFIG.DND5E.abilities ) dataset.ability = ability;
+        
+        const config = { type: "concentration", format: "short", icon: true };
+        const buttonLabel = createRollLabel({ ...dataset, ...config });
+        const hiddenLabel = createRollLabel({ ...dataset, ...config, hideDC: true });
+        const flavor = game.i18n.format("DND5E.ConcentrationCheckFor", { effect: effectName });
+        const content = await foundry.applications.handlebars.renderTemplate(
+          "systems/dnd5e/templates/chat/roll-request-card.hbs",
+          {
+            buttons: [{
+              dataset: { ...dataset, type: "concentration", visibility: "all" },
+              buttonLabel,
+              hiddenLabel
+            }]
+          }
+        );
+
+        promises.push(ChatMessage.implementation.create({
+          content,
+          flavor,
+          whisper: game.users.filter(user => this.testUserPermission(user, "OWNER")),
+          speaker: ChatMessage.getSpeaker({ actor: this })
+        }));
+      }
+      return Promise.all(promises);
+   }
 
     const dataset = {
       action: "concentration",

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1164,6 +1164,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       whisper: game.users.filter(user => this.testUserPermission(user, "OWNER")),
       speaker: ChatMessage.implementation.getSpeaker({ actor: this })
     });
+  }
 
   /* -------------------------------------------- */
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1103,7 +1103,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @param {object} [options]
    * @param {number} [options.dc]         The target value of the saving throw.
    * @param {string} [options.ability]    An ability to use instead of the default.
-   * @returns {Promise<ChatMessage5e|ChatMessage5e[]>}    A promise that resolves to the created chat message(s).
+   * @returns {Promise<ChatMessage5e>}    A promise that resolves to the created chat message.
    */
   async challengeConcentration({ dc=10, ability=null }={}) {
     const isConcentrating = this.concentration.effects.size > 0;
@@ -1111,70 +1111,59 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const effects = Array.from(this.concentration.effects);
 
     const perEffect = game.settings.get("dnd5e", "concentrationPerEffect");
+    const buttons = [];
 
     if (perEffect && effects.length > 1) {
-      const promises = [];
       for (const effect of effects) {
-        const effectName = effect.name || game.i18n.localize("DND5E.ConcentratingItemless");
+        const itemId = effect.flags?.dnd5e?.item?.id;
+        let itemName = this.items.get(itemId)?.name;
+        const effectName = itemName || game.i18n.localize("DND5E.ConcentratingItemless");
         const dataset = {
           action: "concentration",
           dc: dc,
-          effectId: effect.id  
+          effectName: effectName, 
+          effectId: effect.id
         };
-        if ( ability in CONFIG.DND5E.abilities ) dataset.ability = ability;
-        
+        if (ability && ability in CONFIG.DND5E.abilities) {
+          dataset.ability = ability;
+        }
         const config = { type: "concentration", format: "short", icon: true };
         const buttonLabel = createRollLabel({ ...dataset, ...config });
         const hiddenLabel = createRollLabel({ ...dataset, ...config, hideDC: true });
-        const flavor = game.i18n.format("DND5E.ConcentrationCheckFor", { effect: effectName });
-        const content = await foundry.applications.handlebars.renderTemplate(
-          "systems/dnd5e/templates/chat/roll-request-card.hbs",
-          {
-            buttons: [{
-              dataset: { ...dataset, type: "concentration", visibility: "all" },
-              buttonLabel,
-              hiddenLabel
-            }]
-          }
-        );
-
-        promises.push(ChatMessage.implementation.create({
-          content,
-          flavor,
-          whisper: game.users.filter(user => this.testUserPermission(user, "OWNER")),
-          speaker: ChatMessage.getSpeaker({ actor: this })
-        }));
+        buttons.push({
+          dataset: { ...dataset, type: "concentration", visibility: "all" },
+          buttonLabel,
+          hiddenLabel
+        });
       }
-      return Promise.all(promises);
-   }
+    } else {
+      const dataset = { action: "concentration", dc: dc };
+      if (ability && ability in CONFIG.DND5E.abilities) dataset.ability = ability;
+      const config = { type: "concentration", format: "short", icon: true };
+      const buttonLabel = createRollLabel({ ...dataset, ...config });
+      const hiddenLabel = createRollLabel({ ...dataset, ...config, hideDC: true });
+      buttons.push({
+        dataset: { ...dataset, type: "concentration", visibility: "all" },
+        buttonLabel,
+        hiddenLabel
+      });
+    }
 
-    const dataset = {
-      action: "concentration",
-      dc: dc
-    };
-    if ( ability in CONFIG.DND5E.abilities ) dataset.ability = ability;
+    const content = await foundry.applications.handlebars.renderTemplate(
+      "systems/dnd5e/templates/chat/roll-request-card.hbs",
+      { buttons }
+    );
 
-    const config = {
-      type: "concentration",
-      format: "short",
-      icon: true
-    };
+    const flavor = (perEffect && effects.length > 1)
+      ? game.i18n.localize("DND5E.ConcentrationMultiPrompt")
+      : game.i18n.localize("DND5E.Concentration");
 
     return ChatMessage.implementation.create({
-      content: await foundry.applications.handlebars.renderTemplate(
-        "systems/dnd5e/templates/chat/roll-request-card.hbs",
-        {
-          buttons: [{
-            dataset: { ...dataset, type: "concentration", visibility: "all" },
-            buttonLabel: createRollLabel({ ...dataset, ...config }),
-            hiddenLabel: createRollLabel({ ...dataset, ...config, hideDC: true })
-          }]
-        }
-      ),
+      content,
+      flavor,
       whisper: game.users.filter(user => this.testUserPermission(user, "OWNER")),
       speaker: ChatMessage.implementation.getSpeaker({ actor: this })
     });
-  }
 
   /* -------------------------------------------- */
 

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -911,7 +911,7 @@ async function rollCheckSave(config, event) {
           if (effect) {
             flavor = game.i18n.format("DND5E.ConcentrationCheckFor", {
               effect: effect.name || game.i18n.localize("DND5E.ConcentratingItemless")
-            }
+            });
           }
         } else {
           ui.notifications.warn("DND5E.ConcentratingMissingItem");

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -922,7 +922,7 @@ async function rollCheckSave(config, event) {
             speaker: ChatMessage.implementation.getSpeaker({ actor, scene: canvas.scene, token: actor.token })
           }
         };
-        await actor.rollConcentration({ ...rollData, target: dc }, {}, message);
+        await actor.rollConcentration({ ...options, target: Number(dc) }, {}, message);
         break;
       case "save":
         await actor.rollSavingThrow(options);

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -922,7 +922,7 @@ async function rollCheckSave(config, event) {
             speaker: ChatMessage.implementation.getSpeaker({ actor, scene: canvas.scene, token: actor.token })
           }
         };
-        await actor.rollConcentration({ ...options, target: Number(dc) }, {}, message);
+        await actor.rollConcentration(options, {}, message);
         break;
       case "save":
         await actor.rollSavingThrow(options);

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -904,7 +904,25 @@ async function rollCheckSave(config, event) {
         await actor.rollAbilityCheck(options);
         break;
       case "concentration":
-        await actor.rollConcentration(options);
+        const effectId = config.effectId;
+        let flavor = game.i18n.localize("DND5E.Concentration");
+        if (effectId) {
+          const effect = actor.effects.get(effectId);
+          if (effect) {
+            flavor = game.i18n.format("DND5E.ConcentrationCheckFor", {
+              effect: effect.name || game.i18n.localize("DND5E.ConcentratingItemless")
+            }
+          }
+        } else {
+          ui.notifications.warn("DND5E.ConcentratingMissingItem");
+        }
+        const message = {
+          data: {
+            flavor,
+            speaker: ChatMessage.getSpeaker({ actor, scene: canvas.scene, token: actor.token })
+          }
+        };
+        await actor.rollConcentration({ ...rollData, target: dc }, {}, message);
         break;
       case "save":
         await actor.rollSavingThrow(options);

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -919,7 +919,7 @@ async function rollCheckSave(config, event) {
         const message = {
           data: {
             flavor,
-            speaker: ChatMessage.getSpeaker({ actor, scene: canvas.scene, token: actor.token })
+            speaker: ChatMessage.implementation.getSpeaker({ actor, scene: canvas.scene, token: actor.token })
           }
         };
         await actor.rollConcentration({ ...rollData, target: dc }, {}, message);
@@ -1640,9 +1640,15 @@ export function createRollLabel(config) {
       }
       break;
     case "concentration":
+      label = config.effectName
+        ? `${game.i18n.localize("DND5E.Concentration")}: ${config.effectName}`
+        : game.i18n.localize("DND5E.Concentration");
+      if (ability) label = `${label} (${abbreviation})`;
+      if (showDC) label = _loc("EDITOR.DND5E.Inline.DC", { dc: config.dc, check: label });
+      label = _loc(`EDITOR.DND5E.Inline.Save${longSuffix}`, { save: label });
+      break;
     case "save":
-      if ( config.type === "save" ) label = ability;
-      else label = `${_loc("DND5E.Concentration")} ${ability ? `(${abbreviation})` : ""}`;
+      label = ability;
       if ( showDC ) label = _loc("EDITOR.DND5E.Inline.DC", { dc: config.dc, check: label });
       label = _loc(`EDITOR.DND5E.Inline.Save${longSuffix}`, { save: label });
       break;

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -95,6 +95,16 @@ export function registerSystemSettings() {
     }
   });
 
+  // Separate Concentration Checks per Effect
+  game.settings.register("dnd5e", "concentrationPerEffect", {
+    name: "SETTINGS.DND5E.ConcentrationPerEffect.Name",
+    hint: "SETTINGS.DND5E.ConcentrationPerEffect.Hint",
+    scope: "world",
+    config: true,
+    default: false,
+    type: Boolean
+  });
+
   // Sense-to-token vision sync
   game.settings.register("dnd5e", "senseVisionSync", {
     name: "SETTINGS.DND5E.AUTOMATION.SenseVision.Name",


### PR DESCRIPTION
Adds a world setting that enables separate concentration checks for each effect a character is maintaining.
<img width="381" height="300" alt="QQ_1781887301388" src="https://github.com/user-attachments/assets/48b2f56f-11d4-4062-9ccc-ef193d456bfd" />
