### PR TITLE
[#2759] Move speeds into `movement.speeds` to allow custom speeds

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -284,7 +284,7 @@ function _configureTrackableAttributes() {
     bar: [],
     value: [
       ...Object.keys(DND5E.abilities).map(ability => `abilities.${ability}.value`),
-      ...Object.keys(DND5E.movementTypes).map(movement => `attributes.movement.${movement}`),
+      ...Object.keys(DND5E.movementTypes).map(movement => `attributes.movement.speeds.${movement}`),
       "attributes.ac.value", "attributes.init.total"
     ]
   };
@@ -439,7 +439,6 @@ Hooks.once("setup", function() {
   _configureTrackableAttributes();
   _configureConsumableAttributes();
 
-  CONFIG.DND5E.trackableAttributes = expandAttributeList(CONFIG.DND5E.trackableAttributes);
   Tooltips5e.activateListeners();
   game.dnd5e.tooltips.observe();
 
@@ -463,20 +462,6 @@ Hooks.once("setup", function() {
   `;
   document.head.append(style);
 });
-
-/* --------------------------------------------- */
-
-/**
- * Expand a list of attribute paths into an object that can be traversed.
- * @param {string[]} attributes  The initial attributes configuration.
- * @returns {object}  The expanded object structure.
- */
-function expandAttributeList(attributes) {
-  return attributes.reduce((obj, attr) => {
-    foundry.utils.setProperty(obj, attr, true);
-    return obj;
-  }, {});
-}
 
 /* --------------------------------------------- */
 

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -573,7 +573,7 @@ export default class CharacterActorSheet extends BaseActorSheet {
     // Speed
     context.speed = Object.entries(CONFIG.DND5E.movementTypes).reduce((obj, [k, { hidden, label }]) => {
       if ( hidden ) return obj;
-      const value = attributes.movement[k];
+      const value = attributes.movement.speeds[k];
       if ( (k === "fly") && attributes.movement.hover ) {
         label = _loc("DND5E.MOVEMENT.HoverSpeed", { speed: label });
       }

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -372,7 +372,7 @@ export default class NPCActorSheet extends BaseActorSheet {
     // Speed
     context.speed = [
       ...Object.entries(CONFIG.DND5E.movementTypes).filter(([, m]) => !m.hidden).map(([k, { label }]) => {
-        const value = attributes.movement[k];
+        const value = attributes.movement.speeds[k];
         if ( !value ) return null;
         const data = { label, value };
         if ( (k === "fly") && attributes.movement.hover ) data.icons = [{

--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -267,7 +267,7 @@ export default class VehicleActorSheet extends BaseActorSheet {
     const { movement } = context.system.attributes;
     const units = movement.units || defaultUnits("length");
     let combatSpeed = formatLength(movement.max, units, { parts: true });
-    if ( movement.hover && (movement.fly > 0) && (movement.fly >= movement.max) ) {
+    if ( movement.hover && (movement.speeds.fly > 0) && (movement.speeds.fly >= movement.max) ) {
       combatSpeed = _loc("DND5E.MOVEMENT.HoverSpeed", { speed: combatSpeed });
     }
     context.combatSpeed = combatSpeed;

--- a/module/applications/shared/movement-senses-config.mjs
+++ b/module/applications/shared/movement-senses-config.mjs
@@ -44,7 +44,7 @@ export default class MovementSensesConfig extends BaseConfigSheet {
    * @type {string|null}
    */
   get subPath() {
-    return this.options.type === "movement" ? null : "ranges";
+    return this.options.type === "movement" ? "speeds" : "ranges";
   }
 
   /* -------------------------------------------- */

--- a/module/canvas/ruler.mjs
+++ b/module/canvas/ruler.mjs
@@ -90,7 +90,7 @@ export default class TokenRuler5e extends foundry.canvas.placeables.tokens.Token
       || CONFIG.Token.movement.actions[waypoint.action]?.teleport ) return style;
 
     // Get actor's movement speed for currently selected token movement action
-    const movement = this.token.actor?.system.attributes?.movement;
+    const movement = this.token.actor?.system.attributes?.movement?.speeds;
     if ( !movement || !this.token.actor?.system.isCreature ) return style;
     let currActionSpeed = movement[waypoint.action] ?? 0;
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3584,19 +3584,6 @@ preLocalize("cover");
 /* -------------------------------------------- */
 
 /**
- * A selection of actor attributes that can be tracked on token resource bars.
- * @type {string[]}
- * @deprecated since v10
- */
-DND5E.trackableAttributes = [
-  "attributes.ac.value", "attributes.init.bonus", "attributes.movement", "attributes.senses",
-  "attributes.spell.attack", "attributes.spell.dc", "attributes.spell.level", "details.cr",
-  "details.xp.value", "skills.*.passive", "abilities.*.value"
-];
-
-/* -------------------------------------------- */
-
-/**
  * A selection of actor and item attributes that are valid targets for item resource consumption.
  * @type {string[]}
  */

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -4,6 +4,7 @@ import { defaultUnits, simplifyBonus } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import LocalDocumentField from "../fields/local-document-field.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
+import MovementField from "../shared/movement-field.mjs";
 import RollConfigField from "../shared/roll-config-field.mjs";
 import SensesField from "../shared/senses-field.mjs";
 import SimpleTraitField from "./fields/simple-trait-field.mjs";
@@ -151,6 +152,7 @@ export default class CharacterData extends CreatureTemplate {
     super._migrateData(source);
     AttributesFields._migrateArmorClass(source.attributes);
     AttributesFields._migrateInitiative(source.attributes);
+    MovementField._migrate(source.attributes?.movement);
     return source;
   }
 
@@ -188,6 +190,7 @@ export default class CharacterData extends CreatureTemplate {
 
     AttributesFields.prepareBaseArmorClass.call(this);
     AttributesFields.prepareBaseEncumbrance.call(this);
+    MovementField._shim(this.attributes.movement);
     SensesField._shim(this.attributes.senses);
   }
 
@@ -204,7 +207,7 @@ export default class CharacterData extends CreatureTemplate {
     } else {
       this.details.type = new CreatureTypeField({ swarm: false }).initialize({ value: "humanoid" }, this);
     }
-    for ( const key of Object.keys(CONFIG.DND5E.movementTypes) ) this.attributes.movement[key] ??= 0;
+    for ( const key of Object.keys(CONFIG.DND5E.movementTypes) ) this.attributes.movement.speeds[key] ??= 0;
     for ( const key of Object.keys(CONFIG.DND5E.senses) ) this.attributes.senses.ranges[key] ??= 0;
     this.attributes.movement.units ??= defaultUnits("length");
     this.attributes.senses.units ??= defaultUnits("length");

--- a/module/data/actor/fields/travel-field.mjs
+++ b/module/data/actor/fields/travel-field.mjs
@@ -72,8 +72,8 @@ export default class TravelField extends foundry.data.fields.SchemaField {
 
     if ( !movement ) return;
     for ( const [type, { travel: travelType="land" }] of Object.entries(CONFIG.DND5E.movementTypes) ) {
-      if ( !movement[type] ) continue;
-      const speed = TravelField.convertMovementToTravel(movement[type], movement.units, units);
+      if ( !movement.speeds?.[type] ) continue;
+      const speed = TravelField.convertMovementToTravel(movement.speeds[type], movement.units, units);
       const pace = travel.paces[travelType] ||= TravelField.applyPaceMultiplier(
         speed * travel.time, paceMode, CONFIG.DND5E.movementUnits[movement.units]?.type
       );

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -5,6 +5,7 @@ import { getRulesVersion } from "../../enrichers.mjs";
 import { defaultUnits, formatCR, formatLength, formatNumber, getPluralRules, splitSemicolons } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
+import MovementField from "../shared/movement-field.mjs";
 import RollConfigField from "../shared/roll-config-field.mjs";
 import SensesField from "../shared/senses-field.mjs";
 import SourceField from "../shared/source-field.mjs";
@@ -193,8 +194,14 @@ export default class NPCData extends CreatureTemplate {
         },
         createFilter: (filters, value, def) => {
           for ( const [k, v] of Object.entries(value ?? {}) ) {
-            if ( v === 1 ) filters.push({ k: `system.attributes.movement.${k}`, o: "gt", v: 0 });
-            if ( v === -1 ) filters.push({ o: "NOT", v: { k: `system.attributes.movement.${k}`, o: "gt", v: 0 } });
+            if ( v === 1 ) filters.push({ o: "OR", v: [
+              { k: `system.attributes.movement.${k}`, o: "gt", v: 0 },
+              { k: `system.attributes.movement.speeds.${k}`, o: "gt", v: 0 }
+            ] });
+            if ( v === -1 ) filters.push({ o: "NOR", v: [
+              { k: `system.attributes.movement.${k}`, o: "gt", v: 0 },
+              { k: `system.attributes.movement.speeds.${k}`, o: "gt", v: 0 }
+            ] });
           }
         }
       }]
@@ -228,6 +235,7 @@ export default class NPCData extends CreatureTemplate {
     NPCData.#migrateTypeData(source);
     AttributesFields._migrateArmorClass(source.attributes);
     AttributesFields._migrateInitiative(source.attributes);
+    MovementField._migrate(source.attributes?.movement);
     return source;
   }
 
@@ -386,6 +394,7 @@ export default class NPCData extends CreatureTemplate {
 
     AttributesFields.prepareBaseArmorClass.call(this);
     AttributesFields.prepareBaseEncumbrance.call(this);
+    MovementField._shim(this.attributes.movement);
     SensesField._shim(this.attributes.senses);
   }
 
@@ -400,7 +409,7 @@ export default class NPCData extends CreatureTemplate {
       AttributesFields.prepareRace.call(this, this.details.race, { force: true });
       this.details.type = this.details.race.system.type;
     }
-    for ( const key of Object.keys(CONFIG.DND5E.movementTypes) ) this.attributes.movement[key] ??= 0;
+    for ( const key of Object.keys(CONFIG.DND5E.movementTypes) ) this.attributes.movement.speeds[key] ??= 0;
     for ( const key of Object.keys(CONFIG.DND5E.senses) ) this.attributes.senses.ranges[key] ??= 0;
     this.attributes.movement.units ??= defaultUnits("length");
     this.attributes.senses.units ??= defaultUnits("length");
@@ -617,11 +626,11 @@ export default class NPCData extends CreatureTemplate {
 
     const prepareSpeed = () => {
       const standard = formatter.format([
-        prepareMeasured(this.attributes.movement.walk, this.attributes.movement.units),
+        prepareMeasured(this.attributes.movement.speeds.walk, this.attributes.movement.units),
         ...Object.entries(CONFIG.DND5E.movementTypes)
-          .filter(([k, { hidden }]) => this.attributes.movement[k] && (k !== "walk") && !hidden)
+          .filter(([k, { hidden }]) => this.attributes.movement.speeds[k] && (k !== "walk") && !hidden)
           .map(([k, { label }]) => {
-            let prepared = prepareMeasured(this.attributes.movement[k], this.attributes.movement.units, label);
+            let prepared = prepareMeasured(this.attributes.movement.speeds[k], this.attributes.movement.units, label);
             if ( (k === "fly") && this.attributes.movement.hover ) {
               prepared = _loc("DND5E.MOVEMENT.HoverSpeed", { speed: prepared });
             }

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -529,10 +529,11 @@ export default class AttributesFields {
     const statuses = this.parent.statuses;
     const noMovement = this.parent.hasConditionEffect("noMovement");
     const crawl = this.parent.hasConditionEffect("crawl");
+    const speeds = this.attributes.movement.speeds;
     for ( const type of Object.keys(CONFIG.DND5E.movementTypes) ) {
-      if ( noMovement || (crawl && (type !== "walk")) ) this.attributes.movement[type] = 0;
-      else this.attributes.movement[type] = Math.max(0, simplifyBonus(this.attributes.movement[type], rollData));
-      if ( type === "walk" ) this.attributes.movement.speed = this.attributes.movement.walk;
+      if ( noMovement || (crawl && (type !== "walk")) ) speeds[type] = 0;
+      else speeds[type] = Math.max(0, simplifyBonus(speeds[type], rollData));
+      if ( type === "walk" ) this.attributes.movement.speed = speeds.walk;
     }
 
     const halfMovement = this.parent.hasConditionEffect("halfMovement");
@@ -559,7 +560,7 @@ export default class AttributesFields {
     const bonus = simplifyBonus(this.attributes.movement.bonus, rollData);
     this.attributes.movement.max = 0;
     for ( const type of Object.keys(CONFIG.DND5E.movementTypes) ) {
-      let speed = Math.max(0, this.attributes.movement[type] - reduction);
+      let speed = Math.max(0, speeds[type] - reduction);
       if ( speed ) {
         speed = Math.max(0, speed + bonus);
         if ( halfMovement ) speed *= 0.5;
@@ -572,13 +573,13 @@ export default class AttributesFields {
           speed = Math.min(speed, CONFIG.DND5E.encumbrance.speedReduction.exceedingCarryingCapacity[units] ?? 0);
         }
       }
-      this.attributes.movement[type] = speed;
+      speeds[type] = speed;
       this.attributes.movement.max = Math.max(speed, this.attributes.movement.max);
       if ( type === "walk" ) this.attributes.movement.speed = speed;
     }
-    const baseSpeed = this._source.attributes.movement.walk || this.attributes.movement.fromSpecies?.walk;
-    this.attributes.movement.slowed = this.attributes.movement.walk <= (simplifyBonus(baseSpeed, rollData) / 2);
-    this.attributes.movement.jump = (this.abilities?.str.value ?? 0) / 2;
+    const baseSpeed = this._source.attributes.movement.speeds.walk || this.attributes.movement.fromSpecies?.walk;
+    this.attributes.movement.slowed = speeds.walk <= (simplifyBonus(baseSpeed, rollData) / 2);
+    this.attributes.movement.speeds.jump = (this.abilities?.str.value ?? 0) / 2;
   }
 
   /* -------------------------------------------- */
@@ -592,22 +593,23 @@ export default class AttributesFields {
    * @this {CharacterData|NPCData}
    */
   static prepareRace(race, { force=false }={}) {
+    const { movement, senses } = race.system;
     for ( const key of Object.keys(CONFIG.DND5E.movementTypes) ) {
-      if ( !race.system.movement[key] || (!force && this.attributes.movement[key]) ) continue;
+      if ( !movement.speeds[key] || (!force && this.attributes.movement.speeds[key]) ) continue;
       this.attributes.movement.fromSpecies ??= {};
-      this.attributes.movement[key] = this.attributes.movement.fromSpecies[key] = race.system.movement[key];
+      this.attributes.movement.speeds[key] = this.attributes.movement.fromSpecies[key] = movement.speeds[key];
     }
-    if ( race.system.movement.hover ) this.attributes.movement.hover = true;
-    if ( force && race.system.movement.units ) this.attributes.movement.units = race.system.movement.units;
-    else this.attributes.movement.units ??= race.system.movement.units;
+    if ( movement.hover ) this.attributes.movement.hover = true;
+    if ( force && movement.units ) this.attributes.movement.units = movement.units;
+    else this.attributes.movement.units ??= movement.units;
 
     for ( const key of Object.keys(CONFIG.DND5E.senses) ) {
-      if ( !race.system.senses.ranges[key] || (!force && (this.attributes.senses.ranges[key] !== null)) ) continue;
-      this.attributes.senses.ranges[key] = race.system.senses.ranges[key];
+      if ( !senses.ranges[key] || (!force && (this.attributes.senses.ranges[key] !== null)) ) continue;
+      this.attributes.senses.ranges[key] = senses.ranges[key];
     }
-    this.attributes.senses.special = [this.attributes.senses.special, race.system.senses.special].filterJoin(";");
-    if ( force && race.system.senses.units ) this.attributes.senses.units = race.system.senses.units;
-    else this.attributes.senses.units ??= race.system.senses.units;
+    this.attributes.senses.special = [this.attributes.senses.special, senses.special].filterJoin(";");
+    if ( force && senses.units ) this.attributes.senses.units = senses.units;
+    else this.attributes.senses.units ??= senses.units;
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -124,10 +124,12 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
    */
   static #migrateMovementData(source) {
     const original = source.attributes?.speed?.value ?? source.attributes?.speed;
-    if ( (typeof original !== "string") || (source.attributes.movement?.walk !== undefined) ) return;
+    if ( (typeof original !== "string") || (source.attributes.movement?.walk !== undefined)
+      || (source.attributes.movement?.speeds?.walk !== undefined) ) return;
     source.attributes.movement ??= {};
+    source.attributes.movement.speeds ??= {};
     const s = original.split(" ");
-    if ( s.length > 0 ) source.attributes.movement.walk = Number.isNumeric(s[0]) ? parseInt(s[0]) : 0;
+    if ( s.length > 0 ) source.attributes.movement.speeds.walk = Number.isNumeric(s[0]) ? parseInt(s[0]) : 0;
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -1,4 +1,5 @@
 import { convertWeight, defaultUnits, parseDelta } from "../../utils.mjs";
+import MovementField from "../shared/movement-field.mjs";
 import SourceField from "../shared/source-field.mjs";
 import TravelField from "./fields/travel-field.mjs";
 import AttributesFields from "./templates/attributes.mjs";
@@ -224,6 +225,8 @@ export default class VehicleData extends CommonTemplate {
       units: newUnits
     };
     movement.units = null;
+
+    MovementField._migrate(source.attributes?.movement);
   }
 
   /* -------------------------------------------- */
@@ -264,6 +267,7 @@ export default class VehicleData extends CommonTemplate {
     this.attributes.prof = 0;
     AttributesFields.prepareBaseArmorClass.call(this);
     AttributesFields.prepareBaseEncumbrance.call(this);
+    MovementField._shim(this.attributes.movement);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -73,7 +73,7 @@ export default class RaceData extends ItemDataModel.mixin(AdvancementTemplate, I
   get movementLabels() {
     const units = this.movement.units || defaultUnits("length");
     return Object.entries(CONFIG.DND5E.movementTypes).reduce((obj, [k, { label }]) => {
-      const value = this.movement[k];
+      const value = this.movement.speeds[k];
       if ( value ) obj[k] = `${label} ${formatLength(value, units)}`;
       return obj;
     }, {});
@@ -112,6 +112,7 @@ export default class RaceData extends ItemDataModel.mixin(AdvancementTemplate, I
   static _migrateData(source) {
     super._migrateData(source);
     AdvancementTemplate.migrateAdvancement(source);
+    MovementField._migrate(source.movement);
     SensesField._migrate(source.senses);
     return source;
   }
@@ -124,6 +125,7 @@ export default class RaceData extends ItemDataModel.mixin(AdvancementTemplate, I
   prepareDerivedData() {
     super.prepareDerivedData();
     this.prepareDescriptionData();
+    MovementField._shim(this.movement);
     SensesField._shim(this.senses);
   }
 
@@ -148,7 +150,7 @@ export default class RaceData extends ItemDataModel.mixin(AdvancementTemplate, I
       config: "movement",
       tooltip: "DND5E.MOVEMENT.Action.Configure",
       value: Object.entries(CONFIG.DND5E.movementTypes).reduce((str, [k, { label }]) => {
-        const value = this.movement[k];
+        const value = this.movement.speeds[k];
         if ( !value ) return str;
         return `${str}
           <span class="key">${label}</span>

--- a/module/data/shared/_types.mjs
+++ b/module/data/shared/_types.mjs
@@ -54,13 +54,9 @@
 
 /**
  * @typedef MovementData
- * @property {number} walk                          Actor walking speed.
- * @property {number} burrow                        Actor burrowing speed.
- * @property {number} climb                         Actor climbing speed.
- * @property {number} fly                           Actor flying speed.
- * @property {number} swim                          Actor swimming speed.
  * @property {string} bonus                         Bonus applied to all movement types that already have a speed.
  * @property {string} special                       Semi-colon separated list of special movement information.
+ * @property {Record<string, string>} speeds        Speeds for various movement types.
  * @property {string} units                         Movement used to measure the various speeds.
  * @property {boolean} hover                        This flying creature able to hover in place.
  * @property {Set<string>} ignoredDifficultTerrain  Types of difficult terrain ignored.

--- a/module/data/shared/movement-field.mjs
+++ b/module/data/shared/movement-field.mjs
@@ -1,9 +1,11 @@
 import FormulaField from "../fields/formula-field.mjs";
+import MappingField from "../fields/mapping-field.mjs";
 
 const { BooleanField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { TravelPace5e } from "../actor/fields/_types.mjs";
+ * @import { MovementData } from "./_types.mjs";
  */
 
 /**
@@ -12,13 +14,11 @@ const { BooleanField, SetField, StringField } = foundry.data.fields;
 export default class MovementField extends foundry.data.fields.SchemaField {
   constructor(fields={}, { initialUnits=null, ...options }={}) {
     fields = {
-      walk: new FormulaField({ deterministic: true, label: "DND5E.MOVEMENT.Type.Speed", speed: true }),
-      burrow: new FormulaField({ deterministic: true, label: "DND5E.MOVEMENT.Type.Burrow", speed: true }),
-      climb: new FormulaField({ deterministic: true, label: "DND5E.MOVEMENT.Type.Climb", speed: true }),
-      fly: new FormulaField({ deterministic: true, label: "DND5E.MOVEMENT.Type.Fly", speed: true }),
-      swim: new FormulaField({ deterministic: true, label: "DND5E.MOVEMENT.Type.Swim", speed: true }),
       bonus: new FormulaField({ deterministic: true, label: "DND5E.MOVEMENT.FIELDS.bonus.label" }),
       special: new StringField({ label: "DND5E.MOVEMENT.FIELDS.special.label" }),
+      speeds: new MappingField(new FormulaField({ deterministic: true }), {
+        initialKeys: CONFIG.DND5E.movementTypes, initialKeysOnly: true
+      }),
       units: new StringField({
         required: true, nullable: true, blank: false, initial: initialUnits, label: "DND5E.MOVEMENT.FIELDS.units.label"
       }),
@@ -30,5 +30,59 @@ export default class MovementField extends foundry.data.fields.SchemaField {
     };
     Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);
     super(fields, { label: "DND5E.Movement", ...options });
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Migration                              */
+  /* -------------------------------------------- */
+
+  /**
+   * Default movement types that need to be migrated and shimmed.
+   * @type {string[]}
+   */
+  static #DEFAULT_SPEEDS = ["walk", "burrow", "climb", "fly", "jump", "swim"];
+
+  /* -------------------------------------------- */
+
+  /**
+   * Migrate movement types into mapping field.
+   * @param {MovementData} [movement]  Movement data object to shim.
+   */
+  static _migrate(movement) {
+    if ( !movement ) return;
+    movement.speeds ??= {};
+    for ( const key of MovementField.#DEFAULT_SPEEDS ) {
+      if ( !(key in movement) || (key in movement.speeds) ) continue;
+      movement.speeds[key] = movement[key];
+      delete movement[key];
+    }
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Shims                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Apply shims to the senses field so old sense locations still work.
+   * @param {SensesData} senses  Senses data object to shim.
+   */
+  static _shim(senses) {
+    for ( const key of MovementField.#DEFAULT_SPEEDS ) {
+      Object.defineProperty(senses, key, {
+        get() {
+          foundry.utils.logCompatibilityWarning(`movement.${key} has moved to "movement.speeds.${key}".`, {
+            since: "DnD5e 6.0", until: "DnD5e 7.0", once: true
+          });
+          return this.speeds[key];
+        },
+        set(value) {
+          foundry.utils.logCompatibilityWarning(`movement.${key} has moved to "movement.speeds.${key}".`, {
+            since: "DnD5e 6.0", until: "DnD5e 7.0", once: true
+          });
+          this.speeds[key] = value;
+        },
+        enumerable: true
+      });
+    }
   }
 }

--- a/module/data/shared/movement-field.mjs
+++ b/module/data/shared/movement-field.mjs
@@ -63,16 +63,13 @@ export default class MovementField extends foundry.data.fields.SchemaField {
   /* -------------------------------------------- */
 
   /**
-   * Apply shims to the senses field so old sense locations still work.
-   * @param {SensesData} senses  Senses data object to shim.
+   * Apply shims to the movement field so old movement locations still work.
+   * @param {MovementData} movement  Movement data object to shim.
    */
-  static _shim(senses) {
+  static _shim(movement) {
     for ( const key of MovementField.#DEFAULT_SPEEDS ) {
-      Object.defineProperty(senses, key, {
+      Object.defineProperty(movement, key, {
         get() {
-          foundry.utils.logCompatibilityWarning(`movement.${key} has moved to "movement.speeds.${key}".`, {
-            since: "DnD5e 6.0", until: "DnD5e 7.0", once: true
-          });
           return this.speeds[key];
         },
         set(value) {

--- a/module/data/shared/senses-field.mjs
+++ b/module/data/shared/senses-field.mjs
@@ -3,6 +3,10 @@ import MappingField from "../fields/mapping-field.mjs";
 const { NumberField, StringField } = foundry.data.fields;
 
 /**
+ * @import { SensesData } from "./_types.mjs";
+ */
+
+/**
  * Field for storing senses data.
  */
 export default class SensesField extends foundry.data.fields.SchemaField {

--- a/module/data/shared/senses-field.mjs
+++ b/module/data/shared/senses-field.mjs
@@ -64,9 +64,6 @@ export default class SensesField extends foundry.data.fields.SchemaField {
     for ( const key of SensesField.#DEFAULT_SENSES ) {
       Object.defineProperty(senses, key, {
         get() {
-          foundry.utils.logCompatibilityWarning(`senses.${key} has moved to "senses.ranges.${key}".`, {
-            since: "DnD5e 5.3", until: "DnD5e 6.1", once: true
-          });
           return this.ranges[key];
         },
         set(value) {

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -60,6 +60,12 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    */
   static SHIM_FIELDS = {
     "system.attributes.movement.speed": { key: "system.attributes.movement.walk" },
+    "system.attributes.movement.burrow": { key: "system.attributes.movement.speeds.burrow" },
+    "system.attributes.movement.climb": { key: "system.attributes.movement.speeds.climb" },
+    "system.attributes.movement.fly": { key: "system.attributes.movement.speeds.fly" },
+    "system.attributes.movement.jump": { key: "system.attributes.movement.speeds.jump" },
+    "system.attributes.movement.swim": { key: "system.attributes.movement.speeds.swim" },
+    "system.attributes.movement.walk": { key: "system.attributes.movement.speeds.walk" },
     "system.attributes.senses.darkvision": { key: "system.attributes.senses.ranges.darkvision" },
     "system.attributes.senses.blindsight": { key: "system.attributes.senses.ranges.blindsight" },
     "system.attributes.senses.tremorsense": { key: "system.attributes.senses.ranges.tremorsense" },

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2668,7 +2668,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }</span>`;
     return Object.entries(CONFIG.DND5E.movementTypes).reduce((html, [k, { hidden, label }]) => {
       if ( hidden ) return html;
-      const value = movement[k];
+      const value = movement.speeds[k];
       if ( (k === "fly") && movement.hover ) label = _loc("DND5E.MOVEMENT.HoverSpeed", { speed: label });
       if ( value || (k === "walk") ) html += `
         <div class="row">

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -967,7 +967,7 @@ function _migrateActorFlags(actorData, updateData) {
 function _migrateActorMovementSenses(actorData, updateData) {
   if ( actorData._stats?.systemVersion && foundry.utils.isNewerVersion("2.4.0", actorData._stats.systemVersion) ) {
     for ( const key of Object.keys(CONFIG.DND5E.movementTypes) ) {
-      const keyPath = `system.attributes.movement.${key}`;
+      const keyPath = `system.attributes.movement.speeds.${key}`;
       if ( foundry.utils.getProperty(actorData, keyPath) === 0 ) updateData[keyPath] = null;
     }
     for ( const key of Object.keys(CONFIG.DND5E.senses) ) {

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1394,13 +1394,10 @@ export function getHumanReadableAttributeLabel(attr, { actor, item, prefixItemNa
   }
 
   // Movement
-  else if ( attr.startsWith("attributes.movement.speeds.") ) {
-    label = CONFIG.DND5E.movementTypes[attr.split(".")[3]]?.label;
-  } else if ( attr.startsWith("attributes.movement.") ) label = CONFIG.DND5E.movementTypes[attr.split(".")[2]]?.label;
+  else if ( attr.startsWith("attributes.movement.") ) label = CONFIG.DND5E.movementTypes[attr.split(".").at(-1)]?.label;
 
   // Senses
-  else if ( attr.startsWith("attributes.senses.ranges.") ) label = CONFIG.DND5E.senses[attr.split(".")[3]]?.label;
-  else if ( attr.startsWith("attributes.senses.") ) label = CONFIG.DND5E.senses[attr.split(".")[2]]?.label;
+  else if ( attr.startsWith("attributes.senses.") ) label = CONFIG.DND5E.senses[attr.split(".").at(-1)]?.label;
 
   // Resources
   else if ( attr === "resources.legact.spent" ) label = "DND5E.LegendaryAction.LabelPl";

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1329,7 +1329,7 @@ export function getHumanReadableAttributeLabel(attr, { actor, item, prefixItemNa
     return item?.name ?? getUnknownLabel(attr, { actor, item });
   }
 
-  // Check if the attribute is already in cache.
+  // Check if the attribute is already in cache
   let label = item ? null : _attributeLabelCache.actor.get(attr);
   if ( label ) return label;
   let name;
@@ -1386,12 +1386,17 @@ export function getHumanReadableAttributeLabel(attr, { actor, item, prefixItemNa
   else if ( attr === "attributes.spell.attack" ) label = "DND5E.SpellAttackBonus";
   else if ( attr === "attributes.spell.dc" ) label = "DND5E.SpellDC";
 
-  // Abilities.
+  // Abilities
   else if ( attr.startsWith("abilities.") || attr.startsWith("attributes.ac.clamped.") ) {
     const [key, ...keyPath] = attr.split(".").slice(attr.startsWith("abilities.") ? 1 : 3);
     const mapping = dnd5e.dataModels.actor.CharacterData.schema.getField("abilities");
     label = mapping.getFieldLabel(key, keyPath.toReversed());
   }
+
+  // Movement
+  else if ( attr.startsWith("attributes.movement.speeds.") ) {
+    label = CONFIG.DND5E.movementTypes[attr.split(".")[3]]?.label;
+  } else if ( attr.startsWith("attributes.movement.") ) label = CONFIG.DND5E.movementTypes[attr.split(".")[2]]?.label;
 
   // Senses
   else if ( attr.startsWith("attributes.senses.ranges.") ) label = CONFIG.DND5E.senses[attr.split(".")[3]]?.label;
@@ -1422,7 +1427,7 @@ export function getHumanReadableAttributeLabel(attr, { actor, item, prefixItemNa
     label = mapping.getFieldLabel(key, keyPath.toReversed());
   }
 
-  // Spell slots.
+  // Spell slots
   else if ( attr.startsWith("spells.") ) {
     const [, key] = attr.split(".");
     if ( !/spell\d+/.test(key) ) label = `DND5E.SpellSlots${key.capitalize()}`;
@@ -1439,7 +1444,7 @@ export function getHumanReadableAttributeLabel(attr, { actor, item, prefixItemNa
     label = CONFIG.DND5E.currencies[key]?.label;
   }
 
-  // Attempt to find the attribute in a data model.
+  // Attempt to find the attribute in a data model
   if ( !label && (type === "actor") ) label = getSchemaLabel(attr, "Actor", actor);
 
   // Call hook if no label is available


### PR DESCRIPTION
Moves individual movement speeds into `movement.speeds` as a `MappingField` to allow for custom speeds, shim the old location, and add permanent active effect redirections.

Closes #2759