### PR TITLE
[#5647] Display bastion turn reminder in time passed message

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -534,6 +534,7 @@ Hooks.once("i18nInit", () => {
   Object.values(CONFIG.DND5E.activityTypes).forEach(c => c.documentClass.localize());
   Object.values(CONFIG.DND5E.activityBehaviorTypes).forEach(c => c.model.localize());
   Object.values(CONFIG.DND5E.advancementTypes).forEach(c => c.documentClass.localize());
+  foundry.helpers.Localization.localizeDataModel(dataModels.settings.BastionSetting);
   foundry.helpers.Localization.localizeDataModel(dataModels.settings.CalendarConfigSetting);
   foundry.helpers.Localization.localizeDataModel(dataModels.settings.CalendarPreferencesSetting);
   foundry.helpers.Localization.localizeDataModel(dataModels.settings.TransformationSetting);

--- a/lang/en.json
+++ b/lang/en.json
@@ -1305,10 +1305,6 @@
     },
     "Title": "Bastion Attack"
   },
-  "Button": {
-    "Label": "Show Bastion Turn Button",
-    "Hint": "Display a button for advancing bastion turns in the main game interface."
-  },
   "Configuration": {
     "Name": "Bastions",
     "Label": "Configure Bastions",
@@ -1318,12 +1314,22 @@
     "Advance": "This will advance all bastion facility order progress by {duration}, issue the maintain order to all idle facilities, and repair any disabled facilities, would you like to continue?",
     "Maintain": "This will issue the maintain order to all idle bastion facilities and repair any disabled facilities, would you like to continue?"
   },
-  "Duration": {
-    "Label": "Bastion Turn Duration (days)"
-  },
-  "Enabled": {
-    "Label": "Enable Bastion Functionality",
-    "Hint": "When enabled, player characters will have access to a new Bastion tab on their character sheets when reaching level 5, and will be able to build facilities and issue orders to them."
+  "FIELDS": {
+    "button": {
+      "hint": "Display a button for advancing bastion turns in the main game interface.",
+      "label": "Show Bastion Turn Button"
+    },
+    "duration": {
+      "label": "Bastion Turn Duration (days)"
+    },
+    "enabled": {
+      "hint": "When enabled, player characters will have access to a new Bastion tab on their character sheets when reaching level 5, and will be able to build facilities and issue orders to them.",
+      "label": "Enable Bastion Functionality"
+    },
+    "reminder": {
+      "hint": "Display a reminder in chat when the next bastion turn should occur based on the advancement of time.",
+      "label": "Automatic Turn Reminder"
+    }
   },
   "Gold": {
     "Claim": "Claim Income",
@@ -1331,6 +1337,11 @@
     "Unclaimed": "unclaimed"
   },
   "Label": "Bastion",
+  "Reminder": {
+    "Ellapsed": "It has been {time} since the last bastion turn.",
+    "Triggered": "A bastion turn has occured.",
+    "Unknown": "It has been some time since the last bastion turn."
+  },
   "Summary": {
     "Gold": "{value} ({claimed})",
     "NoOrders": "No orders issued to special facilities this turn.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1338,8 +1338,8 @@
   },
   "Label": "Bastion",
   "Reminder": {
-    "Ellapsed": "It has been {time} since the last bastion turn.",
-    "Triggered": "A bastion turn has occured.",
+    "Elapsed": "It has been {time} since the last bastion turn.",
+    "Triggered": "A bastion turn has occurred.",
     "Unknown": "It has been some time since the last bastion turn."
   },
   "Summary": {

--- a/module/applications/actor/rest/base-rest-dialog.mjs
+++ b/module/applications/actor/rest/base-rest-dialog.mjs
@@ -136,6 +136,52 @@ export default class BaseRestDialog extends Dialog5e {
       isGroup: this.isPartyGroup,
       variant: game.settings.get("dnd5e", "restVariant")
     };
+
+    await this._prepareFields(context, options);
+
+    if ( context.fields.length ) {
+      context.formSections.push({ legend: "DND5E.REST.Configuration", fields: context.fields });
+    }
+    if ( context.hitPoints.length ) {
+      context.formSections.push({ legend: "DND5E.HitPoints", fields: context.hitPoints });
+    }
+
+    if ( this.isPartyGroup ) {
+      const restSettings = this.actor.getFlag("dnd5e", "restSettings") ?? {};
+      context.request = [
+        {
+          field: new BooleanField({
+            label: _loc("DND5E.REST.Request.AutoRest.Label"),
+            hint: _loc("DND5E.REST.Request.AutoRest.Hint")
+          }),
+          name: "autoRest",
+          input: context.inputs.createCheckboxInput,
+          value: restSettings.autoRest
+        },
+        ...this.actor.system.members
+          .filter(m => m.actor?.system.isCreature)
+          .map(m => ({
+            field: new BooleanField({
+              label: m.actor.name
+            }),
+            name: `targets.${m.actor.id}`,
+            input: context.inputs.createCheckboxInput,
+            value: restSettings.targets ? restSettings.targets?.has(m.actor.id) : true
+          }))
+      ];
+    }
+
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle preparing the main list of fields for the dialog.
+   * @param {ApplicationRenderContext} context  Context being prepared.
+   * @param {HandlebarsRenderOptions} options   Options which configure application rendering behavior.
+   */
+  async _prepareFields(context, options) {
     if ( this.promptNewDay ) context.fields.push({
       disabled: !!this.config.request,
       field: new BooleanField({
@@ -147,7 +193,7 @@ export default class BaseRestDialog extends Dialog5e {
       value: context.config.newDay
     });
 
-    if ( context.isGroup && game.settings.get("dnd5e", "calendarConfig").enabled ) {
+    if ( context.isGroup && dnd5e.settings.calendarConfig.enabled ) {
       const duration = convertTime(this.duration, "minute", { strict: false });
       context.duration = {
         fields: [
@@ -190,40 +236,6 @@ export default class BaseRestDialog extends Dialog5e {
       name: "recoverTempMax",
       value: context.config.recoverTempMax
     });
-
-    if ( context.fields.length ) {
-      context.formSections.push({ legend: "DND5E.REST.Configuration", fields: context.fields });
-    }
-    if ( context.hitPoints.length ) {
-      context.formSections.push({ legend: "DND5E.HitPoints", fields: context.hitPoints });
-    }
-
-    if ( this.isPartyGroup ) {
-      const restSettings = this.actor.getFlag("dnd5e", "restSettings") ?? {};
-      context.request = [
-        {
-          field: new BooleanField({
-            label: _loc("DND5E.REST.Request.AutoRest.Label"),
-            hint: _loc("DND5E.REST.Request.AutoRest.Hint")
-          }),
-          name: "autoRest",
-          input: context.inputs.createCheckboxInput,
-          value: restSettings.autoRest
-        },
-        ...this.actor.system.members
-          .filter(m => m.actor?.system.isCreature)
-          .map(m => ({
-            field: new BooleanField({
-              label: m.actor.name
-            }),
-            name: `targets.${m.actor.id}`,
-            input: context.inputs.createCheckboxInput,
-            value: restSettings.targets ? restSettings.targets?.has(m.actor.id) : true
-          }))
-      ];
-    }
-
-    return context;
   }
 
   /* -------------------------------------------- */

--- a/module/applications/actor/rest/long-rest-dialog.mjs
+++ b/module/applications/actor/rest/long-rest-dialog.mjs
@@ -29,17 +29,16 @@ export default class LongRestDialog extends BaseRestDialog {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  async _prepareContext(options) {
-    const context = await super._prepareContext(options);
+  async _prepareFields(context, options) {
+    await super._prepareFields(context, options);
 
-    const { enabled } = game.settings.get("dnd5e", "bastionConfiguration");
-    if ( game.user.isGM && context.isGroup && enabled ) context.fields.unshift({
-      field: new BooleanField({ label: _loc("DND5E.Bastion.Action.BastionTurn") }),
+    const { enabled, reminder } = dnd5e.settings.bastionConfiguration;
+    const { enabled: calendarEnabled } = dnd5e.settings.calendarConfig;
+    if ( game.user.isGM && context.isGroup && enabled && (!calendarEnabled || !reminder) ) context.fields.unshift({
+      field: new BooleanField({ label: _loc(`DND5E.Bastion.Action.${calendarEnabled ? "Maintain" : "Advance"}`) }),
       input: context.inputs.createCheckboxInput,
       name: "advanceBastionTurn",
       value: context.config.advanceBastionTurn
     });
-
-    return context;
   }
 }

--- a/module/applications/actor/rest/short-rest-dialog.mjs
+++ b/module/applications/actor/rest/short-rest-dialog.mjs
@@ -44,10 +44,6 @@ export default class ShortRestDialog extends BaseRestDialog {
   /** @inheritDoc */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
-    context.autoRoll = new BooleanField({
-      label: _loc("DND5E.REST.HitDice.AutoSpend.Label"),
-      hint: _loc("DND5E.REST.HitDice.AutoSpend.Hint")
-    });
 
     if ( this.actor.system.isNPC ) {
       const hd = this.actor.system.attributes.hd;
@@ -73,18 +69,6 @@ export default class ShortRestDialog extends BaseRestDialog {
         ? this.#denom : context.hitDice.options.find(o => o.number > 0)?.value;
     }
 
-    else {
-      if ( !context.fields.length ) {
-        context.formSections.unshift({ legend: "DND5E.REST.Configuration", fields: context.fields });
-      }
-      context.fields.unshift({
-        field: context.autoRoll,
-        input: context.inputs.createCheckboxInput,
-        name: "autoHD",
-        value: context.config.autoHD
-      });
-    }
-
     const denom = Number(context.hitDice.denomination?.slice(1));
     if ( denom ) {
       const { pct, effectiveMax: max } = this.actor.system.attributes.hp;
@@ -103,6 +87,26 @@ export default class ShortRestDialog extends BaseRestDialog {
     }
 
     return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _prepareFields(context, options) {
+    await super._prepareFields(context, options);
+
+    context.autoRoll = new BooleanField({
+      label: _loc("DND5E.REST.HitDice.AutoSpend.Label"),
+      hint: _loc("DND5E.REST.HitDice.AutoSpend.Hint")
+    });
+
+    if ( this.actor.system.isNPC || foundry.utils.hasProperty(this.actor, "system.attributes.hd") ) return;
+    context.fields.unshift({
+      field: context.autoRoll,
+      input: context.inputs.createCheckboxInput,
+      name: "autoHD",
+      value: context.config.autoHD
+    });
   }
 
   /* -------------------------------------------- */

--- a/module/applications/settings/bastion-settings.mjs
+++ b/module/applications/settings/bastion-settings.mjs
@@ -12,6 +12,8 @@ export default class BastionSettingsConfig extends BaseSettingsConfig {
     }
   };
 
+  /* -------------------------------------------- */
+
   /** @override */
   static PARTS = {
     ...super.PARTS,
@@ -28,9 +30,7 @@ export default class BastionSettingsConfig extends BaseSettingsConfig {
   async _preparePartContext(partId, context, options) {
     context = await super._preparePartContext(partId, context, options);
     context.fields = BastionSetting.schema.fields;
-    context.source = game.settings.get("dnd5e", "bastionConfiguration");
+    context.source = dnd5e.settings.bastionConfiguration._source;
     return context;
   }
 }
-
-export { BastionSetting };

--- a/module/data/calendar/calendar-data.mjs
+++ b/module/data/calendar/calendar-data.mjs
@@ -317,7 +317,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
       return 0;
     };
 
-    const days = CalendarData5e.#dayDifference(previousTime, nowTime);
+    const days = CalendarData5e.dayDifference(previousTime, nowTime);
     foundry.utils.setProperty(options, "dnd5e.deltas", {
       midnights: days,
       middays: days + passedHour(game.time.calendar.days.hoursPerDay / 2),
@@ -409,6 +409,19 @@ export default class CalendarData5e extends foundry.data.CalendarData {
       }
     };
 
+    // Display bastion turn reminder
+    if ( advanceFacilities && bastion.enabled && bastion.reminder ) {
+      const lastBastionTurn = dnd5e.settings.bastionTurns.at(-1);
+      const days = lastBastionTurn !== undefined ? CalendarData5e.dayDifference(
+        game.time.calendar.timeToComponents(lastBastionTurn),
+        game.time.calendar.timeToComponents(game.time.worldTime)
+      ) : Infinity;
+      if ( days >= dnd5e.settings.bastionConfiguration.duration ) {
+        messageConfig.create = true;
+        messageConfig.data.system.bastion = { reminder: true };
+      }
+    }
+
     /**
      * A hook event that fires before a time passed chat message is created.
      * @function dnd5e.preCreateTimePassedMessage
@@ -465,7 +478,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
    * @param {Components} currentTime
    * @returns {number}
    */
-  static #dayDifference(previousTime, currentTime) {
+  static dayDifference(previousTime, currentTime) {
     // If years are the same, simple subtraction should work
     if ( previousTime.year === currentTime.year ) return currentTime.day - previousTime.day;
 

--- a/module/data/calendar/calendar-data.mjs
+++ b/module/data/calendar/calendar-data.mjs
@@ -357,9 +357,10 @@ export default class CalendarData5e extends foundry.data.CalendarData {
 
     const changes = [];
     const rolls = [];
+    let hasBastion = false;
 
     const bastion = dnd5e.settings.bastionConfiguration;
-    const advanceFacilities = timePassageData.midnights > 0;
+    const advanceFacilities = dnd5e.settings.calendarConfig.enabled && (timePassageData.midnights > 0);
     const recoverUses = !dnd5e.settings.calendarConfig.manualRecovery && periods.size;
     if ( advanceFacilities || recoverUses ) {
       const operations = [];
@@ -374,6 +375,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
             duration: timePassageData.midnights, performUpdates: false, summary: "auto", turn: false
           });
           updates.push(...results.updates);
+          hasBastion = true;
         }
 
         // Recover item & activity uses
@@ -410,15 +412,20 @@ export default class CalendarData5e extends foundry.data.CalendarData {
     };
 
     // Display bastion turn reminder
-    if ( advanceFacilities && bastion.enabled && bastion.reminder ) {
+    if ( advanceFacilities && bastion.enabled && bastion.reminder && hasBastion ) {
       const lastBastionTurn = dnd5e.settings.bastionTurns.at(-1);
-      const days = lastBastionTurn !== undefined ? CalendarData5e.dayDifference(
-        game.time.calendar.timeToComponents(lastBastionTurn),
-        game.time.calendar.timeToComponents(game.time.worldTime)
-      ) : Infinity;
-      if ( days >= dnd5e.settings.bastionConfiguration.duration ) {
-        messageConfig.create = true;
-        messageConfig.data.system.bastion = { reminder: true };
+      if ( lastBastionTurn === undefined ) {
+        await game.settings.set("dnd5e", "bastionTurns", [game.time.worldTime]);
+      } else {
+        const days = lastBastionTurn !== undefined ? CalendarData5e.dayDifference(
+          game.time.calendar.timeToComponents(lastBastionTurn),
+          game.time.calendar.timeToComponents(game.time.worldTime)
+        ) : Infinity;
+        const previousDays = days - timePassageData.midnights;
+        if ( Math.floor(days / bastion.duration) > Math.floor(previousDays / bastion.duration) ) {
+          messageConfig.create = true;
+          messageConfig.data.system.bastion = { reminder: true };
+        }
       }
     }
 

--- a/module/data/calendar/calendar-data.mjs
+++ b/module/data/calendar/calendar-data.mjs
@@ -370,7 +370,7 @@ export default class CalendarData5e extends foundry.data.CalendarData {
         const updates = [];
 
         // Advance bastion facilities
-        if ( advanceFacilities && bastion?.availableForActor(actor) && actor.itemTypes.facility.length ) {
+        if ( advanceFacilities && bastion.availableForActor(actor) && actor.itemTypes.facility.length ) {
           const results = await dnd5e.bastion.advanceAllFacilities(actor, {
             duration: timePassageData.midnights, performUpdates: false, summary: "auto", turn: false
           });
@@ -417,10 +417,10 @@ export default class CalendarData5e extends foundry.data.CalendarData {
       if ( lastBastionTurn === undefined ) {
         await game.settings.set("dnd5e", "bastionTurns", [game.time.worldTime]);
       } else {
-        const days = lastBastionTurn !== undefined ? CalendarData5e.dayDifference(
+        const days = CalendarData5e.dayDifference(
           game.time.calendar.timeToComponents(lastBastionTurn),
           game.time.calendar.timeToComponents(game.time.worldTime)
-        ) : Infinity;
+        );
         const previousDays = days - timePassageData.midnights;
         if ( Math.floor(days / bastion.duration) > Math.floor(previousDays / bastion.duration) ) {
           messageConfig.create = true;

--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -230,7 +230,7 @@
 /**
  * @typedef TimePassedMessageSystemData
  * @property {object} [bastion]
- * @property {boolean} [bastion.remind]      Should the bastion turn reminder button be displayed?
+ * @property {boolean} [bastion.reminder]    Should the bastion turn reminder button be displayed?
  * @property {boolean} [bastion.triggered]   The GM has advanced a bastion turn from this card.
  * @property {DocumentDeltasData[]} changes  Item recovery from this time change.
  * @property {number} time                   World time after the time passage.

--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -229,7 +229,11 @@
 
 /**
  * @typedef TimePassedMessageSystemData
+ * @property {object} [bastion]
+ * @property {boolean} [bastion.remind]      Should the bastion turn reminder button be displayed?
+ * @property {boolean} [bastion.triggered]   The GM has advanced a bastion turn from this card.
  * @property {DocumentDeltasData[]} changes  Item recovery from this time change.
+ * @property {number} time                   World time after the time passage.
  */
 
 /**

--- a/module/data/chat-message/time-passed-message-data.mjs
+++ b/module/data/chat-message/time-passed-message-data.mjs
@@ -1,8 +1,10 @@
+import { formatTime } from "../../utils.mjs";
 import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
+import CalendarData5e from "../calendar/calendar-data.mjs";
 import { ActorDeltasField } from "./fields/deltas-field.mjs";
 
 const TextEditor = foundry.applications.ux.TextEditor.implementation;
-const { ArrayField, DocumentUUIDField, SchemaField } = foundry.data.fields;
+const { ArrayField, BooleanField, DocumentUUIDField, NumberField, SchemaField } = foundry.data.fields;
 
 /**
  * @import { TimePassedMessageSystemData } from "./_types.mjs";
@@ -22,10 +24,15 @@ export default class TimePassedMessageData extends ChatMessageDataModel {
   /** @override */
   static defineSchema() {
     return {
+      bastion: new SchemaField({
+        reminder: new BooleanField(),
+        triggered: new BooleanField()
+      }, { required: false, initial: undefined }),
       changes: new ArrayField(new SchemaField({
         deltas: new ActorDeltasField(),
         uuid: new DocumentUUIDField()
-      }))
+      })),
+      time: new NumberField({ initial: () => game.time.worldTime })
     };
   }
 
@@ -33,6 +40,9 @@ export default class TimePassedMessageData extends ChatMessageDataModel {
 
   /** @inheritDoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    actions: {
+      bastionTurn: TimePassedMessageData.#onBastionTurn
+    },
     template: "systems/dnd5e/templates/chat/time-passed-card.hbs"
   }, { inplace: false }));
 
@@ -50,9 +60,26 @@ export default class TimePassedMessageData extends ChatMessageDataModel {
   /** @override */
   async _prepareContext() {
     const context = {
+      bastion: { ...this.bastion },
       content: await TextEditor.enrichHTML(this.parent.content, { rollData: this.parent.getRollData() }),
       deltas: []
     };
+
+    if ( this.bastion?.reminder && game.user.isGM ) {
+      if ( this.bastion.triggered ) {
+        context.bastion.message = _loc("DND5E.Bastion.Reminder.Triggered");
+      } else {
+        const lastBastionTurn = dnd5e.settings.bastionTurns.at(-1);
+        const days = lastBastionTurn !== undefined ? CalendarData5e.dayDifference(
+          game.time.calendar.timeToComponents(lastBastionTurn),
+          game.time.calendar.timeToComponents(this.time)
+        ) : Infinity;
+        if ( days > 0 ) context.bastion.message = _loc(
+          `DND5E.Bastion.Reminder.${Number.isFinite(days) ? "Ellapsed" : "Unknown"}`,
+          { time: formatTime(days, "day") }
+        );
+      }
+    }
 
     for ( const { deltas, uuid } of this.changes ) {
       const actor = fromUuidSync(uuid, { strict: false });
@@ -69,5 +96,19 @@ export default class TimePassedMessageData extends ChatMessageDataModel {
   _onRender(element, options={}) {
     super._onRender(element, options);
     element.classList.add("compact");
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners and Handlers                */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle advancing a bastion turn.
+   * @this {TimePassedMessageData}
+   * @type {ApplicationClickAction}
+   */
+  static async #onBastionTurn(event, target) {
+    if ( await dnd5e.bastion.confirmAdvance() === false ) return;
+    this.parent.update({ "system.bastion.triggered": true });
   }
 }

--- a/module/data/chat-message/time-passed-message-data.mjs
+++ b/module/data/chat-message/time-passed-message-data.mjs
@@ -75,7 +75,7 @@ export default class TimePassedMessageData extends ChatMessageDataModel {
           game.time.calendar.timeToComponents(this.time)
         ) : Infinity;
         if ( days > 0 ) context.bastion.message = _loc(
-          `DND5E.Bastion.Reminder.${Number.isFinite(days) ? "Ellapsed" : "Unknown"}`,
+          `DND5E.Bastion.Reminder.${Number.isFinite(days) ? "Elapsed" : "Unknown"}`,
           { time: formatTime(days, "day") }
         );
       }

--- a/module/data/settings/_types.mjs
+++ b/module/data/settings/_types.mjs
@@ -1,8 +1,9 @@
 /**
  * @typedef BastionSettingData
- * @property {boolean} button   Display the "Advance Bastion Turn" button in the interface for GM users.
- * @property {number} duration  Time between bastion turns in days.
- * @property {boolean} enabled  Display bastion tab on sheets of characters that are 5th level or higher.
+ * @property {boolean} button    Display the "Advance Bastion Turn" button in the interface for GM users.
+ * @property {number} duration   Time between bastion turns in days.
+ * @property {boolean} enabled   Display bastion tab on sheets of characters that are 5th level or higher.
+ * @property {boolean} reminder  Display a reminder for when the next bastion turn should occur.
  */
 
 /* -------------------------------------------- */

--- a/module/data/settings/bastion-setting.mjs
+++ b/module/data/settings/bastion-setting.mjs
@@ -10,18 +10,19 @@ const { BooleanField, NumberField } = foundry.data.fields;
  * @mixes BastionSettingData
  */
 export default class BastionSetting extends foundry.abstract.DataModel {
+
+  /** @override */
+  static LOCALIZATION_PREFIXES = ["DND5E.Bastion"];
+
+  /* -------------------------------------------- */
+
   /** @override */
   static defineSchema() {
     return {
-      button: new BooleanField({
-        required: true, label: "DND5E.Bastion.Button.Label", hint: "DND5E.Bastion.Button.Hint"
-      }),
-      duration: new NumberField({
-        required: true, positive: true, integer: true, initial: 7, label: "DND5E.Bastion.Duration.Label"
-      }),
-      enabled: new BooleanField({
-        required: true, label: "DND5E.Bastion.Enabled.Label", hint: "DND5E.Bastion.Enabled.Hint"
-      })
+      button: new BooleanField({ required: true }),
+      duration: new NumberField({ required: true, positive: true, integer: true, initial: 7 }),
+      enabled: new BooleanField({ required: true }),
+      reminder: new BooleanField({ required: true, initial: true })
     };
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2161,12 +2161,16 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const clone = this.clone();
     const restConfig = CONFIG.DND5E.restTypes[config.type];
     config = foundry.utils.mergeObject({
-      dialog: true, chat: restConfig.chat !== false,
+      dialog: true,
+      chat: restConfig.chat !== false,
       duration: restConfig.duration[game.settings.get("dnd5e", "restVariant")],
       newDay: restConfig.newDay === true,
-      advanceBastionTurn: restConfig.advanceBastionTurn === true, advanceTime: restConfig.advanceTime === true,
-      autoHD: restConfig.autoHD === true, autoHDThreshold: 3,
-      recoverTemp: restConfig.recoverTemp, recoverTempMax: restConfig.recoverTempMax,
+      advanceBastionTurn: restConfig.advanceBastionTurn === true,
+      advanceTime: restConfig.advanceTime === true,
+      autoHD: restConfig.autoHD === true,
+      autoHDThreshold: 3,
+      recoverTemp: restConfig.recoverTemp,
+      recoverTempMax: restConfig.recoverTempMax,
       exhaustionDelta: restConfig.exhaustionDelta
     }, config);
     config.dialogClass ??= restConfig.dialogClass ?? BaseRestDialog;

--- a/module/documents/actor/bastion.mjs
+++ b/module/documents/actor/bastion.mjs
@@ -23,6 +23,7 @@ export default class Bastion {
     const duration = dnd5e.settings.calendarConfig.enabled ? 0 : dnd5e.settings.bastionConfiguration.duration;
     const haveBastions = game.actors.filter(a => a.system.isCharacter && a.itemTypes.facility.length);
     for ( const actor of haveBastions ) await this.advanceAllFacilities(actor, { duration });
+    game.settings.set("dnd5e", "bastionTurns", [...game.settings.get("dnd5e", "bastionTurns"), game.time.worldTime]);
   }
 
   /* -------------------------------------------- */
@@ -256,10 +257,10 @@ export default class Bastion {
 
   /**
    * Confirm the bastion turn should be advanced.
-   * @returns {Promise<void>}
+   * @returns {Promise<boolean>}
    */
   async confirmAdvance() {
-    if ( !game.user.isGM ) return;
+    if ( !game.user.isGM ) return false;
     const mode = dnd5e.settings.calendarConfig.enabled ? "Maintain" : "Advance";
     const proceed = await foundry.applications.api.DialogV2.confirm({
       content: _loc(`DND5E.Bastion.Confirm.${mode}`, {
@@ -268,7 +269,9 @@ export default class Bastion {
       rejectClose: false,
       window: { icon: "fa-solid fa-chess-rook", title: `DND5E.Bastion.Action.${mode}` }
     });
-    if ( proceed ) return this.advanceAllBastions();
+    if ( !proceed ) return false;
+    await this.advanceAllBastions();
+    return true;
   }
 
   /* -------------------------------------------- */
@@ -278,9 +281,9 @@ export default class Bastion {
    */
   initializeUI() {
     const turnButton = document.getElementById("bastion-turn");
-    const { button, enabled } = game.settings.get("dnd5e", "bastionConfiguration");
+    const { button, enabled } = dnd5e.settings.bastionConfiguration;
 
-    if ( !enabled || !button || !game.user.isGM) {
+    if ( !enabled || !button || !game.user.isGM ) {
       turnButton?.remove();
       return;
     }

--- a/module/documents/actor/bastion.mjs
+++ b/module/documents/actor/bastion.mjs
@@ -20,9 +20,8 @@ export default class Bastion {
    * @returns {Promise<void>}
    */
   async advanceAllBastions() {
-    const duration = dnd5e.settings.calendarConfig.enabled ? 0 : dnd5e.settings.bastionConfiguration.duration;
     const haveBastions = game.actors.filter(a => a.system.isCharacter && a.itemTypes.facility.length);
-    for ( const actor of haveBastions ) await this.advanceAllFacilities(actor, { duration });
+    for ( const actor of haveBastions ) await this.advanceAllFacilities(actor);
     game.settings.set("dnd5e", "bastionTurns", [...game.settings.get("dnd5e", "bastionTurns"), game.time.worldTime]);
   }
 
@@ -32,14 +31,15 @@ export default class Bastion {
    * Advance all the facilities of a given Actor by one bastion turn.
    * @param {Actor5e} actor                          The actor.
    * @param {object} [options]
-   * @param {number} [options.duration=7]            The number of days the bastion turn spanned.
+   * @param {number} [options.duration]              The number of days the bastion turn spanned.
    * @param {boolean} [options.performUpdates=true]  Update the actor's facilities.
    * @param {boolean|"auto"} [options.summary=true]  Print a chat message summary of the turn. If set to "auto" then
    *                                                 the message will only be created if an order is completed.
    * @param {boolean} [options.turn=true]            Trigger events like recovery that are tied to turns, not days.
    * @returns {Promise<{ [message]: ChatMessage5e, updates: object[] }>}
    */
-  async advanceAllFacilities(actor, { duration=7, performUpdates=true, summary=true, turn=true }={}) {
+  async advanceAllFacilities(actor, { duration, performUpdates=true, summary=true, turn=true }={}) {
+    duration ??= dnd5e.settings.calendarConfig.enabled ? 0 : dnd5e.settings.bastionConfiguration.duration;
     const results = { orders: [], items: [], gold: 0 };
     const itemUpdates = [];
     for ( const facility of actor.itemTypes.facility ) {

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -12,7 +12,7 @@ import PrimaryPartySetting from "./data/settings/primary-party-setting.mjs";
 import TransformationSetting from "./data/settings/transformation-setting.mjs";
 import * as LEGACY from "./config-legacy.mjs";
 
-const { StringField } = foundry.data.fields;
+const { ArrayField, NumberField, StringField } = foundry.data.fields;
 
 /**
  * Register all of the system's keybindings.
@@ -386,6 +386,13 @@ export function registerSystemSettings() {
       duration: 7
     },
     onChange: () => game.dnd5e.bastion.initializeUI()
+  });
+
+  game.settings.register("dnd5e", "bastionTurns", {
+    name: "Bastion Turns",
+    scope: "world",
+    config: false,
+    type: new ArrayField(new NumberField())
   });
 
   // Calendar Settings

--- a/templates/chat/time-passed-card.hbs
+++ b/templates/chat/time-passed-card.hbs
@@ -1,6 +1,22 @@
 <div class="chat-card time-passed-card">
     {{{ content }}}
 
+    {{!-- Bastions --}}
+    {{#if bastion.message}}
+    <section class="bastion">
+        <strong class="roboto-condensed-upper">{{ localize "DND5E.Bastion.Label" }}</strong>
+        <p>{{ bastion.message }}</p>
+        {{#unless bastion.triggered}}
+        <div class="card-buttons">
+            <button type="button" data-action="bastionTurn">
+                <i class="fa-solid fa-chess-rook" inert></i>
+                <span>{{ localize "DND5E.Bastion.Action.Advance" }}</span>
+            </button>
+        </div>
+        {{/unless}}
+    </section>
+    {{/if}}
+
     {{!-- Deltas --}}
     {{#if deltas.length}}{{> "dnd5e.card-deltas" }}{{/if}}
 </div>

--- a/templates/settings/bastion-config.hbs
+++ b/templates/settings/bastion-config.hbs
@@ -3,13 +3,16 @@
 
     {{!-- Enabled --}}
     {{ formField fields.enabled name="bastionConfiguration.enabled" value=source.enabled
-                 input=inputs.createCheckboxInput localize=true rootId=partId }}
+                 input=inputs.createCheckboxInput rootId=partId }}
 
     {{!-- Button --}}
     {{ formField fields.button name="bastionConfiguration.button" value=source.button input=inputs.createCheckboxInput
-                 localize=true rootId=partId }}
+                 rootId=partId }}
 
     {{!-- Duration --}}
-    {{ formField fields.duration name="bastionConfiguration.duration" value=source.duration localize=true
-                 rootId=partId }}
+    {{ formField fields.duration name="bastionConfiguration.duration" value=source.duration rootId=partId }}
+
+    {{!-- Reminder --}}
+    {{ formField fields.reminder name="bastionConfiguration.reminder" value=source.reminder
+                 input=inputs.createCheckboxInput rootId=partId }}
 </fieldset>


### PR DESCRIPTION
Keeps track of when each bastion turn occurs and if more time has passed than the bastion turn duration this will display a message in chat indicating how much time has passed with a button to advance the bastion turn. This means the permanent bastion button is no longer required when using the calendar.

<img width="308" height="211" alt="Time Passage Bastion Turn" src="https://github.com/user-attachments/assets/54121b81-0c31-49c8-8be3-a5ae0e161f2a" />

A new settings `bastionTurns` has been added that logs the world time for each bastion turn. `CalendarData5e#handleTimePassage` is then responsible for checking this if a new day has occured and checking on if a reminde is required.

The turn passed message keeps track of whether a reminder is required and whether a turn has been triggered from that card.

Closes #5647