### PR TITLE
Add single `attributes.movement.multiplier` field to fix doubling

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4341,6 +4341,9 @@
     "ignoredDifficultTerrain": {
       "label": "Ignored Difficult Terrain"
     },
+    "multiplier": {
+      "label": "Movement Multiplier"
+    },
     "special": {
       "label": "Special Movement"
     },

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -566,12 +566,12 @@ export default class AttributesFields {
     }
     reduction = convertLength(reduction, CONFIG.DND5E.defaultUnits.length.imperial, units);
     const bonus = simplifyBonus(this.attributes.movement.bonus, rollData);
+    const multiplier = this.attributes.movement.multiplier * (halfMovement ? 0.5 : 1);
     this.attributes.movement.max = 0;
     for ( const type of Object.keys(CONFIG.DND5E.movementTypes) ) {
       let speed = Math.max(0, speeds[type] - reduction);
-      if ( speed ) {
-        speed = Math.max(0, speed + bonus);
-        if ( halfMovement ) speed *= 0.5;
+      if ( (speed * multiplier) > 0 ) {
+        speed = Math.max(0, speed + bonus) * multiplier;
         if ( heavilyEncumbered ) {
           speed = Math.max(0, speed - (CONFIG.DND5E.encumbrance.speedReduction.heavilyEncumbered[units] ?? 0));
         } else if ( encumbered ) {
@@ -580,10 +580,12 @@ export default class AttributesFields {
         if ( exceedingCarryingCapacity ) {
           speed = Math.min(speed, CONFIG.DND5E.encumbrance.speedReduction.exceedingCarryingCapacity[units] ?? 0);
         }
+        speeds[type] = speed;
+      } else {
+        speeds[type] = 0;
       }
-      speeds[type] = speed;
-      this.attributes.movement.max = Math.max(speed, this.attributes.movement.max);
-      if ( type === "walk" ) this.attributes.movement.speed = speed;
+      this.attributes.movement.max = Math.max(speeds[type], this.attributes.movement.max);
+      if ( type === "walk" ) this.attributes.movement.speed = speeds[type];
     }
     const baseSpeed = this._source.attributes.movement.speeds.walk || this.attributes.movement.fromSpecies?.walk;
     this.attributes.movement.slowed = speeds.walk <= (simplifyBonus(baseSpeed, rollData) / 2);

--- a/module/data/item/_types.mjs
+++ b/module/data/item/_types.mjs
@@ -123,7 +123,7 @@
 
 /**
  * @typedef RaceItemSystemData
- * @property {Omit<MovementData, "special">} movement
+ * @property {Omit<MovementData, "bonus"|"multiplier"|"special">} movement
  * @property {SensesData} senses
  * @property {Omit<CreatureTypeData, "swarm">} type
  */

--- a/module/data/item/race.mjs
+++ b/module/data/item/race.mjs
@@ -31,7 +31,10 @@ export default class RaceData extends ItemDataModel.mixin(AdvancementTemplate, I
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema(super.defineSchema(), {
-      movement: new MovementField({ bonus: false, special: false }, { initialUnits: defaultUnits("length") }),
+      movement: new MovementField(
+        { bonus: false, multiplier: false, special: false },
+        { initialUnits: defaultUnits("length") }
+      ),
       senses: new SensesField({}, { initialUnits: defaultUnits("length") }),
       type: new CreatureTypeField({ swarm: false }, { initial: { value: "humanoid" } })
     });

--- a/module/data/shared/_types.mjs
+++ b/module/data/shared/_types.mjs
@@ -55,6 +55,7 @@
 /**
  * @typedef MovementData
  * @property {string} bonus                         Bonus applied to all movement types that already have a speed.
+ * @property {number} multiplier                    Multiplier for each movement type.
  * @property {string} special                       Semi-colon separated list of special movement information.
  * @property {Record<string, string>} speeds        Speeds for various movement types.
  * @property {string} units                         Movement used to measure the various speeds.

--- a/module/data/shared/movement-field.mjs
+++ b/module/data/shared/movement-field.mjs
@@ -1,7 +1,7 @@
 import FormulaField from "../fields/formula-field.mjs";
 import MappingField from "../fields/mapping-field.mjs";
 
-const { BooleanField, SetField, StringField } = foundry.data.fields;
+const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { TravelPace5e } from "../actor/fields/_types.mjs";
@@ -15,6 +15,9 @@ export default class MovementField extends foundry.data.fields.SchemaField {
   constructor(fields={}, { initialUnits=null, ...options }={}) {
     fields = {
       bonus: new FormulaField({ deterministic: true, label: "DND5E.MOVEMENT.FIELDS.bonus.label" }),
+      multiplier: new NumberField({
+        min: 0, initial: 1, persisted: false, label: "DND5E.MOVEMENT.FIELDS.multiplier.label"
+      }),
       special: new StringField({ label: "DND5E.MOVEMENT.FIELDS.special.label" }),
       speeds: new MappingField(new FormulaField({ deterministic: true }), {
         initialKeys: CONFIG.DND5E.movementTypes, initialKeysOnly: true


### PR DESCRIPTION
Adds a non-persisted multiplier field to movement data to be targeted by active effects. This field is required to ensure that speed multiplication occurs at the correct point and that speed multiplication isn't done more than once (for example, if a speed uses the formula `@attributes.movement.speed`, then walking speed would be halved first and then this speed would be halved, ending up with only a quarter of the desired speed).