### PR TITLE
Handle generating dispositions for area of effect behaviors

### DIFF
--- a/module/data/region-behavior/apply-active-effect.mjs
+++ b/module/data/region-behavior/apply-active-effect.mjs
@@ -210,9 +210,10 @@ export class ApplyActiveEffectActivityBehavior extends BaseActivityBehavior {
 
   /** @override */
   createBehaviorData(activity, options={}) {
+    const disposition = activity.actor?.token?.disposition ?? activity.actor?.prototypeToken?.disposition;
     return {
       system: {
-        dispositions: this.getDispositions(activity.target),
+        dispositions: this.getDispositions(activity.target, { relativeTo: disposition }),
         effects: this.effects,
         sizes: this.sizes,
         types: this.types

--- a/module/data/region-behavior/apply-active-effect.mjs
+++ b/module/data/region-behavior/apply-active-effect.mjs
@@ -41,6 +41,7 @@ export default class ApplyActiveEffect5eRegionBehaviorType extends foundry.data.
    * @returns {boolean}
    */
   #evaluateConditions(token) {
+    if ( token.disposition === CONST.TOKEN_DISPOSITIONS.SECRET ) return false;
     if ( this.dispositions.size && !this.dispositions.has(token.disposition) ) return false;
     if ( this.sizes.size && !this.sizes.has(token.actor.system.traits?.size) ) return false;
     if ( this.types.size && !this.types.has(token.actor.system.details?.type?.value) ) return false;
@@ -211,10 +212,10 @@ export class ApplyActiveEffectActivityBehavior extends BaseActivityBehavior {
   createBehaviorData(activity, options={}) {
     return {
       system: {
+        dispositions: this.getDispositions(activity.target),
         effects: this.effects,
         sizes: this.sizes,
         types: this.types
-        // TODO: Set "dispositions" based on target affects settings
       },
       type: "dnd5e.applyActiveEffect"
     };

--- a/module/data/region-behavior/base-activity-behavior.mjs
+++ b/module/data/region-behavior/base-activity-behavior.mjs
@@ -105,4 +105,20 @@ export default class BaseActivityBehavior extends foundry.abstract.DataModel {
       }
     }
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Determine what dispositions this region should apply to or ignore based on activity targeting data.
+   * @param {TargetData} target          Target data from the activity.
+   * @param {object} [options={}]
+   * @param {boolean} [options.ignored]  Should this generate an ignored list rather than a targeted list.
+   * @returns {Set<string>}              Set of dispositions to target.
+   */
+  getDispositions(target, { ignored }={}) {
+    const { HOSTILE, NEUTRAL, FRIENDLY } = CONST.TOKEN_DISPOSITIONS;
+    if ( target.affects.type === "ally" ) return new Set(ignored ? [HOSTILE, NEUTRAL] : [FRIENDLY]);
+    else if ( target.affects.type === "enemy" ) return new Set(ignored ? [NEUTRAL, FRIENDLY] : [HOSTILE]);
+    else return new Set();
+  }
 }

--- a/module/data/region-behavior/base-activity-behavior.mjs
+++ b/module/data/region-behavior/base-activity-behavior.mjs
@@ -110,15 +110,18 @@ export default class BaseActivityBehavior extends foundry.abstract.DataModel {
 
   /**
    * Determine what dispositions this region should apply to or ignore based on activity targeting data.
-   * @param {TargetData} target          Target data from the activity.
+   * @param {TargetData} target            Target data from the activity.
    * @param {object} [options={}]
-   * @param {boolean} [options.ignored]  Should this generate an ignored list rather than a targeted list.
-   * @returns {Set<string>}              Set of dispositions to target.
+   * @param {boolean} [options.ignored]    Should this generate an ignored list rather than a targeted list.
+   * @param {number} [options.relativeTo]  Determine dispositions relative to this disposition.
+   * @returns {Set<number>}                Set of dispositions to target or ignore.
    */
-  getDispositions(target, { ignored }={}) {
+  getDispositions(target, { ignored, relativeTo }={}) {
     const { HOSTILE, NEUTRAL, FRIENDLY } = CONST.TOKEN_DISPOSITIONS;
-    if ( target.affects.type === "ally" ) return new Set(ignored ? [HOSTILE, NEUTRAL] : [FRIENDLY]);
-    else if ( target.affects.type === "enemy" ) return new Set(ignored ? [NEUTRAL, FRIENDLY] : [HOSTILE]);
+    const type = relativeTo !== HOSTILE ? target.affects.type
+      : target.affects.type === "ally" ? "enemy" : target.affects.type === "enemy" ? "ally" : target.affects.type;
+    if ( type === "ally" ) return new Set(ignored ? [HOSTILE, NEUTRAL] : [FRIENDLY]);
+    else if ( type === "enemy" ) return new Set(ignored ? [NEUTRAL, FRIENDLY] : [HOSTILE]);
     else return new Set();
   }
 }

--- a/module/data/region-behavior/difficult-terrain.mjs
+++ b/module/data/region-behavior/difficult-terrain.mjs
@@ -122,9 +122,10 @@ export class DifficultTerrainActivityBehavior extends BaseActivityBehavior {
 
   /** @override */
   createBehaviorData(activity, options={}) {
+    const disposition = activity.actor?.token?.disposition ?? activity.actor?.prototypeToken?.disposition;
     return {
       system: {
-        ignoredDispositions: this.getDispositions(activity.target, { ignored: true }),
+        ignoredDispositions: this.getDispositions(activity.target, { ignored: true, relativeTo: disposition }),
         magical: activity.isSpell || activity.item?.system.properties?.has("mgc"),
         types: this.types
       },

--- a/module/data/region-behavior/difficult-terrain.mjs
+++ b/module/data/region-behavior/difficult-terrain.mjs
@@ -86,6 +86,7 @@ export default class DifficultTerrainRegionBehaviorType extends foundry.data.reg
   /** @override */
   _getTerrainEffects(token, segment) {
     const ignoredTypes = token.actor?.system.attributes?.movement?.ignoredDifficultTerrain ?? new Set();
+    if ( token.disposition === CONST.TOKEN_DISPOSITIONS.SECRET ) return [];
     if ( this.ignoredDispositions.has(token.disposition) || ignoredTypes.has("all")
       || (this.types.size && !this.types.difference(ignoredTypes).size)
       || (ignoredTypes.has("magical") && this.magical)
@@ -123,9 +124,9 @@ export class DifficultTerrainActivityBehavior extends BaseActivityBehavior {
   createBehaviorData(activity, options={}) {
     return {
       system: {
+        ignoredDispositions: this.getDispositions(activity.target, { ignored: true }),
         magical: activity.isSpell || activity.item?.system.properties?.has("mgc"),
         types: this.types
-        // TODO: Set "ignoredDispositions" based on target affects settings
       },
       type: "dnd5e.difficultTerrain"
     };


### PR DESCRIPTION
Adds `BaseActivityBehavior#getDispositions` to determine what dispositions should be applied to a region behavior based on the targeting data from an activity.

Also makes difficult terrain regions and apply active effect regions ignore tokens with the secret disposition.