### PR TITLE
[#6442] Loot effects tab

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -689,16 +689,6 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
   }
 
   /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  _replaceHTML(result, content, options) {
-    if ( !this.constructor.itemHasEffects(this.document) ) {
-      this.element.querySelector("[data-application-part=effects]")?.remove();
-    }
-    super._replaceHTML(result, content, options);
-  }
-
-  /* -------------------------------------------- */
   /*  Event Listeners and Handlers                */
   /* -------------------------------------------- */
 
@@ -1173,7 +1163,6 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
    */
   static itemHasEffects(item) {
     if ( !this.isItemIdentified(item) ) return false;
-
     const { hasEffects } = item.system.constructor.metadata;
     if ( hasEffects === null ) return item.effects.size > 0;
     return hasEffects;

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -689,6 +689,16 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _replaceHTML(result, content, options) {
+    if ( !this.constructor.itemHasEffects(this.document) ) {
+      this.element.querySelector("[data-application-part=effects]")?.remove();
+    }
+    super._replaceHTML(result, content, options);
+  }
+
+  /* -------------------------------------------- */
   /*  Event Listeners and Handlers                */
   /* -------------------------------------------- */
 
@@ -1162,6 +1172,10 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
    * @returns {boolean}
    */
   static itemHasEffects(item) {
-    return this.isItemIdentified(item) && item.system.constructor.metadata.hasEffects;
+    if ( !this.isItemIdentified(item) ) return false;
+
+    const { hasEffects } = item.system.constructor.metadata;
+    if ( hasEffects === null ) return item.effects.size > 0;
+    return hasEffects;
   }
 }

--- a/module/data/abstract/_types.mjs
+++ b/module/data/abstract/_types.mjs
@@ -20,7 +20,8 @@
  * @property {boolean} compendiumGearSource            Only for physical items. When fetching item as gear from a NPC,
  *                                                     prefer the compendium source over the embedded version.
  * @property {boolean} enchantable                     Can this item be modified by enchantment effects?
- * @property {boolean} hasEffects                      Display the effects tab on this item's sheet.
+ * @property {boolean|null} hasEffects                 Display the effects tab on this item's sheet.
+ *                                                     If null, only displayed if the item has one or more effects.
  * @property {boolean} singleton                       Should only a single item of this type be allowed on an actor?
  * @property {InventorySectionDescriptor} [inventory]  Configuration for displaying this item type in its own section
  *                                                     in creature inventories.

--- a/module/data/item/container.mjs
+++ b/module/data/item/container.mjs
@@ -66,7 +66,8 @@ export default class ContainerData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
-    enchantable: true
+    enchantable: true,
+    hasEffects: null
   }, {inplace: false}));
 
   /* -------------------------------------------- */

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -51,7 +51,8 @@ export default class LootData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
-    enchantable: true
+    enchantable: true,
+    hasEffects: null
   }, {inplace: false}));
 
   /* -------------------------------------------- */


### PR DESCRIPTION
- If `metadata.hasEffects` is `null`, visibility of the Effects tab depends on the item having any effects.
- Allows for `loot` items to display an Effects tab if they have one or more effects.
- If remaining effects are removed and the Effects tab is no longer displayed, fall back to activating the first tab.

Closes #6442.