### PR TITLE
[#7196] Allow for subtracting an instance of advantage or disadvantage

### DIFF
--- a/module/data/fields/advantage-mode-field.mjs
+++ b/module/data/fields/advantage-mode-field.mjs
@@ -40,6 +40,17 @@ export default class AdvantageModeField extends foundry.data.fields.NumberField 
   /* -------------------------------------------- */
 
   /** @override */
+  _applyChangeSubtract(value, delta, model, change) {
+    if ( (delta !== -1) && (delta !== 1) ) return value;
+    const counts = this.constructor.getCounts(model, change.key);
+    if ( delta === 1 ) counts.advantages.count--;
+    else counts.disadvantage.count--;
+    return this.constructor.resolveMode(model, change, counts);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
   _applyChangeDowngrade(value, delta, model, change) {
     // Downgrade the roll so that it can no longer benefit from advantage.
     if ( (delta !== -1) && (delta !== 0) ) return value;
@@ -149,8 +160,8 @@ export default class AdvantageModeField extends foundry.data.fields.NumberField 
     const { override, advantages, disadvantages } = counts ?? this.getCounts(model, keyPath);
     if ( override !== null ) return override;
     const src = foundry.utils.getProperty(model._source, keyPath) ?? 0;
-    const advantageCount = advantages.suppressed ? 0 : advantages.count + Number(src === 1);
-    const disadvantageCount = disadvantages.suppressed ? 0 : disadvantages.count + Number(src === -1);
+    const advantageCount = advantages.suppressed ? 0 : Math.max(0, advantages.count + Number(src === 1));
+    const disadvantageCount = disadvantages.suppressed ? 0 : Math.max(0, disadvantages.count + Number(src === -1));
     return Math.sign(advantageCount) - Math.sign(disadvantageCount);
   }
 

--- a/module/data/fields/advantage-mode-field.mjs
+++ b/module/data/fields/advantage-mode-field.mjs
@@ -44,7 +44,7 @@ export default class AdvantageModeField extends foundry.data.fields.NumberField 
     if ( (delta !== -1) && (delta !== 1) ) return value;
     const counts = this.constructor.getCounts(model, change.key);
     if ( delta === 1 ) counts.advantages.count--;
-    else counts.disadvantage.count--;
+    else counts.disadvantages.count--;
     return this.constructor.resolveMode(model, change, counts);
   }
 


### PR DESCRIPTION
Closes #7196.

`subtract 1` removes an instance of advantage.

`subtract -1` removes an instance of disadvantage.

`subtract <anything else>` does nothing.

Final count (when comparing advantages to disadvantages) uses `Math.max` to prevent the two counts going below 0.