### PR TITLE
[#6315] Add base system for applied rules, attack bonus rule

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -61,7 +61,6 @@ Hooks.once("init", function() {
   // Record Configuration Values
   CONFIG.DND5E = DND5E;
   CONFIG.ActiveEffect.documentClass = documents.ActiveEffect5e;
-  CONFIG.ActiveEffect.legacyTransferral = false;
   CONFIG.Actor.collection = dataModels.collection.Actors5e;
   CONFIG.Actor.documentClass = documents.Actor5e;
   CONFIG.Adventure.documentClass = documents.Adventure5e;
@@ -125,6 +124,7 @@ Hooks.once("init", function() {
   CONFIG.Dice.rolls = [dice.BasicRoll, dice.D20Roll, dice.DamageRoll];
 
   // Hook up system data types
+  Object.assign(CONFIG.ActiveEffect.changeTypes, DND5E.activeEffectChangeTypes);
   Object.assign(CONFIG.ActiveEffect.dataModels, dataModels.activeEffect.config);
   CONFIG.Actor.dataModels = dataModels.actor.config;
   CONFIG.ChatMessage.dataModels = dataModels.chatMessage.config;

--- a/lang/en.json
+++ b/lang/en.json
@@ -290,6 +290,11 @@
 
 "DND5E.ACTIVEEFFECT": {
   "AttributeKeyTooltip": "For a list of common keys and their accepted values, see <a href=\"{url}\">the wiki</a>.",
+  "ChangeType": {
+    "Bonus": {
+      "Label": "Rule: Bonus"
+    }
+  },
   "Expired": "Expired",
   "Expiry": {
     "GROUPS": {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -9,6 +9,7 @@ import { CalendarHarptos, CALENDAR_OF_HARPTOS } from "./data/calendar/calendar-o
 import { CalendarKhorvaire, CALENDAR_OF_KHORVAIRE } from "./data/calendar/calendar-of-khorvaire.mjs";
 import MappingField from "./data/fields/mapping-field.mjs";
 import * as regionBehaviors from "./data/region-behavior/_module.mjs";
+import ActiveEffect5e from "./documents/active-effect.mjs";
 import * as activities from "./documents/activity/_module.mjs";
 import Actor5e from "./documents/actor/actor.mjs";
 import * as advancement from "./documents/advancement/_module.mjs";
@@ -3897,6 +3898,21 @@ DND5E.bloodied = {
   img: "systems/dnd5e/icons/svg/statuses/bloodied.svg",
   threshold: 50
 };
+
+/* -------------------------------------------- */
+
+/**
+ * System provided active effect change types.
+ * @enum {ActiveEffectChangeTypeConfig & { [skipConditions]: boolean }}
+ */
+DND5E.activeEffectChangeTypes = Object.freeze({
+  "dnd5e.bonus": {
+    label: "DND5E.ACTIVEEFFECT.ChangeType.Bonus.Label",
+    defaultPriority: 100,
+    handler: ActiveEffect5e._applyChangeRule,
+    skipConditions: true
+  }
+});
 
 /* -------------------------------------------- */
 /*  Languages                                   */

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -258,7 +258,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
    * @returns {{ data: object, parts: string[] }}
    */
   getAttackData({ ammunition, attackMode, situational }={}) {
-    const rollData = Object.assign(this.getRollData(), { roll: { attackMode } });
+    const rollData = this.getRollData({ data: { roll: { attack: { mode: attackMode } } } });
     if ( this.attack.flat ) return CONFIG.Dice.BasicRoll.constructParts({ toHit: this.attack.bonus }, rollData);
 
     const weapon = this.item.system;
@@ -365,6 +365,20 @@ export default class BaseAttackActivityData extends BaseActivityData {
     }
 
     return game.i18n.getListFormatter({ type: "disjunction" }).format(parts.filter(_ => _));
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  getRollData(options={}) {
+    const rollData = super.getRollData(options);
+    if ( rollData.roll ) {
+      rollData.roll.attack ??= {};
+      rollData.roll.attack.classification = this.attack.type.classification;
+      rollData.roll.attack.type = rollData.roll.attack.mode?.includes("thrown") ? "ranged" : this.attack.type.value;
+      rollData.roll.type = "attack";
+    }
+    return rollData;
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -258,7 +258,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
    * @returns {{ data: object, parts: string[] }}
    */
   getAttackData({ ammunition, attackMode, situational }={}) {
-    const rollData = this.getRollData({ roll: { attackMode } });
+    const rollData = Object.assign(this.getRollData(), { roll: { attackMode } });
     if ( this.attack.flat ) return CONFIG.Dice.BasicRoll.constructParts({ toHit: this.attack.bonus }, rollData);
 
     const weapon = this.item.system;

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -1,4 +1,5 @@
 import simplifyRollFormula from "../../dice/simplify-roll-formula.mjs";
+import AppliedRules from "../../documents/applied-rules.mjs";
 import { convertLength, formatLength, formatNumber, simplifyBonus } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import DamageField from "../shared/damage-field.mjs";
@@ -257,7 +258,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
    * @returns {{ data: object, parts: string[] }}
    */
   getAttackData({ ammunition, attackMode, situational }={}) {
-    const rollData = this.getRollData();
+    const rollData = this.getRollData({ roll: { attackMode } });
     if ( this.attack.flat ) return CONFIG.Dice.BasicRoll.constructParts({ toHit: this.attack.bonus }, rollData);
 
     const weapon = this.item.system;
@@ -269,6 +270,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
       weaponMagic: weapon.magicAvailable ? weapon.magicalBonus : null,
       ammoMagic: ammo?.magicAvailable ? ammo.magicalBonus : null,
       actorBonus: this.actor?.system.bonuses?.[this.getActionType(attackMode)]?.attack,
+      ruleBonus: AppliedRules.collect("attack:bonus", this.actor, this.item).filterWith(rollData).toFormula(),
       situational
     }, rollData);
 

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -743,6 +743,19 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * Effects that can be applied from this activity.
+   * @returns {Promise<ActiveEffect5e[]>|null}
+   */
+  getApplicableEffects() {
+    const applicableEffects = this.applicableEffects;
+    return applicableEffects
+      ? Promise.all(applicableEffects.map(e => e.getEffect())).then(e => e.filter(_ => _))
+      : null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Get the roll parts used to create the damage rolls.
    * @param {Partial<DamageRollProcessConfiguration>} [config={}]  Existing damage configuration to merge into this one.
    * @param {object} [options]                                     Damage configuration options.
@@ -766,14 +779,17 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
-   * Effects that can be applied from this activity.
-   * @returns {Promise<ActiveEffect5e[]>|null}
+   * Prepare a data object which defines the data schema used by dice roll commands against this Activity.
+   * @param {ActivityRollDataOptions} [options]
+   * @returns {ActivityRollData}
    */
-  getApplicableEffects() {
-    const applicableEffects = this.applicableEffects;
-    return applicableEffects
-      ? Promise.all(applicableEffects.map(e => e.getEffect())).then(e => e.filter(_ => _))
-      : null;
+  getRollData({ data, ...options }={}) {
+    const rollData = this.item.getRollData(options);
+    rollData.activity = { ...this };
+    rollData.consumed = this.item.flags.dnd5e?.consumed;
+    rollData.mod = this.actor?.system.abilities?.[this.ability]?.mod ?? 0;
+    if ( data ) Object.assign(rollData, data);
+    return rollData;
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -19,7 +19,7 @@ const {
 
 /**
  * @import { DamageRollConfiguration, DamageRollProcessConfiguration } from "../../dice/_types.mjs";
- * @import { ActivityRollData } from "../../documents/_types.mjs";
+ * @import { ActivityRollData, ActivityRollDataOptions } from "../../documents/_types.mjs";
  * @import { DamageFormulaOptions } from "../shared/_types.mjs";
  * @import { ActivityData, BehaviorApplicationData, EffectApplicationData } from "./_types.mjs";
  */

--- a/module/documents/_module.mjs
+++ b/module/documents/_module.mjs
@@ -19,6 +19,7 @@ export {default as HitDice} from "./actor/hit-dice.mjs";
 export {default as Proficiency} from "./actor/proficiency.mjs";
 export {default as SelectChoices} from "./actor/select-choices.mjs";
 export * as Trait from "./actor/trait.mjs";
+export {default as AppliedRules} from "./applied-rules.mjs";
 export * as mixins from "./mixins/_module.mjs";
 export * as macro from "./macro.mjs";
 export {default as Scaling} from "./scaling.mjs";

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -142,6 +142,12 @@
  * @property {object} activity    Object containing the activity's data.
  * @property {object} [consumed]  Information on what resources the activity's activation consumed.
  * @property {number} mod         The ability modifier value used by the activity.
+ * @property {object} [roll]      Data describing a specific roll being performed.
+ */
+
+/**
+ * @typedef {RollDataOptions} ActivityRollDataOptions
+ * @property {object} [roll]  Changes to the roll object within the activity's roll data.
  */
 
 /**

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -1,6 +1,7 @@
 /**
  * @import { SpellScrollValues } from "../_types.mjs";
  * @import { ActorUpdatesDescription } from "../data/chat-message/fields/_types.mjs";
+ * @import { WeaponAttackMode } from "../dice/_types.mjs";
  */
 
 /**
@@ -139,15 +140,24 @@
 
 /**
  * @typedef {ItemRollData & Maybe<ActorRollData>} ActivityRollData
- * @property {object} activity    Object containing the activity's data.
- * @property {object} [consumed]  Information on what resources the activity's activation consumed.
- * @property {number} mod         The ability modifier value used by the activity.
- * @property {object} [roll]      Data describing a specific roll being performed.
+ * @property {object} activity         Object containing the activity's data.
+ * @property {object} [consumed]       Information on what resources the activity's activation consumed.
+ * @property {number} mod              The ability modifier value used by the activity.
+ * @property {RollDescription} [roll]  Data describing a specific roll being performed.
+ */
+
+/**
+ * @typedef RollDescription
+ * @param {object} [attack]
+ * @param {"spell"|"unarmed"|"weapon"} [attack.classification]  Source of the attack.
+ * @param {WeaponAttackMode} [attack.mode]  Selected weapon attack mode.
+ * @param {"melee"|"ranged"} [attack.type]  Whether this is a melee or ranged attack.
+ * @param {string} type                     Type of roll being performed (e.g. "attack", "skill", "tool", etc.).
  */
 
 /**
  * @typedef {RollDataOptions} ActivityRollDataOptions
- * @property {object} [roll]  Changes to the roll object within the activity's roll data.
+ * @property {object} [data]  Arbitrary data assigned to the roll data object.
  */
 
 /**

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -401,6 +401,17 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /* -------------------------------------------- */
 
   /**
+   * Apply one of the rule active effect change types.
+   * @type {ActiveEffectChangeHandler}
+   */
+  static _applyChangeRule(targetDoc, change, options) {
+    if ( !targetDoc.appliedRules ) return;
+    targetDoc.appliedRules.set(change);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Modify the provided change according to a shim an emit a warning if required.
    * @param {EffectChangeData} change  The change being applied.
    * @returns {EffectChangeData}
@@ -480,7 +491,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @internal
    */
   _checkCondition(change, conditionData) {
-    if ( conditionData ) {
+    if ( conditionData && !CONFIG.ActiveEffect.changeTypes[change.type]?.skipConditions ) {
       if ( this.system.conditions?.check(conditionData) === false ) return false;
       if ( change.conditions?.check(conditionData) === false ) return false;
     }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -406,7 +406,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    */
   static _applyChangeRule(targetDoc, change, options) {
     if ( !targetDoc.appliedRules ) return;
-    targetDoc.appliedRules.set(change);
+    targetDoc.appliedRules.add(change);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -13,7 +13,6 @@ import PseudoDocumentMixin from "../mixins/pseudo-document.mjs";
  * @import {
  *   BasicRollDialogConfiguration, BasicRollMessageConfiguration, DamageRollProcessConfiguration
  * } from "../../dice/_types.mjs";
- * @import { ActivityRollData, ActivityRollDataOptions } from "../_types.mjs";
  * @import {
  *   ActivityConsumptionDescriptor, ActivityDialogConfiguration, ActivityMessageConfiguration, ActivityMetadata,
  *   ActivityUsageChatButton, ActivityUsageResults, ActivityUsageUpdates, ActivityUseConfiguration

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -13,7 +13,7 @@ import PseudoDocumentMixin from "../mixins/pseudo-document.mjs";
  * @import {
  *   BasicRollDialogConfiguration, BasicRollMessageConfiguration, DamageRollProcessConfiguration
  * } from "../../dice/_types.mjs";
- * @import { ActivityRollData, RollDataOptions } from "../_types.mjs";
+ * @import { ActivityRollData, ActivityRollDataOptions } from "../_types.mjs";
  * @import {
  *   ActivityConsumptionDescriptor, ActivityDialogConfiguration, ActivityMessageConfiguration, ActivityMetadata,
  *   ActivityUsageChatButton, ActivityUsageResults, ActivityUsageUpdates, ActivityUseConfiguration
@@ -1217,14 +1217,15 @@ export default function ActivityMixin(Base) {
 
     /**
      * Prepare a data object which defines the data schema used by dice roll commands against this Activity.
-     * @param {RollDataOptions} [options]
+     * @param {ActivityRollDataOptions} [options]
      * @returns {ActivityRollData}
      */
-    getRollData(options) {
+    getRollData({ roll, ...options }={}) {
       const rollData = this.item.getRollData(options);
       rollData.activity = { ...this };
       rollData.consumed = this.item.flags.dnd5e?.consumed;
       rollData.mod = this.actor?.system.abilities?.[this.ability]?.mod ?? 0;
+      rollData.roll = roll;
       return rollData;
     }
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1220,12 +1220,11 @@ export default function ActivityMixin(Base) {
      * @param {ActivityRollDataOptions} [options]
      * @returns {ActivityRollData}
      */
-    getRollData({ roll, ...options }={}) {
+    getRollData(options) {
       const rollData = this.item.getRollData(options);
       rollData.activity = { ...this };
       rollData.consumed = this.item.flags.dnd5e?.consumed;
       rollData.mod = this.actor?.system.abilities?.[this.ability]?.mod ?? 0;
-      rollData.roll = roll;
       return rollData;
     }
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1216,21 +1216,6 @@ export default function ActivityMixin(Base) {
     /* -------------------------------------------- */
 
     /**
-     * Prepare a data object which defines the data schema used by dice roll commands against this Activity.
-     * @param {ActivityRollDataOptions} [options]
-     * @returns {ActivityRollData}
-     */
-    getRollData(options) {
-      const rollData = this.item.getRollData(options);
-      rollData.activity = { ...this };
-      rollData.consumed = this.item.flags.dnd5e?.consumed;
-      rollData.mod = this.actor?.system.abilities?.[this.ability]?.mod ?? 0;
-      return rollData;
-    }
-
-    /* -------------------------------------------- */
-
-    /**
      * Get the best matched token from which this activity is being used if one can be found for this actor
      * in the current scene.
      * @returns {TokenDocument|void}

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -313,20 +313,18 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
   /** @inheritDoc */
   prepareData() {
-    if ( this.system.modelProvider !== dnd5e ) return super.prepareData();
-    this._clearCachedValues();
     super.prepareData();
-    this.items.forEach(item => item.prepareFinalAttributes());
-    this._prepareSpellcasting();
+    if ( this.system.modelProvider === dnd5e ) {
+      this.items.forEach(item => item.prepareFinalAttributes());
+      this._prepareSpellcasting();
+    }
   }
 
   /* --------------------------------------------- */
 
-  /**
-   * Clear cached class collections.
-   * @internal
-   */
+  /** @inheritDoc */
   _clearCachedValues() {
+    super._clearCachedValues();
     this._lazy = {};
     this._preferredArtwork = null;
     this._preparationWarnings = [];

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -1,0 +1,148 @@
+/**
+ * @extends {Map<string, Map<string, ChangeData[]>>}
+ */
+export default class AppliedRules extends Map {
+  /** @inheritDoc */
+  get(key) {
+    if ( !key ) return;
+    if ( key.includes(":") ) {
+      const [target, type] = key.split(":", 2);
+      return super.get(target)?.get(type);
+    }
+    return super.get(key);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get just the rule values for a provided key.
+   * @property {string} key  Rule target and type separated by a colon (e.g. "attack:bonus").
+   * @returns {any[]}
+   */
+  getValues(key) {
+    return this.get(key)?.map(c => c.value) ?? [];
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  set(key, value) {
+    if ( !key ) return this;
+    if ( key.type && key.key ) {
+      const type = key.type.split(".")[1];
+      if ( !this.has(key.key) ) super.set(key.key, new Map());
+      if ( this.get(key.key).has(type) ) this.get(key.key).get(type).push(key);
+      else this.get(key.key).set(type, [key]);
+    } else {
+      super.set(key, value);
+    }
+    return this;
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Consolidate rules from actor and items.
+   * @param {string} rule      Rule target and type separated by a colon (e.g. "attack:bonus").
+   * @param {Actor5e} [actor]  Actor from which to fetch the rules.
+   * @param {Item5e} [item]    Item from which to fetch the rules.
+   * @yields {ChangeData}
+   */
+  static *#collect(rule, actor, item) {
+    for ( const r of actor?.appliedRules.get(rule) ?? [] ) yield r;
+    for ( const r of item?.appliedRules.get(rule) ?? [] ) yield r;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Consolidate rules from actor and items.
+   * @param {string} rule      Rule target and type separated by a colon (e.g. "attack:bonus").
+   * @param {Actor5e} [actor]  Actor from which to fetch the rules.
+   * @param {Item5e} [item]    Item from which to fetch the rules.
+   * @returns {RulesIterator}
+   */
+  static collect(rule, actor, item) {
+    return new RulesIterator(AppliedRules.#collect(rule, actor, item));
+  }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Special iterator for rules that adds some additional helper methods.
+ */
+class RulesIterator extends Iterator {
+  constructor(iterator) {
+    super();
+    this.#iterator = iterator;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Internal iterator.
+   * @type {Iterator}
+   */
+  #iterator;
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  next() {
+    return this.#iterator.next();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Filter rules based on effect & change conditions.
+   * @param {RollData} rollData
+   * @returns {RulesIterator}
+   */
+  filterWith(rollData) {
+    return new RulesIterator(this.#iterator.filter(r => {
+      if ( r.effect?.system.conditions?.recheck(rollData) === false ) return false;
+      if ( r.conditions?.recheck(rollData) === false ) return false;
+      return true;
+    }));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Convert each value of the iterator to a single formula.
+   * @returns {string}
+   */
+  toFormula() {
+    return this.#iterator.map(c => c.value).toArray().join(" + ");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Find the highest value among all of the provided rules, or `-Infinity` of no rules are available.
+   * @returns {number}
+   */
+  toMax() {
+    return this.#iterator.reduce((max, c) => {
+      const value = Number(c.value);
+      return value > max ? value : max;
+    }, -Infinity);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Find the lowest value among all of the provided rules, or `Infinity` of no rules are available.
+   * @returns {number}
+   */
+  toMin() {
+    return this.#iterator.reduce((min, c) => {
+      const value = Number(c.value);
+      return value < min ? value : min;
+    }, Infinity);
+  }
+}

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -2,6 +2,19 @@
  * @extends {Map<string, Map<string, ChangeData[]>>}
  */
 export default class AppliedRules extends Map {
+  /**
+   * Add a change to the collection of applied rules.
+   * @param {ActiveEffectChangeData} change
+   */
+  add(change) {
+    const type = change.type.startsWith("dnd5e.") ? change.type.split(".")[1] : change.type;
+    if ( !this.has(change.key) ) super.set(change.key, new Map());
+    if ( this.get(change.key).has(type) ) this.get(change.key).get(type).push(change);
+    else this.get(change.key).set(type, [change]);
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   get(key) {
     if ( !key ) return;
@@ -21,22 +34,6 @@ export default class AppliedRules extends Map {
    */
   getValues(key) {
     return this.get(key)?.map(c => c.value) ?? [];
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  set(key, value) {
-    if ( !key ) return this;
-    if ( key.type && key.key ) {
-      const type = key.type.split(".")[1];
-      if ( !this.has(key.key) ) super.set(key.key, new Map());
-      if ( this.get(key.key).has(type) ) this.get(key.key).get(type).push(key);
-      else this.get(key.key).set(type, [key]);
-    } else {
-      super.set(key, value);
-    }
-    return this;
   }
 
   /* -------------------------------------------- */
@@ -104,8 +101,8 @@ class RulesIterator extends Iterator {
    */
   filterWith(rollData) {
     return new RulesIterator(this.filter(r => {
-      if ( r.effect?.system.conditions?.recheck(rollData) === false ) return false;
-      if ( r.conditions?.recheck(rollData) === false ) return false;
+      if ( r.effect?.system.conditions?.check(rollData) === false ) return false;
+      if ( r.conditions?.check(rollData) === false ) return false;
       return true;
     }));
   }
@@ -123,31 +120,13 @@ class RulesIterator extends Iterator {
   /* -------------------------------------------- */
 
   /**
-   * Find the highest value among all of the provided rules, or `-Infinity` of no rules are available.
-   * @returns {number}
-   */
-  toLargest() {
-    return this.values(Number).reduce((max, value) => value > max ? value : max, -Infinity);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Find the lowest value among all of the provided rules, or `Infinity` of no rules are available.
-   * @returns {number}
-   */
-  toSmallest() {
-    return this.values(Number).reduce((min, value) => value < min ? value : min, Infinity);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
    * Transform each rule element into its underlying value.
    * @param {Number|String} [type]  Transform value into specific primitive type.
    * @returns {RulesIterator}
    */
   values(type) {
-    return new RulesIterator(this.map(r => type ? type(r.value ?? r) : r.value ?? r));
+    return new RulesIterator(
+      this.map(r => r.value ?? r).filter(v => (v !== "") && (v != null)).map(v => type ? type(v) : v)
+    );
   }
 }

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -16,7 +16,7 @@ export default class AppliedRules extends Map {
 
   /**
    * Get just the rule values for a provided key.
-   * @property {string} key  Rule target and type separated by a colon (e.g. "attack:bonus").
+   * @param {string} key  Rule target and type separated by a colon (e.g. "attack:bonus").
    * @returns {any[]}
    */
   getValues(key) {
@@ -117,7 +117,7 @@ class RulesIterator extends Iterator {
    * @returns {string}
    */
   toFormula() {
-    return this.#iterator.map(c => c.value).toArray().join(" + ");
+    return this.values(String).toArray().join(" + ");
   }
 
   /* -------------------------------------------- */
@@ -126,11 +126,8 @@ class RulesIterator extends Iterator {
    * Find the highest value among all of the provided rules, or `-Infinity` of no rules are available.
    * @returns {number}
    */
-  toMax() {
-    return this.#iterator.reduce((max, c) => {
-      const value = Number(c.value);
-      return value > max ? value : max;
-    }, -Infinity);
+  toLargest() {
+    return this.values(Number).reduce((max, value) => value > max ? value : max, -Infinity);
   }
 
   /* -------------------------------------------- */
@@ -139,10 +136,17 @@ class RulesIterator extends Iterator {
    * Find the lowest value among all of the provided rules, or `Infinity` of no rules are available.
    * @returns {number}
    */
-  toMin() {
-    return this.#iterator.reduce((min, c) => {
-      const value = Number(c.value);
-      return value < min ? value : min;
-    }, Infinity);
+  toSmallest() {
+    return this.values(Number).reduce((min, value) => value < min ? value : min, Infinity);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Transform each rule element into its underlying value.
+   * @param {Number|String} [type]  Transform value into specific primitive type.
+   */
+  values(type) {
+    return new RulesIterator(this.#iterator.map(r => type ? type(r.value ?? r) : r.value ?? r));
   }
 }

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -103,7 +103,7 @@ class RulesIterator extends Iterator {
    * @returns {RulesIterator}
    */
   filterWith(rollData) {
-    return new RulesIterator(this.#iterator.filter(r => {
+    return new RulesIterator(this.filter(r => {
       if ( r.effect?.system.conditions?.recheck(rollData) === false ) return false;
       if ( r.conditions?.recheck(rollData) === false ) return false;
       return true;
@@ -145,8 +145,9 @@ class RulesIterator extends Iterator {
   /**
    * Transform each rule element into its underlying value.
    * @param {Number|String} [type]  Transform value into specific primitive type.
+   * @returns {RulesIterator}
    */
   values(type) {
-    return new RulesIterator(this.#iterator.map(r => type ? type(r.value ?? r) : r.value ?? r));
+    return new RulesIterator(this.map(r => type ? type(r.value ?? r) : r.value ?? r));
   }
 }

--- a/module/documents/mixins/document.mjs
+++ b/module/documents/mixins/document.mjs
@@ -1,3 +1,4 @@
+import AppliedRules from "../applied-rules.mjs";
 import DependentDocumentMixin from "./dependent.mjs";
 import SystemFlagsMixin from "./flags.mjs";
 
@@ -10,9 +11,42 @@ import SystemFlagsMixin from "./flags.mjs";
  */
 export default function SystemDocumentMixin(Base) {
   class SystemDocument extends DependentDocumentMixin(SystemFlagsMixin(Base)) {
+
+    /* -------------------------------------------- */
+    /*  Properties                                  */
+    /* -------------------------------------------- */
+
+    /**
+     * Rule active effects grouped by type and then key.
+     * @type {AppliedRules}
+     */
+    appliedRules = this.appliedRules;
+
+    /* -------------------------------------------- */
+
     /** @inheritDoc */
     get _systemFlagsDataModel() {
       return this.system?.metadata?.systemFlagsModel ?? null;
+    }
+
+    /* -------------------------------------------- */
+    /*  Data Preparation                            */
+    /* -------------------------------------------- */
+
+    /**
+     * Clear cached data.
+     * @protected
+     */
+    _clearCachedValues() {
+      this.appliedRules = new AppliedRules();
+    }
+
+    /* -------------------------------------------- */
+
+    /** @inheritDoc */
+    prepareData() {
+      this._clearCachedValues();
+      super.prepareData();
     }
   }
   return SystemDocument;


### PR DESCRIPTION
Adds a system for collecting rules on actors and items applied by custom active effect change types. When these changes are applied they add to the `Actor5e#appliedRules` or `Item5e#appliedRules` objects grouped by type and key. This allows for quick retrieval of specific rules using a description like `attack:bonus`.

The `AppliedRules` map adds a helper method `collect` that takes a rule description as well as an actor and optional item and returns an iterator for all applicable rules. The iterator has some custom methods to aid handling the rules:

```javascript
// Collects all attack bonuses, checks their conditions, and creates a final formula
AppliedRules
  .collect("attack:bonus", this.actor, this.item)
  .filterWith(rollData)
  .toFormula();
```

This implements a single new change type of `bonus` and a single accepted key of `attack`, allowing attack bonuses to be defined. Additional change types and keys will be added once the basic design is approved.