### PR TITLE
[#6671] Add conditions to active effects and changes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2608,6 +2608,10 @@
     "FIELDS": {
       "changes": {
         "element": {
+          "conditions": {
+            "hint": "Condition that must be met for this change to apply.",
+            "label": "Change Conditions"
+          },
           "key": {
             "label": "Attribute Key"
           },
@@ -2625,6 +2629,10 @@
             "label": "Value"
           }
         }
+      },
+      "conditions": {
+        "hint": "Conditions that control when the effect will be applied.",
+        "label": "Effect Conditions"
       },
       "magical": {
         "hint": "This effect is from a magical source and should be disabled when magic isn't available.",

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -1,4 +1,5 @@
 import { getHumanReadableAttributeLabel } from "../../utils.mjs";
+import FiltersField from "../fields/filters-field.mjs";
 
 const { DocumentIdField } = foundry.data.fields;
 
@@ -15,7 +16,8 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
   static defineSchema() {
     const schema = super.defineSchema();
     schema.changes.element.extendFields({
-      _id: new DocumentIdField({ initial: () => foundry.utils.randomID() })
+      _id: new DocumentIdField({ initial: () => foundry.utils.randomID() }),
+      conditions: new FiltersField()
     });
     return schema;
   }
@@ -50,6 +52,16 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
    * @type {boolean}
    */
   get isConcealed() {
+    return false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is there some system logic that makes this Active Effect ineligible for application?
+   * @type {boolean}
+   */
+  get isSuppressed() {
     return false;
   }
 

--- a/module/data/active-effect/base.mjs
+++ b/module/data/active-effect/base.mjs
@@ -1,4 +1,5 @@
 import ActiveEffectDataModel from "../abstract/active-effect-data-model.mjs";
+import FiltersField from "../fields/filters-field.mjs";
 
 const { BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
 
@@ -25,6 +26,7 @@ export default class BaseEffectData extends ActiveEffectDataModel {
   static defineSchema() {
     return {
       ...super.defineSchema(),
+      conditions: new FiltersField(),
       magical: new BooleanField(),
       rider: new SchemaField({
         statuses: new SetField(new StringField())

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -226,6 +226,8 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     // Apply shims to moved fields
     change = change.effect._applyChangeShim(change);
 
+    if ( !change.effect.shouldApplyChange(change, options.replacementData) ) return {};
+
     // Handle special actor flags
     if ( change.key.startsWith("flags.dnd5e.") ) change = change.effect._prepareFlagChange(model, change);
 
@@ -388,21 +390,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     return super._applyChangeUpgrade(actor, change, current, delta, changes);
   }
 
-  /* -------------------------------------------- */
-
-  /**
-   * Evaluate the conditions to see if the effect or change should be applied.
-   * @param {Filter} [conditions]  Filter definition to evaluate.
-   * @returns {boolean}
-   */
-  evaluateConditions(conditions) {
-    if ( !conditions ) return true;
-    const rollData = (this.system.applicableType === "Actor") && this.actor
-      ? this.actor.getRollData({ deterministic: true })
-      : this.item.getRollData({ deterministic: true });
-    return conditions.check(rollData);
-  }
-
   /* --------------------------------------------- */
 
   /**
@@ -439,22 +426,18 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /**
    * Determine whether a specific change should be applied during this phase, setting `applied` if approved.
    * @param {object} change           Change that might be applied.
-   * @param {object} [options={}]
-   * @param {string} [options.phase]  Active effect phase being checked.
+   * @param {object} [conditionData]  Data used to evaluate conditions.
    * @returns {boolean}
    */
-  shouldApplyChange(change, { phase }={}) {
-    // TODO: Adapt when core implements https://github.com/foundryvtt/foundryvtt/issues/13931, if it does
-    if ( change.phase !== phase ) return false;
-
-    const targetDoc = this.applicableType === "Actor" ? this.actor : this.applicableType === "Item" ? this.item : null;
-    const conditionData = targetDoc?.getRollData?.();
+  shouldApplyChange(change, conditionData) {
     if ( conditionData ) {
-      if ( change.effect.system.conditions?.check(conditionData) === false ) return false;
+      if ( this.system.conditions?.check(conditionData) === false ) return false;
       if ( change.conditions?.check(conditionData) === false ) return false;
     }
 
-    change.applied = true;
+    const originalChange = this.system.changes.find(c => c._id === change._id);
+    if ( originalChange ) originalChange.applied = true;
+
     return true;
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -226,7 +226,8 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     // Apply shims to moved fields
     change = change.effect._applyChangeShim(change);
 
-    if ( !change.effect.shouldApplyChange(change, options.replacementData) ) return {};
+    if ( (model instanceof foundry.abstract.Document)
+      && !change.effect._checkCondition(change, options.replacementData) ) return {};
 
     // Handle special actor flags
     if ( change.key.startsWith("flags.dnd5e.") ) change = change.effect._prepareFlagChange(model, change);
@@ -428,8 +429,9 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @param {object} change           Change that might be applied.
    * @param {object} [conditionData]  Data used to evaluate conditions.
    * @returns {boolean}
+   * @internal
    */
-  shouldApplyChange(change, conditionData) {
+  _checkCondition(change, conditionData) {
     if ( conditionData ) {
       if ( this.system.conditions?.check(conditionData) === false ) return false;
       if ( change.conditions?.check(conditionData) === false ) return false;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -129,7 +129,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /** @inheritDoc */
   get isSuppressed() {
-    if ( super.isSuppressed ) return true;
+    if ( super.isSuppressed || this.system.isSuppressed ) return true;
     if ( this.system.magical && this.actor?.statuses.has("antimagic") ) return true;
     if ( this.type === "enchantment" ) return false;
     if ( this.type === "condition" ) return false;
@@ -388,6 +388,21 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     return super._applyChangeUpgrade(actor, change, current, delta, changes);
   }
 
+  /* -------------------------------------------- */
+
+  /**
+   * Evaluate the conditions to see if the effect or change should be applied.
+   * @param {Filter} [conditions]  Filter definition to evaluate.
+   * @returns {boolean}
+   */
+  evaluateConditions(conditions) {
+    if ( !conditions ) return true;
+    const rollData = (this.system.applicableType === "Actor") && this.actor
+      ? this.actor.getRollData({ deterministic: true })
+      : this.item.getRollData({ deterministic: true });
+    return conditions.check(rollData);
+  }
+
   /* --------------------------------------------- */
 
   /**
@@ -417,6 +432,24 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       else change.value = Boolean(value);
     }
     return change;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  shouldApplyChange(change, { phase }={}) {
+    // TODO: Adapt when core implements https://github.com/foundryvtt/foundryvtt/issues/13931, if it does
+    if ( change.phase !== phase ) return false;
+
+    const targetDoc = this.applicableType === "Actor" ? this.actor : this.applicableType === "Item" ? this.item : null;
+    const conditionData = targetDoc?.getRollData?.();
+    if ( conditionData ) {
+      if ( change.effect.system.conditions?.check(conditionData) === false ) return false;
+      if ( change.conditions?.check(conditionData) === false ) return false;
+    }
+
+    change.applied = true;
+    return true;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -436,7 +436,13 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /* -------------------------------------------- */
 
-  /** @inheritDoc */
+  /**
+   * Determine whether a specific change should be applied during this phase, setting `applied` if approved.
+   * @param {object} change           Change that might be applied.
+   * @param {object} [options={}]
+   * @param {string} [options.phase]  Active effect phase being checked.
+   * @returns {boolean}
+   */
   shouldApplyChange(change, { phase }={}) {
     // TODO: Adapt when core implements https://github.com/foundryvtt/foundryvtt/issues/13931, if it does
     if ( change.phase !== phase ) return false;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -366,25 +366,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       this.system.prepareEmbeddedData();
     }
 
-    const ActiveEffect = foundry.documents.ActiveEffect.implementation;
-    if ( typeof phase !== "string" ) {
-      phase = this._completedActiveEffectPhases.has("initial") ? "final" : "initial";
-      const message = 'Actor#applyActiveEffects must be called with a string phase identifier, with "initial"'
-        + " as the first phase.";
-      foundry.utils.logCompatibilityWarning(message, {since: 14, until: 16, once: true});
-    }
-    else if ( !(phase in ActiveEffect.CHANGE_PHASES) ) {
-      const error = new Error(`"${phase}" is not a registered ActiveEffect application phase.`);
-      Hooks.onError("Actor#applyActiveEffects", error, {log: "error"});
-    }
-    if ( this._completedActiveEffectPhases.has(phase) ) {
-      const error = new Error(`ActiveEffect application phase "${phase}" has already completed and cannot be run again`
-        + " in this Actor's data-preparation cycle.");
-      Hooks.onError("Actor#applyActiveEffects", error, {log: "error"});
-      return;
-    }
-    this._completedActiveEffectPhases.add(phase);
-
     // Pre-collect statuses so they can be reliably used for conditions
     if ( phase === "initial" ) {
       for ( const effect of this.allApplicableEffects() ) {
@@ -392,38 +373,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       }
     }
 
-    // Organize non-disabled effects by their application priority
-    /** @type {ActiveEffectChangeData[]} */
-    const changes = [];
-    /** @type {ActiveEffectChangeData[]} */
-    const tokenChanges = [];
-    for ( const effect of this.allApplicableEffects() ) {
-      if ( !effect.active ) continue;
-      for ( const change of effect.system.changes ) {
-        if ( (change.key === "") || !effect.shouldApplyChange(change, { phase }) ) continue;
-        const copy = foundry.utils.deepClone(change);
-        copy.effect = effect;
-        if ( copy.key?.startsWith("token.") ) { // Keep Token changes separate for later application
-          copy.key = copy.key.slice(6);
-          tokenChanges.push(copy);
-        }
-        else changes.push(copy);
-      }
-    }
-    changes.sort((a, b) => a.priority - b.priority);
-    ActiveEffect._shimChanges(changes);
-    this.tokenActiveEffectChanges[phase] = tokenChanges;
-
-    // Apply all changes
-    const overrides = {};
-    const replacementData = this.getRollData();
-    for ( const change of changes ) {
-      const result = ActiveEffect.applyChange(this, change, {replacementData});
-      if ( foundry.utils.isPlainObject(result) ) Object.assign(overrides, result);
-    }
-
-    // Expand the set of final overrides
-    foundry.utils.mergeObject(this.overrides, foundry.utils.expandObject(overrides));
+    return super.applyActiveEffects(phase);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -365,7 +365,65 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( (this.system?.prepareEmbeddedData instanceof Function) && (phase === "initial") ) {
       this.system.prepareEmbeddedData();
     }
-    return super.applyActiveEffects(phase);
+
+    const ActiveEffect = foundry.documents.ActiveEffect.implementation;
+    if ( typeof phase !== "string" ) {
+      phase = this._completedActiveEffectPhases.has("initial") ? "final" : "initial";
+      const message = 'Actor#applyActiveEffects must be called with a string phase identifier, with "initial"'
+        + " as the first phase.";
+      foundry.utils.logCompatibilityWarning(message, {since: 14, until: 16, once: true});
+    }
+    else if ( !(phase in ActiveEffect.CHANGE_PHASES) ) {
+      const error = new Error(`"${phase}" is not a registered ActiveEffect application phase.`);
+      Hooks.onError("Actor#applyActiveEffects", error, {log: "error"});
+    }
+    if ( this._completedActiveEffectPhases.has(phase) ) {
+      const error = new Error(`ActiveEffect application phase "${phase}" has already completed and cannot be run again`
+        + " in this Actor's data-preparation cycle.");
+      Hooks.onError("Actor#applyActiveEffects", error, {log: "error"});
+      return;
+    }
+    this._completedActiveEffectPhases.add(phase);
+
+    // Pre-collect statuses so they can be reliably used for conditions
+    if ( phase === "initial" ) {
+      for ( const effect of this.allApplicableEffects() ) {
+        if ( effect.active ) for ( const statusId of effect.statuses ) this.statuses.add(statusId);
+      }
+    }
+
+    // Organize non-disabled effects by their application priority
+    /** @type {ActiveEffectChangeData[]} */
+    const changes = [];
+    /** @type {ActiveEffectChangeData[]} */
+    const tokenChanges = [];
+    for ( const effect of this.allApplicableEffects() ) {
+      if ( !effect.active ) continue;
+      for ( const change of effect.system.changes ) {
+        if ( (change.key === "") || !effect.shouldApplyChange(change, { phase }) ) continue;
+        const copy = foundry.utils.deepClone(change);
+        copy.effect = effect;
+        if ( copy.key?.startsWith("token.") ) { // Keep Token changes separate for later application
+          copy.key = copy.key.slice(6);
+          tokenChanges.push(copy);
+        }
+        else changes.push(copy);
+      }
+    }
+    changes.sort((a, b) => a.priority - b.priority);
+    ActiveEffect._shimChanges(changes);
+    this.tokenActiveEffectChanges[phase] = tokenChanges;
+
+    // Apply all changes
+    const overrides = {};
+    const replacementData = this.getRollData();
+    for ( const change of changes ) {
+      const result = ActiveEffect.applyChange(this, change, {replacementData});
+      if ( foundry.utils.isPlainObject(result) ) Object.assign(overrides, result);
+    }
+
+    // Expand the set of final overrides
+    foundry.utils.mergeObject(this.overrides, foundry.utils.expandObject(overrides));
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -474,7 +474,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     for ( const effect of this.allApplicableEffects() ) {
       if ( !effect.active ) continue;
       for ( const change of effect.system.changes ) {
-        if ( (change.key === "") || !effect.shouldApplyChange(change) ) continue;
+        if ( change.key === "" ) continue;
         const copy = foundry.utils.deepClone(change);
         copy.effect = effect;
         changes.push(copy);
@@ -487,7 +487,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const overrides = {};
     const replacementData = this.getRollData();
     for ( const change of changes ) {
-      const result = ActiveEffect.CHANGE_TYPES[change.type].handler?.(this, change)
+      const result = ActiveEffect.CHANGE_TYPES[change.type]?.handler?.(this, change)
         ?? change.effect.constructor.applyChange(this, change, { replacementData });
       if ( foundry.utils.isPlainObject(result) ) Object.assign(overrides, result);
     }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -473,12 +473,12 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const changes = [];
     for ( const effect of this.allApplicableEffects() ) {
       if ( !effect.active ) continue;
-      changes.push(...effect.changes.map(change => {
-        const c = foundry.utils.deepClone(change);
-        c.effect = effect;
-        c.priority ??= c.mode * 10;
-        return c;
-      }));
+      for ( const change of effect.system.changes ) {
+        if ( (change.key === "") || !effect.shouldApplyChange(change) ) continue;
+        const copy = foundry.utils.deepClone(change);
+        copy.effect = effect;
+        changes.push(copy);
+      }
     }
     changes.sort((a, b) => a.priority - b.priority);
     foundry.documents.ActiveEffect._shimChanges?.(changes);
@@ -487,9 +487,9 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const overrides = {};
     const replacementData = this.getRollData();
     for ( const change of changes ) {
-      if ( !change.key ) continue;
-      const changes = change.effect.constructor.applyChange(this, change, { replacementData });
-      Object.assign(overrides, changes);
+      const result = ActiveEffect.CHANGE_TYPES[change.type].handler?.(this, change)
+        ?? change.effect.constructor.applyChange(this, change, { replacementData });
+      if ( foundry.utils.isPlainObject(result) ) Object.assign(overrides, result);
     }
 
     // Expand the set of final overrides

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -487,8 +487,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const overrides = {};
     const replacementData = this.getRollData();
     for ( const change of changes ) {
-      const result = ActiveEffect.CHANGE_TYPES[change.type]?.handler?.(this, change)
-        ?? change.effect.constructor.applyChange(this, change, { replacementData });
+      const result = change.effect.constructor.applyChange(this, change, { replacementData });
       if ( foundry.utils.isPlainObject(result) ) Object.assign(overrides, result);
     }
 

--- a/module/filter.mjs
+++ b/module/filter.mjs
@@ -21,44 +21,22 @@ export class Filter {
   #definition;
 
   /* -------------------------------------------- */
-
-  /**
-   * Cached result of the filter check.
-   * @type {boolean}
-   */
-  #result;
-
-  /* -------------------------------------------- */
   /*  Methods                                     */
   /* -------------------------------------------- */
 
   /**
-   * Check some data against the filter to determine if it matches. Result will be cached between multiple calls.
+   * Check some data against the filter to determine if it matches.
    * @param {object} data  Arbitrary data object to check.
    * @returns {boolean}
    */
   check(data) {
-    if ( this.#result !== undefined ) return this.#result;
     try {
-      if ( foundry.utils.isEmpty(this.#definition) ) this.#result = true;
-      else this.#result = performCheck(data, this.#definition);
-      return this.#result;
+      if ( foundry.utils.isEmpty(this.#definition) ) return true;
+      else return performCheck(data, this.#definition);
     } catch(err) {
       console.error(err);
       return false;
     }
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Clear the cached result of the filter check and perform the check again.
-   * @param {object} data  Arbitrary data object to check.
-   * @returns {boolean}
-   */
-  recheck(data) {
-    this.#result = undefined;
-    return this.check(data);
   }
 }
 

--- a/templates/effects/change-config.hbs
+++ b/templates/effects/change-config.hbs
@@ -6,4 +6,7 @@
     {{ formField fields.value name=(concat prefix "value") value=source.value elementType="input" rootId=partId }}
     {{ formField fields.priority name=(concat prefix "priority") value=source.priority
                  placeholder=defaultPriority rootId=partId }}
+    {{#if fields.conditions}}
+    {{ formField fields.conditions name=(concat prefix "conditions") value=source.conditions rootId=partId }}
+    {{/if}}
 </fieldset>

--- a/templates/effects/columns/controls.hbs
+++ b/templates/effects/columns/controls.hbs
@@ -39,9 +39,8 @@
     {{else if isChange}}
 
     <span class="application-status">
-        <!-- TODO: Change this to checking `entry.applied` once conditions are merged -->
-        <i class="fa-solid fa-{{ ifThen effect.active 'check' 'xmark' }}"
-           aria-label="{{ localize (concat 'DND5E.EFFECT.Status.Change' (ifThen effect.active 'Active' 'Inactive')) }}"></i>
+        <i class="fa-solid fa-{{ ifThen ctx.applied 'check' 'xmark' }}"
+           aria-label="{{ localize (concat 'DND5E.EFFECT.Status.Change' (ifThen ctx.applied 'Active' 'Inactive')) }}"></i>
     </span>
 
     {{/if}}

--- a/templates/effects/effect-details.hbs
+++ b/templates/effects/effect-details.hbs
@@ -3,6 +3,10 @@
     {{ formGroup fields.description value=source.description rootId=rootId }}
     {{ formGroup fields.disabled value=source.disabled input=inputs.createCheckboxInput rootId=rootId }}
 
+    {{#if systemFields.conditions}}
+    {{ formGroup systemFields.conditions value=source.system.conditions rootId=partId }}
+    {{/if}}
+
     {{#if isActorEffect}}
     {{ formGroup fields.origin value=source.origin rootId=rootId disabled=true }}
     {{else if isItemEffect}}


### PR DESCRIPTION
Adds the ability to define conditions to both active effects and individual changes. These changes are specified using the filters system which is evaluated before the change is appplied. These conditions don't cause the whole effect to become suppressed, but instead each individual change is skipped which will be marked on the sheet once the AE breakdown is integrated.

<img width="665" height="913" alt="Active Effect Conditions" src="https://github.com/user-attachments/assets/f0c406e7-46cd-44d1-9d43-bdbe375f6ecd" />

This re-implements the `Actor#applyActiveEffects` method from core completely to add two new pieces of functionality. First, applying status effects to the actor is done in its own pass just before the `initial` phase. This makes conditions based on status effects work reliably and not order dependant. This also calls a new method `ActiveEffect5e#shouldApplyChange` which is where the conditions are evaluated. This is done here rather than in `applyChange` so that an `applied` boolean can be added to changes to be used on the sheet (before the change is cloned).

Closes #6671