### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to foundryvtt/dnd5e
 
-Code and content contributions are accepted. Please feel free to submit issues to the issue tracker or submit merge requests for code/content changes. Approval for such requests involves code and (if necessary) design review by the Maintainers of this repo. Please reach out on the [Foundry Community Discord](https://discord.gg/foundryvtt) with any questions.
+Code and content contributions are accepted. Please feel free to submit issues to the issue tracker or submit pull requests for code/content changes. Approval for such requests involves code and (if necessary) design review by the Maintainers of this repo. Please reach out on the [Foundry Community Discord](https://discord.gg/foundryvtt) with any questions.
 
 Please ensure there is an open issue about whatever contribution you are submitting. Please also ensure your contribution does not duplicate an existing one.
 
@@ -19,7 +19,7 @@ Installs all dependencies needed to run developer tooling scripts. Then will com
 Runs all relevant build scripts:
 
 - Converts LESS -> CSS
-- Converts JSON -> DB (compendia)
+- Converts YAML -> DB (compendia)
 
 ### `npm run build:css`
 
@@ -29,36 +29,36 @@ Converts the LESS in `./less` to the final `dnd5e.css`.
 
 Runs the LESS -> CSS builder in watch mode so that changes made to the LESS files will automatically compile to CSS.
 
-### Compendia as JSON
+### Compendia as YAML
 
-This repository includes some utilities which allow the Compendia included in the System to be maintained as JSON files. This makes contributions which include changes to the compendia considerably easier to review.
+This repository includes some utilities which allow the compendia included in the system to be maintained as YAML files. This makes contributions which include changes to the compendia considerably easier to review.
 
 #### Compiling Packs
 
-Compile the source JSON files into compendium packs.
+Compile the source YAML files into compendium packs.
 
 ```text
 npm run build:db
 ```
 
-- `npm run build:db` - Compile all JSON files into their LevelDB files.
+- `npm run build:db` - Compile all YAML files into their LevelDB files.
 - `npm run build:db -- classes` - Only compile the specified pack.
 
 #### Extracting Packs
 
-Extract the contents of compendium packs to JSON files.
+Extract the contents of compendium packs to YAML files.
 
 ```text
-npm run build:json
+npm run build:source
 ```
 
-- `npm run build:json` - Extract all compendium LevelDB files into JSON files.
-- `npm run build:json -- classes` - Only extract the contents of the specified compendium.
-- `npm run build:json -- classes Barbarian` - Only extract a single item from the specified compendium.
+- `npm run build:source` - Extract all compendium LevelDB files into YAML files.
+- `npm run build:source -- classes` - Only extract the contents of the specified compendium.
+- `npm run build:source -- classes Barbarian` - Only extract a single item from the specified compendium.
 
 #### Cleaning Packs
 
-Cleans and formats source JSON files, removing unnecessary permissions and flags and adding the proper spacing.
+Cleans and formats source YAML files, removing unnecessary permissions and flags and adding the proper spacing.
 
 ```text
 npm run build:clean
@@ -70,8 +70,8 @@ npm run build:clean
 
 ## Issues
 
-Check that your Issue isn't a duplicate (also check the closed issues, as sometimes work which has not been released closes an issue).
-Issues which are assigned to a Milestone are considered "Prioritized." This assignment is not permanent and issues might be pushed out of milestones if the milestone is approaching a releaseable state without that work being done.
+Check that your issue isn't a duplicate (also check the closed issues, as sometimes work which has not been released closes an issue).
+Issues which are assigned to a Milestone are considered prioritized. This assignment is not permanent and issues might be pushed out of milestones if the milestone is approaching a releaseable state without that work being done.
 
 ### Bugs
 
@@ -85,7 +85,7 @@ Any feature request should be considered from the lens of "Does this belong in t
 
 - Do the Rules as Written (RAW) support this feature? If so, provide some examples.
 - Is the missing feature in the System Reference Document? If not, it might still be supportable, but it is worth mentioning in the request.
-- Does this feature help a GM run a fifth edition game in Foundry VTT?
+- Does this feature help a DM run a D&D game in Foundry VTT?
 
 ## Content
 
@@ -93,7 +93,14 @@ All Content released with this system must come from the WotC [5e System Referen
 
 If there is missing content, please open an issue detailing what is missing.
 
-In general, content contributions will take the shape of fixing typos or bugs in the configuration of the existing items in the included compendia JSON files, which are then compiled into the appropriate db file.
+In general, content contributions will take the shape of fixing typos or bugs in the configuration of the existing items in the included compendia YAML files, which are then compiled into the appropriate db file.
+
+To contribute content, [fork this project](https://docs.github.com/en/get-started/quickstart/fork-a-repo) and submit a pull request against the correct development branch. How you make the change depends on its scope:
+
+- **Small fixes** such as typos can be edited directly in the source YAML files under `packs/_source` and submitted as a PR without any further tooling.
+- **Improvements to how a game feature is modeled** (for example, to take advantage of new system features) should be made through Foundry itself so that the resulting data is valid. Load a clean world, unlock the system compendia, and make your changes directly in the compendium. For more complicated changes, import the entry into the world, make your changes there, then re-export it back to the compendium.
+
+When editing through Foundry, once your changes are complete, close down the world and run `npm run build:source` to extract the updated compendia back to the source YAML files before committing and submitting your PR.
 
 ### Translations
 
@@ -109,7 +116,7 @@ To contribute code, [fork this project](https://docs.github.com/en/get-started/q
 
 ### Style
 
-Please attempt to follow code style present throughout the project. An ESLint profile is included to help with maintaining a consistent code style. All warnings presented by the linter should be resolved before an PR is submitted.
+Please attempt to follow code style present throughout the project. An ESLint profile is included to help with maintaining a consistent code style. All warnings presented by the linter should be resolved before a PR is submitted.
 
 - `npm run lint` - Run the linter and display any issues found.
 - `npm run lint:fix` - Automatically fix any code style issues that can be fixed.
@@ -149,12 +156,14 @@ Please appreciate that reviewing contributions constitutes a substantial amount 
 PRs have a few phases:
 
 0. **Prioritization.** If the PR relates to the current milestone, it is assigned to that milestone.
-1. **Initial Review from the 5e contributor team.** This lets us spread out the review work and catch some of the more obvious things that need to be fixed before final review. Generally this talks about code style and some methodology.
-2. **Final Review from the Maintainers.** Atropos and Kim have final review and are the only ones with merge permission.
+1. **Initial Review from Contributors.** This lets us spread out the review work and catch some of the more obvious things that need to be fixed before final review. Generally this talks about code style and some methodology.
+2. **Final Review from the Maintainers.** PRs not tagged as 'strategic' or tagged as 'uncontroversial' can be merged with Maintainer sign-off, otherwise the PR requires sign-off from one of the Foundry VTT core developer team.
 
 #### PR Size
 
-Please understand that large and sprawling PRs are exceptionally difficult to review. As much as possible, break down the work for a large feature into smaller steps. Even if multiple PRs are required for a single Issue, this will make it considerably easier and therefore more likely that your contributions will be reviewed and merged in a timely manner.
+Please understand that large and sprawling PRs are exceptionally difficult to review. As much as possible, break down the work for a large feature into smaller steps. Even if multiple PRs are required for a single issue, this will make it considerably easier and therefore more likely that your contributions will be reviewed and merged in a timely manner.
+
+Reviewing a contribution is a significant investment of maintainer time, and that investment scales poorly with both the size of the change and the degree to which it fails to meet the project's conventions. We reserve the right to close a large PR without review where it contains numerous code style violations, makes little to no attempt to integrate with the conventions and design of the existing codebase, or lacks the supporting materials needed to evaluate it, such as linked issues, change rationale, or an explanation of the proposed design. If you would like feedback before committing to a large change, open an issue to discuss the approach first.
 
 ## Releases
 
@@ -171,6 +180,22 @@ If either of these conditions are not met on the commit that tag points at, the 
 https://github.com/foundryvtt/dnd5e/releases/download/release-1.6.3/dnd5e-1.6.3.zip
                                                      └─ Tag Name ──┘     └─ V ─┘ (version)
 ```
+
+### Building Locally
+
+If the release GitHub Action is failing, the release artifact can be produced locally with `dist.mjs`. This performs the same steps as CI: it clones a fresh copy of the repo at the given tag, installs dependencies, integrates the free rules content, builds, and zips the result.
+
+```text
+npm run dist -- <tag> <free-rules>
+```
+
+- `<tag>` - the release tag to build, e.g. `release-4.1.0`. The build fails if `system.json`'s `version` and `download` fields do not match the tag.
+- `<free-rules>` - path to a local checkout of the (private) free rules content.
+- `--out`, `-o` - output directory for the build (default `./dist`).
+- `--repo`, `-r` - repository to clone (default `git@github.com:foundryvtt/dnd5e.git`).
+- `--url` - public URL where releases are posted (default `https://github.com/foundryvtt/dnd5e`).
+
+The finished `dnd5e-<tag>.zip` is written to the output directory.
 
 ### Process for Release
 


### PR DESCRIPTION
This document was due an update to clean up some old references to 'merge requests', as well as update all the references to JSON which should now be YAML.

I added a little bit of guidance on improving compendium content, though it still assumes the user has pretty advanced knowledge of foundry and git. But a full tutorial is probably not appropriate for this document.

I also added a section on running `dist.mjs` though it's only useful for maintainers. Seemed to fit the 'Process for Release' though which is also really only relevant to maintainers.

Finally, I expanded the section on 'PR Size' to give us some clear justification we can point to for summarily closing poor quality PRs without review if necessary.