### PR TITLE
Suppress `condition`-type effects for which the Actor has condition immunity

### DIFF
--- a/module/data/active-effect/condition.mjs
+++ b/module/data/active-effect/condition.mjs
@@ -46,6 +46,13 @@ export default class ConditionData extends foundry.data.ActiveEffectTypeDataMode
       : null;
   }
 
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  get isSuppressed() {
+    return this.parent.actor?.system.traits?.ci?.value.has(this.type);
+  }
+
   /* -------------------------------------------------- */
 
   /** @inheritDoc */


### PR DESCRIPTION
Will still appear toggled on in the Conditions panel, even when suppressed. But that feels like something that would be better addressed in a more comprehensive PR like #5296 