### PR TITLE
[#6102] Add school restriction within item choice advancement

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -571,6 +571,10 @@
           "hint": "Only allow spells from these lists.",
           "label": "Spell Lists"
         },
+        "school": {
+          "hint": "Only allow spells from these schools.",
+          "label": "Spell Schools"
+        },
         "subtype": {
           "label": "Subtype"
         },
@@ -600,7 +604,8 @@
       "NoOriginal": "Previously selected choice no longer available for replacement.",
       "SpellLevelAvailable": "Only {level} or lower spells can be chosen for this advancement.",
       "SpellLevelSpecific": "Only {level} spells can be chosen for this advancement.",
-      "SpellList": "Only spells available on the {lists} spell list can be chosen for this advancement."
+      "SpellList": "Only spells available on the {lists} spell list can be chosen for this advancement.",
+      "SpellSchool": "Only spells of the {schools} school can be chosen for this advancement."
     }
   },
   "ItemGrant": {

--- a/module/applications/advancement/item-choice-config.mjs
+++ b/module/applications/advancement/item-choice-config.mjs
@@ -74,6 +74,8 @@ export default class ItemChoiceConfig extends ItemSharedConfig {
       ...Object.entries(CONFIG.DND5E.spellLevels).map(([value, label]) => ({ value, label }))
     ];
     context.listRestrictionOptions = dnd5e.registry.spellLists.options;
+    context.schoolRestrictionOptions = Object.entries(CONFIG.DND5E.spellSchools)
+      .map(([value, { label }]) => ({ value, label }));
     context.showContainerWarning = context.items.some(i => i.index?.type === "container");
     context.showSpellConfig = this.advancement.configuration.type === "spell";
 

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -233,7 +233,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
       return;
     }
 
-    const filters = { locked: { additional: {}, documentClass: "Item" } };
+    const filters = { locked: { additional: {}, documentClass: "Item", exclusive: true } };
 
     // Apply restrictions based on type
     if ( config.type ) {
@@ -267,6 +267,14 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
     // Apply restrictions based on spell list
     if ( (config.type === "spell") && config.restriction.list.size ) {
       filters.locked.additional.spelllist = config.restriction.list.reduce((obj, list) => {
+        obj[list] = 1;
+        return obj;
+      }, {});
+    }
+
+    // Apply restrictions based on spell school
+    if ( (config.type === "spell") && config.restriction.school.size ) {
+      filters.locked.additional.school = config.restriction.school.reduce((obj, list) => {
         obj[list] = 1;
         return obj;
       }, {});

--- a/module/applications/advancement/item-choice-flow.mjs
+++ b/module/applications/advancement/item-choice-flow.mjs
@@ -233,7 +233,7 @@ export default class ItemChoiceFlow extends ItemGrantFlow {
       return;
     }
 
-    const filters = { locked: { additional: {}, documentClass: "Item", exclusive: true } };
+    const filters = { locked: { additional: {}, documentClass: "Item" } };
 
     // Apply restrictions based on type
     if ( config.type ) {

--- a/module/data/advancement/_types.mjs
+++ b/module/data/advancement/_types.mjs
@@ -40,6 +40,7 @@
  * @property {object} restriction
  * @property {"available"|number} restriction.level           Level of spell allowed.
  * @property {Set<string>} restriction.list                   Spell lists from which a spell must be selected.
+ * @property {Set<string>} restriction.school                 Spell schools from which a spell must be selected.
  * @property {string} restriction.subtype                     Item sub-type allowed.
  * @property {string} restriction.type                        Specific item type allowed.
  * @property {"a"|"m"} sorting                                Sorting mode for the item list.

--- a/module/data/advancement/item-choice-data.mjs
+++ b/module/data/advancement/item-choice-data.mjs
@@ -31,7 +31,7 @@ export class ItemChoiceConfigurationData extends foundry.abstract.DataModel {
     return {
       allowDrops: new BooleanField({ initial: true }),
       choices: new MappingField(new SchemaField({
-        count: new NumberField({integer: true, min: 0}),
+        count: new NumberField({ integer: true, min: 0 }),
         replacement: new BooleanField()
       })),
       pool: new ArrayField(new SchemaField({
@@ -41,6 +41,7 @@ export class ItemChoiceConfigurationData extends foundry.abstract.DataModel {
       restriction: new SchemaField({
         level: new StringField(),
         list: new SetField(new StringField()),
+        school: new SetField(new StringField()),
         subtype: new StringField(),
         type: new StringField()
       }),

--- a/module/documents/advancement/item-choice.mjs
+++ b/module/documents/advancement/item-choice.mjs
@@ -312,6 +312,14 @@ export default class ItemChoiceAdvancement extends ItemGrantAdvancement {
       });
     }
 
+    // If spell school is specified, ensure the spell is of that school
+    if ( (type === "spell") && restriction.school.size && !restriction.school.has(item.system.school) ) {
+      const schools = Array.from(restriction.school).map(s => CONFIG.DND5E.spellSchools[s]?.label).filter(_ => _);
+      return handleError("DND5E.ADVANCEMENT.ItemChoice.Warning.SpellSchool", {
+        schools: game.i18n.getListFormatter({ type: "disjunction" }).format(schools)
+      });
+    }
+
     return true;
   }
 }

--- a/templates/advancement/item-choice-config-details.hbs
+++ b/templates/advancement/item-choice-config-details.hbs
@@ -17,6 +17,8 @@
     {{#if @root.showSpellConfig}}
     {{ formGroup fields.level name="configuration.restriction.level" value=data.level
                  options=@root.levelRestrictionOptions rootId=@root.partId }}
+    {{ formGroup fields.school name="configuration.restriction.school" value=data.school
+                 options=@root.schoolRestrictionOptions rootId=@root.partId }}
     {{ formGroup fields.list name="configuration.restriction.list" value=data.list options=@root.listRestrictionOptions
                  rootId=@root.partId }}
     {{/if}}


### PR DESCRIPTION
Allows for restricting spell selection within an item choice advancement to a certain school.

Closes #6102