### PR TITLE
Unify drop area styles. Add document-tags drop-area styles.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -649,6 +649,7 @@
       "AddChange": "Add Change",
       "DeleteChange": "Delete Change"
     },
+    "DropHint": "Drop an Enchantment here",
     "Empty": {
       "WithDropdown": "No changes. Use the <i class=\"fa-solid fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",
       "WithoutDropdown": "No changes. Use the <i class=\"fa-solid fa-plus\"></i> button above to create one."
@@ -2448,7 +2449,8 @@
       }
     }
   },
-  "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, select an existing effect from the drop-down, or drop one from a compendium.",
+  "DropHint": "Drop an Active Effect here",
+  "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",
   "Label": "Available Effects",
   "RIDER": {
     "Activity": "Enchantment Rider Activity",

--- a/less/v2/activities.less
+++ b/less/v2/activities.less
@@ -58,11 +58,6 @@
       line-height: normal;
     }
     .name { flex: 1 0 175px; }
-    .drop-area {
-      border: var(--dnd5e-border-dashed);
-      border-radius: 4px;
-      padding-inline: 4px;
-    }
     .gold-icon {
       --icon-size: 24px;
       --icon-fill: var(--activity-icon-color);
@@ -111,19 +106,13 @@
 /* ----------------------------------------- */
 
 :is(.summon-activity, .transform-activity).sheet .separated-list:not(.effects-list) {
-  .content-link, .drop-area, .name {
+  .content-link, .name {
     display: flex;
     align-items: center;
     align-content: center;
   }
 
-  .drop-area {
-    justify-content: center;
-    font-size: var(--font-size-11);
-    font-style: italic;
-    height: var(--form-field-height);
-    color: var(--color-text-secondary);
-  }
+  .drop-area { height: var(--form-field-height); }
 
   .content-link {
     height: var(--form-field-height);

--- a/less/v2/advancement.less
+++ b/less/v2/advancement.less
@@ -26,11 +26,6 @@
   }
 
   .centered { text-align: center; }
-  .drop-area {
-    border: 1px dashed var(--color-border-light-2);
-    border-radius: 4px;
-    padding: 4px;
-  }
   .hint.warning {
     color: var(--dnd5e-color-maroon);
     font-weight: bold;

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -711,14 +711,13 @@
 
   .drop-area {
     &.drop-area-lg {
-      border: var(--pill-empty-border);
-      color: var(--pill-empty-text-color);
-      border-radius: 4px;
-      display: grid;
-      place-content: center;
-      opacity: .5;
       background: var(--dnd5e-background-card);
+      border: var(--pill-empty-border);
       box-shadow: 0 0 12px var(--dnd5e-shadow-15);
+      color: var(--pill-empty-text-color);
+      font-size: inherit;
+      font-style: normal;
+      opacity: .5;
       padding-block: 16px;
     }
 

--- a/less/v2/blocks.less
+++ b/less/v2/blocks.less
@@ -3,6 +3,18 @@
 /* ------------------------------------------- */
 :is(.dnd5e, .dnd5e2, .dnd5e2-journal) {
 
+  .drop-area {
+    border: var(--dnd5e-border-dashed);
+    border-radius: 4px;
+    color: var(--color-text-secondary);
+    display: grid;
+    font-size: var(--font-size-11);
+    font-style: italic;
+    padding: 6px;
+    place-content: center;
+    text-align: center;
+  }
+
   /* Positioning */
   .float-left {
     float: left;

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -728,17 +728,19 @@
 /*  Enchantment                       */
 /* ---------------------------------- */
 
-enchantment-application {
+enchantment-application.dnd5e2 {
   margin: 4px;
 
   .drop-area {
-    display: grid;
+    background: var(--dnd5e-color-card);
+    border: 1px dashed var(--dnd5e-color-crimson);
+    color: inherit;
+    font-size: inherit;
+    font-style: normal;
     gap: 4px;
     min-block-size: 40px;
-    border: 1px dashed var(--dnd5e-color-crimson);
-    border-radius: 4px;
-    padding: 4px;
-    background: var(--dnd5e-color-card);
+    place-content: normal;
+    text-align: start;
 
     p {
       place-content: center;

--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -521,6 +521,7 @@
         }
       }
     }
+    &:disabled > .input-group { background: var(--input-disabled-background-color); }
   }
 
   :is(.form-group, fieldset) :is(select, input):not([type="range"]) {
@@ -569,6 +570,14 @@
   :is(file-picker, document-tags, string-tags) > button {
     height: var(--form-field-height);
     border: var(--dnd5e-border-gold);
+  }
+
+  document-tags.drop-area {
+    margin-block-start: 4px;
+    min-block-size: var(--form-field-height);
+    padding-block: 8px;
+    > .input-group { display: none; }
+    &::after { content: attr(data-drop-hint); }
   }
 
   /* Numeric Range Fields */

--- a/less/v2/items.less
+++ b/less/v2/items.less
@@ -593,16 +593,9 @@
       &:hover, &:focus-visible { text-shadow: 0 0 5px var(--color-shadow-primary); }
     }
     [name$=".count"] { flex: 0 0 3em; }
-    .content-link, .drop-area {
+    .content-link {
       display: flex;
       align-items: center;
-    }
-    .drop-area {
-      border: 1px dashed var(--color-border-light-2);
-      border-radius: 4px;
-      padding: 6px;
-      font-size: var(--font-size-11);
-      color: var(--color-text-secondary);
     }
     .require-proficiency {
       flex: 0.66;

--- a/templates/activity/parts/activity-effects.hbs
+++ b/templates/activity/parts/activity-effects.hbs
@@ -7,7 +7,6 @@
         </button>
     </legend>
     <multi-select name="appliedLocalEffects" class="hidden-tags">{{ selectOptions allEffects }}</multi-select>
-    <document-tags name="appliedRemoteEffects" class="hidden-tags" type="ActiveEffect"></document-tags>
     <ul class="separated-list effects-list flexcol unlist">
         {{#each appliedEffects}}
         <li data-index="{{ @index }}" data-profile-id="{{ data._id }}" data-effect-id="{{ effect.id }}"
@@ -20,6 +19,8 @@
         </li>
         {{/each}}
     </ul>
+    <document-tags name="appliedRemoteEffects" class="hidden-tags drop-area" type="ActiveEffect"
+                   data-drop-hint="{{ localize (ifThen labels.drop labels.drop "DND5E.EFFECT.DropHint") }}"></document-tags>
 </fieldset>
 
 {{#*inline ".effect"}}

--- a/templates/advancement/item-choice-config-items.hbs
+++ b/templates/advancement/item-choice-config-items.hbs
@@ -40,6 +40,6 @@
         {{#if showContainerWarning}}
         <p class="hint centered warning">{{ localize "DND5E.ADVANCEMENT.ItemGrant.Warning.Container" }}</p>
         {{/if}}
-        <p class="hint centered drop-area">{{ localize "DND5E.ADVANCEMENT.ItemChoice.DropHint" }}</p>
+        <p class="hint drop-area">{{ localize "DND5E.ADVANCEMENT.ItemChoice.DropHint" }}</p>
     </div>
 </fieldset>

--- a/templates/advancement/item-grant-config-items.hbs
+++ b/templates/advancement/item-grant-config-items.hbs
@@ -45,6 +45,6 @@
         {{#if showContainerWarning}}
         <p class="hint centered warning">{{ localize "DND5E.ADVANCEMENT.ItemGrant.Warning.Container" }}</p>
         {{/if}}
-        <p class="hint centered drop-area">{{ localize "DND5E.ADVANCEMENT.ItemGrant.DropHint" }}</p>
+        <p class="hint drop-area">{{ localize "DND5E.ADVANCEMENT.ItemGrant.DropHint" }}</p>
     </div>
 </fieldset>

--- a/templates/advancement/modify-item-config-changes.hbs
+++ b/templates/advancement/modify-item-config-changes.hbs
@@ -9,7 +9,6 @@
     {{#if hasEffectsTab}}
     <multi-select name="selectedLocalEffects" class="hidden-tags">{{ selectOptions allEnchantments }}</multi-select>
     {{/if}}
-    <document-tags name="selectedRemoteEffects" class="hidden-tags" type="ActiveEffect"></document-tags>
     <ul class="separated-list effects-list flexcol unlist">
         {{#each changes}}
         <li class="flexcol" data-index="{{ @index }}" data-profile-id="{{ data._id }}" data-effect-id="{{ effect.id }}">
@@ -21,6 +20,8 @@
         </li>
         {{/each}}
     </ul>
+    <document-tags name="selectedRemoteEffects" class="hidden-tags drop-area" type="ActiveEffect"
+                   data-drop-hint="{{ localize "DND5E.ADVANCEMENT.ModifyItem.DropHint" }}"></document-tags>
 </fieldset>
 
 {{#*inline ".change"}}


### PR DESCRIPTION
Thought for our `.hidden-tags` `<document-tags>` we could style them as drop areas since that's what we mainly use them for. We lose the ability to type or copy-paste a UUID manually but I don't know if that was really being used. Thought I would run it by you first anyway.

<img width="713" height="238" alt="image" src="https://github.com/user-attachments/assets/ea638330-4f5f-4fbc-a9b4-b8c419d69560" />
