### PR TITLE
SRD 5.1 Update - Items (Potions)

### DIFF
--- a/packs/_source/items/potion/acid-vial.yml
+++ b/packs/_source/items/potion/acid-vial.yml
@@ -6,7 +6,8 @@ system:
   description:
     value: >-
       <p>As an action, you can splash the contents of this vial onto a creature
-      within 5 feet of you or throw the vial up to 20 feet, shattering it on
+      within 5 feet of you or throw the vial up to [[lookup
+      @labels.description.range activity=6wCdPWZTzKh8mN0m]], shattering it on
       impact. In either case, make a ranged attack against a creature or object,
       treating the acid as an improvised weapon. On a hit, the target takes 2d6
       acid damage.</p>
@@ -57,8 +58,7 @@ system:
   properties: []
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    6wCdPWZTzKh8mN0m:
       type: attack
       activation:
         type: action
@@ -73,10 +73,11 @@ system:
         spellSlot: true
       description:
         chatFlavor: improvised weapon
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
@@ -93,7 +94,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -127,10 +129,20 @@ system:
               mode: whole
               number: null
               formula: ''
+            modifiers: []
       uses:
         spent: 0
         recovery: []
-      sort: 0
+      sort: 100000
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      _id: 6wCdPWZTzKh8mN0m
   attuned: false
   identifier: acid-vial
 effects: []
@@ -141,11 +153,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037191870
-  modifiedTime: 1725992514681
+  modifiedTime: 1783376448949
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Sx5E6utixHdAbGNb'

--- a/packs/_source/items/potion/alchemists-fire.yml
+++ b/packs/_source/items/potion/alchemists-fire.yml
@@ -1,16 +1,17 @@
 _id: FvNOwWbh5FXyX4xe
 name: Alchemist's Fire
 type: consumable
-img: icons/consumables/potions/bottle-round-corked-yellow.webp
+img: icons/consumables/potions/potion-flask-corked-orange.webp
 system:
   description:
     value: >-
       <p>This sticky, adhesive fluid ignites when exposed to air. As an action,
-      you can throw this flask up to 20 feet, shattering it on impact. Make a
-      ranged attack against a creature or object, treating the alchemist's fire
-      as an improvised weapon. On a hit, the target takes 1d4 fire damage at the
-      start of each of its turns. A creature can end this damage by using its
-      action to make a DC 10 Dexterity check to extinguish the flames.</p>
+      you can throw this flask up to [[lookup @labels.description.range
+      activity=fEkrHFEJKXhIwljC]], shattering it on impact. Make a ranged attack
+      against a creature or object, treating the alchemist's fire as an
+      improvised weapon. On a hit, the target takes 1d4 fire damage at the start
+      of each of its turns. A creature can end this damage by using its action
+      to make a DC 10 Dexterity check to extinguish the flames.</p>
     chat: ''
   source:
     custom: ''
@@ -53,13 +54,13 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: <p>A flask of sticky, adhesive fluid.</p>
+    name: Unidentified Flask
   container: null
   properties: []
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    fEkrHFEJKXhIwljC:
       type: attack
       activation:
         type: action
@@ -80,13 +81,17 @@ system:
         spellSlot: true
       description:
         chatFlavor: improvised weapon
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: qAc1etkfUQkCbmTM
+          uuid: null
+          level: {}
       range:
         value: '20'
         units: ft
@@ -100,7 +105,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -134,87 +140,64 @@ system:
               mode: whole
               number: null
               formula: ''
+            modifiers: []
       uses:
         spent: 0
         recovery: []
-      sort: 0
-    dnd5eactivity100:
-      _id: dnd5eactivity100
-      type: save
-      activation:
-        type: action
-        value: 1
-        condition: ''
-        override: false
-      consumption:
-        targets:
-          - type: itemUses
-            target: ''
-            value: '1'
-            scaling:
-              mode: ''
-              formula: ''
-        scaling:
-          allowed: false
-          max: ''
-        spellSlot: true
-      description:
-        chatFlavor: improvised weapon
-      duration:
-        concentration: false
-        value: ''
-        units: ''
-        special: ''
-        override: false
-      effects: []
-      range:
-        value: '20'
-        units: ft
-        special: ''
-        override: false
-      target:
-        template:
-          count: ''
-          contiguous: false
-          type: ''
-          size: ''
-          width: ''
-          height: ''
-          units: ''
-        affects:
-          count: '1'
-          type: creature
-          choice: false
-          special: ''
-        prompt: true
-        override: false
-      damage:
-        onSave: half
-        parts:
-          - number: 1
-            denomination: 4
-            bonus: ''
-            types:
-              - fire
-            custom:
-              enabled: false
-              formula: ''
-            scaling:
-              mode: whole
-              number: null
-              formula: ''
-      save:
-        ability: dex
-        dc:
-          calculation: ''
-          formula: '10'
-      uses:
-        spent: 0
-        recovery: []
-      sort: 0
+      sort: 100000
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      _id: fEkrHFEJKXhIwljC
   attuned: false
   identifier: alchemists-fire
-effects: []
+effects:
+  - name: Covered in Alchemist's Fire
+    img: icons/magic/fire/flame-burning-skeleton-explosion.webp
+    origin: Compendium.dnd5e.items.Item.FvNOwWbh5FXyX4xe
+    transfer: false
+    _id: qAc1etkfUQkCbmTM
+    type: base
+    system:
+      changes: []
+      magical: false
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: null
+      units: seconds
+      expiry: null
+      expired: false
+    description: >-
+      <p>You are covered in Alchemist's Fire, and take [[/damage 1d4 fire]]
+      damage at the start of each of your turns. You can end this damage by
+      using your action to make a [[/check 10 dex]] check to extinguish the
+      flames.</p>
+    tint: '#ffffff'
+    statuses:
+      - burning
+    showIcon: 2
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783376239339
+      modifiedTime: 1783376346692
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!FvNOwWbh5FXyX4xe.qAc1etkfUQkCbmTM'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -222,11 +205,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037145495
-  modifiedTime: 1725992499021
+  modifiedTime: 1783376239397
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!FvNOwWbh5FXyX4xe'

--- a/packs/_source/items/potion/antitoxin.yml
+++ b/packs/_source/items/potion/antitoxin.yml
@@ -26,7 +26,7 @@ system:
   attunement: ''
   equipped: false
   rarity: ''
-  identified: false
+  identified: true
   uses:
     max: '1'
     recovery: []
@@ -174,7 +174,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037143228
-  modifiedTime: 1783375851022
+  modifiedTime: 1783645994607
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Fc6UfFNOnW80XMzi'

--- a/packs/_source/items/potion/antitoxin.yml
+++ b/packs/_source/items/potion/antitoxin.yml
@@ -1,12 +1,13 @@
 _id: Fc6UfFNOnW80XMzi
 name: Antitoxin
 type: consumable
-img: icons/consumables/potions/bottle-round-corked-pink.webp
+img: icons/consumables/potions/bottle-conical-corked-green.webp
 system:
   description:
     value: >-
       <p>A creature that drinks this vial of liquid gains advantage on saving
-      throws against poison for 1 hour. It confers no benefit to undead or
+      throws against poison for [[lookup @labels.duration
+      activity=aSEhgvHgQF5LiEsf]]. It confers no benefit to undead or
       constructs.</p>
     chat: ''
   source:
@@ -25,7 +26,7 @@ system:
   attunement: ''
   equipped: false
   rarity: ''
-  identified: true
+  identified: false
   uses:
     max: '1'
     recovery: []
@@ -42,16 +43,16 @@ system:
         number: 1
     replace: false
   type:
-    value: potion
+    value: poison
     subtype: ''
   unidentified:
     description: ''
+    name: Unidentified Potion
   container: null
   properties: []
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    aSEhgvHgQF5LiEsf:
       type: utility
       activation:
         type: action
@@ -61,26 +62,27 @@ system:
       consumption:
         targets:
           - type: itemUses
-            target: ''
             value: '1'
-            scaling:
-              mode: ''
-              formula: ''
+            target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: 86kZBSv4Zyis1RQm
+          level: {}
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -91,7 +93,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: self
@@ -107,10 +110,59 @@ system:
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: aSEhgvHgQF5LiEsf
+      name: Drink
   attuned: false
   identifier: antitoxin
-effects: []
+effects:
+  - name: Antitoxin Protection
+    img: icons/consumables/potions/bottle-conical-corked-green.webp
+    origin: Compendium.dnd5e.items.Item.Fc6UfFNOnW80XMzi
+    transfer: false
+    _id: 86kZBSv4Zyis1RQm
+    type: base
+    system:
+      changes: []
+      magical: false
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You have advantage on saving throws against poison.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781978867630
+      modifiedTime: 1781978911227
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!Fc6UfFNOnW80XMzi.86kZBSv4Zyis1RQm'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -118,11 +170,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037143228
-  modifiedTime: 1725992498253
+  modifiedTime: 1783375851022
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Fc6UfFNOnW80XMzi'

--- a/packs/_source/items/potion/flask-of-holy-water.yml
+++ b/packs/_source/items/potion/flask-of-holy-water.yml
@@ -1,7 +1,7 @@
 _id: WPWszFTGzmdIuDRJ
 name: Flask of Holy Water
 type: consumable
-img: icons/consumables/potions/bottle-round-empty-glass.webp
+img: icons/consumables/potions/potion-bottle-corked-fancy-blue.webp
 system:
   description:
     value: >-
@@ -56,12 +56,12 @@ system:
     subtype: ''
   unidentified:
     description: ''
+    name: Unidentified Flask of Water
   container: null
   properties: []
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    mEAnlbwg1J9UZDDC:
       type: attack
       activation:
         type: action
@@ -82,10 +82,11 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
@@ -102,7 +103,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -136,10 +138,20 @@ system:
               mode: whole
               number: null
               formula: ''
+            modifiers: []
       uses:
         spent: 0
         recovery: []
-      sort: 0
+      sort: 100000
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      _id: mEAnlbwg1J9UZDDC
   attuned: false
   identifier: flask-of-holy-water
 effects: []
@@ -150,11 +162,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037205008
-  modifiedTime: 1725992519057
+  modifiedTime: 1783375859239
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!WPWszFTGzmdIuDRJ'

--- a/packs/_source/items/potion/oil-of-etherealness.yml
+++ b/packs/_source/items/potion/oil-of-etherealness.yml
@@ -146,7 +146,7 @@ effects:
       changes: []
       rider:
         statuses: []
-      magical: false
+      magical: true
     disabled: false
     start: null
     duration:
@@ -187,7 +187,7 @@ effects:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1783376748233
-      modifiedTime: 1783376778773
+      modifiedTime: 1783646317151
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: >-
         Compendium.dnd5e.spells.Item.PQuEgKyCdovOvhqN.ActiveEffect.rrA8RYmv4eAuVbg8
@@ -205,7 +205,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037211392
-  modifiedTime: 1783376789761
+  modifiedTime: 1783646353085
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Xbq8CyXSRV358SfP'

--- a/packs/_source/items/potion/oil-of-etherealness.yml
+++ b/packs/_source/items/potion/oil-of-etherealness.yml
@@ -6,14 +6,13 @@ system:
   description:
     value: >-
       <p><em>Beads of this cloudy gray oil form on the outside of its container
-      and quickly evaporate.  </em></p>
-
-      <p>The oil can cover a Medium or smaller creature, along with the
-      equipment it's wearing and carrying (one additional vial is required for
-      each size category above Medium).  Applying the oil takes 10 minutes.  The
+      and quickly evaporate.</em></p><p>The oil can cover a Medium or smaller
+      creature, along with the equipment it's wearing and carrying (one
+      additional vial is required for each size category above Medium). Applying
+      the oil takes [[lookup @labels.activation activity=xb8qrLDAQhKFA9MD]]. The
       affected creature then gains the effect of the
-      @UUID[Compendium.dnd5e.spells.Item.PQuEgKyCdovOvhqN]{Etherealness} spell
-      for 1 hour.</p>
+      @UUID[Compendium.dnd5e.spells.Item.PQuEgKyCdovOvhqN]{etherealness} spell
+      for [[lookup @labels.duration activity=xb8qrLDAQhKFA9MD]].</p>
     chat: ''
   source:
     custom: ''
@@ -51,38 +50,45 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>Beads of this cloudy gray oil form on the outside of its container and
+      quickly evaporate.</p>
+    name: Unidentified Oil
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    xb8qrLDAQhKFA9MD:
       type: utility
       activation:
-        type: action
-        value: 1
-        condition: Medium or smaller creature. Takes 10 minutes to apply.
+        type: minute
+        value: 10
+        condition: ''
         override: false
       consumption:
         targets:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: LajiYiJL7B2TZLUZ
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +101,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +119,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Apply Oil
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +128,72 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: xb8qrLDAQhKFA9MD
   attuned: false
   identifier: oil-of-etherealness
-effects: []
+effects:
+  - name: Etherealness
+    img: icons/creatures/magical/construct-golem-stone-blue.webp
+    origin: Compendium.dnd5e.items.Item.Xbq8CyXSRV358SfP
+    transfer: false
+    _id: LajiYiJL7B2TZLUZ
+    type: base
+    system:
+      changes: []
+      rider:
+        statuses: []
+      magical: false
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>You step into the border regions of the Ethereal Plane, in the area
+      where it overlaps with your current plane. You remain in the Border
+      Ethereal for the duration or until you use your action to dismiss this
+      effect. During this time, you can move in any direction. If you move up or
+      down, every foot of movement costs an extra foot. You can see and hear the
+      plane you originated from, but everything there looks gray, and you can't
+      see anything more than 60 feet away.</p><p>While on the Ethereal Plane,
+      you can only affect and be affected by other creatures on that plane.
+      Creatures that aren't on the Ethereal Plane can't perceive you and can't
+      interact with you, unless a special ability or magic has given them the
+      ability to do so.</p><p>You ignore all objects and effects that aren't on
+      the Ethereal Plane, allowing you to move through objects you perceive on
+      the plane you originated from.</p><p>When this effect ends, you
+      immediately return to the plane you originated from in the spot you
+      currently occupy. If you occupy the same spot as a solid object or
+      creature when this happens, you are immediately shunted to the nearest
+      unoccupied space that you can occupy and take force damage equal to twice
+      the number of feet you are moved.</p>
+    tint: '#ffffff'
+    statuses:
+      - ethereal
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags:
+      dnd5e:
+        riders: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783376748233
+      modifiedTime: 1783376778773
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: >-
+        Compendium.dnd5e.spells.Item.PQuEgKyCdovOvhqN.ActiveEffect.rrA8RYmv4eAuVbg8
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!Xbq8CyXSRV358SfP.LajiYiJL7B2TZLUZ'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +201,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037211392
-  modifiedTime: 1764620165757
+  modifiedTime: 1783376789761
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Xbq8CyXSRV358SfP'

--- a/packs/_source/items/potion/oil-of-sharpness.yml
+++ b/packs/_source/items/potion/oil-of-sharpness.yml
@@ -113,7 +113,7 @@ system:
           count: '1'
           special: ''
         override: false
-        prompt: true
+        prompt: false
       uses:
         spent: 0
         recovery: []
@@ -124,7 +124,7 @@ system:
           max: null
         requireAttunement: false
         requireIdentification: false
-        requireMagic: false
+        requireMagic: true
         identifier: ''
       enchant:
         self: false
@@ -188,7 +188,7 @@ system:
           type: object
           special: ''
         override: false
-        prompt: true
+        prompt: false
       uses:
         spent: 0
         recovery: []
@@ -199,7 +199,7 @@ system:
           max: null
         requireAttunement: false
         requireIdentification: false
-        requireMagic: false
+        requireMagic: true
         identifier: ''
       enchant:
         self: false
@@ -331,7 +331,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037126982
-  modifiedTime: 1783375642051
+  modifiedTime: 1783646334597
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!C0MNXWA81ufzGlp5'

--- a/packs/_source/items/potion/oil-of-sharpness.yml
+++ b/packs/_source/items/potion/oil-of-sharpness.yml
@@ -1,17 +1,16 @@
 _id: C0MNXWA81ufzGlp5
 name: Oil of Sharpness
 type: consumable
-img: icons/consumables/potions/potion-tube-corked-bat-gold-red.webp
+img: icons/consumables/potions/flask-ornate-skull-green.webp
 system:
   description:
     value: >-
       <p><em>This clear, gelatinous oil sparkles with tiny, ultrathin silver
-      shards. </em></p>
-
-      <p>The oil can coat one slashing or piercing weapon or up to 5 pieces of
-      slashing or piercing ammunition. Applying the oil takes 1 minute. For 1
-      hour, the coated item is magical and has a +3 bonus to attack and damage
-      rolls.</p>
+      shards.</em></p><p>The oil can coat one slashing or piercing weapon or up
+      to 5 pieces of slashing or piercing ammunition. Applying the oil takes
+      [[lookup @labels.activation activity=cT06cj9LC81wNski]]. For [[lookup
+      @labels.duration activity=cT06cj9LC81wNski]], the coated item is magical
+      and has a +3 bonus to attack and damage rolls.</p>
     chat: ''
   source:
     custom: ''
@@ -49,80 +48,278 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This clear, gelatinous oil sparkles with tiny, ultrathin silver
+      shards.</p>
+    name: Unidentified Oil
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
-      type: utility
+    cT06cj9LC81wNski:
+      type: enchant
+      name: Apply Oil to Weapon
+      _id: cT06cj9LC81wNski
+      img: ''
+      sort: 200000
       activation:
-        type: action
-        value: 1
-        condition: ''
+        type: minute
         override: false
+        condition: ''
+        value: 1
+      behaviors: []
       consumption:
+        scaling:
+          allowed: false
+        spellSlot: true
         targets:
           - type: itemUses
             value: '1'
             target: ''
-        scaling:
-          allowed: false
-          max: ''
-        spellSlot: true
+            scaling: {}
       description:
+        value: ''
         chatFlavor: ''
       duration:
-        concentration: false
-        value: '1'
         units: hour
-        special: ''
+        concentration: false
         override: false
-      effects: []
+        value: '1'
+      effects:
+        - _id: IHJhvGPE1KPinh1r
+          uuid: null
+          level:
+            min: null
+            max: null
+          riders:
+            activity: []
+            effect: []
+            item: []
+      flags: {}
       range:
         units: touch
-        special: ''
         override: false
+        special: ''
       target:
         template:
-          count: ''
           contiguous: false
+          stationary: false
+          units: ft
           type: ''
-          size: ''
-          width: ''
-          height: ''
-          units: ''
         affects:
-          count: ''
-          type: object
           choice: false
+          type: object
+          count: '1'
           special: ''
-        prompt: true
         override: false
-      roll:
-        formula: ''
-        name: ''
-        prompt: false
-        visible: false
+        prompt: true
       uses:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
-      img: ''
       visibility:
-        requireMagic: true
         level:
           min: null
           max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
         identifier: ''
-      appliedEffects: []
+      enchant:
+        self: false
+      restrictions:
+        allowMagical: true
+        categories: []
+        properties: []
+        type: weapon
+    Wa0cWtddVr7eTGOz:
+      type: enchant
+      name: Apply Oil to Ammunition
+      img: ''
+      sort: 300000
+      activation:
+        type: minute
+        override: false
+        value: 1
+        condition: ''
+      behaviors: []
+      consumption:
+        scaling:
+          allowed: false
+        spellSlot: true
+        targets:
+          - type: itemUses
+            value: '1'
+            target: ''
+            scaling: {}
+      description:
+        value: ''
+        chatFlavor: ''
+      duration:
+        units: hour
+        concentration: false
+        override: false
+        value: '1'
+      effects:
+        - _id: IHJhvGPE1KPinh1r
+          uuid: null
+          level:
+            min: null
+            max: null
+          riders:
+            activity: []
+            effect: []
+            item: []
+      flags: {}
+      range:
+        units: touch
+        override: false
+        special: ''
+      target:
+        template:
+          contiguous: false
+          stationary: false
+          units: ft
+          type: ''
+        affects:
+          choice: false
+          count: '5'
+          type: object
+          special: ''
+        override: false
+        prompt: true
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      enchant:
+        self: false
+      restrictions:
+        allowMagical: true
+        categories:
+          - ammo
+        properties: []
+        type: consumable
+      _id: Wa0cWtddVr7eTGOz
   attuned: false
   identifier: oil-of-sharpness
-effects: []
+effects:
+  - type: enchantment
+    name: 'Oil of Sharpness: Weapon'
+    img: icons/consumables/potions/flask-ornate-skull-green.webp
+    disabled: true
+    _id: IHJhvGPE1KPinh1r
+    system:
+      changes:
+        - key: system.magicalBonus
+          type: upgrade
+          value: 3
+          phase: initial
+          priority: null
+        - key: system.description.value
+          type: override
+          value: >-
+            {} <p><strong>Oil of Sharpness.</strong> For the duration, this
+            weapon is magical and has a +3 bonus to attack and damage rolls.</p>
+          phase: initial
+          priority: null
+        - key: system.properties
+          type: add
+          value: mgc
+          phase: initial
+          priority: null
+      magical: true
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>For the duration, this weapon is magical and has a +3 bonus to attack
+      and damage rolls.</p>
+    origin: null
+    tint: '#ffffff'
+    transfer: true
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783375289476
+      modifiedTime: 1783375558654
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!C0MNXWA81ufzGlp5.IHJhvGPE1KPinh1r'
+  - type: enchantment
+    name: 'Oil of Sharpness: Ammunition'
+    img: icons/consumables/potions/flask-ornate-skull-green.webp
+    disabled: true
+    system:
+      changes:
+        - key: system.magicalBonus
+          type: upgrade
+          value: 3
+          phase: initial
+          priority: null
+        - key: system.description.value
+          type: override
+          value: >-
+            {} <p><strong>Oil of Sharpness.</strong> For the duration, this
+            piece of ammunition is magical and has a +3 bonus to attack and
+            damage rolls.</p>
+          phase: initial
+          priority: null
+        - key: system.properties
+          type: add
+          value: mgc
+          phase: initial
+          priority: null
+      magical: true
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>For the duration, this piece of ammunition is magical and has a +3
+      bonus to attack and damage rolls.</p>
+    origin: null
+    tint: '#ffffff'
+    transfer: true
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783375559743
+      modifiedTime: 1783375616755
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _id: L6ERoLhCCv7UsF1b
+    _key: '!items.effects!C0MNXWA81ufzGlp5.L6ERoLhCCv7UsF1b'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -130,11 +327,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037126982
-  modifiedTime: 1764619248930
+  modifiedTime: 1783375642051
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!C0MNXWA81ufzGlp5'

--- a/packs/_source/items/potion/oil-of-slipperiness.yml
+++ b/packs/_source/items/potion/oil-of-slipperiness.yml
@@ -1,24 +1,22 @@
 _id: FIDyR0kZnxGy7bj8
 name: Oil of Slipperiness
 type: consumable
-img: icons/consumables/potions/bottle-circular-corked-labeled-green.webp
+img: icons/consumables/potions/potion-tube-corked-blue.webp
 system:
   description:
     value: >-
       <p><em>This sticky black unguent is thick and heavy in the container, but
-      it flows quickly when poured. </em></p>
-
-      <p>The oil can cover a Medium or smaller creature, along with the
-      equipment it's wearing and carrying (one additional vial is required for
-      each size category above Medium).  Applying the oil takes 10 minutes.  The
+      it flows quickly when poured.</em></p><p>The oil can cover a Medium or
+      smaller creature, along with the equipment it's wearing and carrying (one
+      additional vial is required for each size category above Medium). Applying
+      the oil takes [[lookup @labels.activation activity=OMSMC85UR5All9Vz]]. The
       affected creature then gains the effect of a
       @UUID[Compendium.dnd5e.spells.Item.da0a1t2FqaTjRZGT]{Freedom of Movement}
-      spell for 8 hours.</p>
-
-      <p>Alternatively, the oil can be poured on the ground as an action, where
-      it covers a 10‑foot square, duplicating the effect of the
-      @UUID[Compendium.dnd5e.spells.Item.etgcR9wqmrhyZ0tx]{Grease} spell in that
-      area for 8 hours.</p>
+      spell for [[lookup @labels.duration
+      activity=OMSMC85UR5All9Vz]].</p><p>Alternatively, the oil can be poured on
+      the ground as an action, where it covers a 10‑foot square, duplicating the
+      effect of the @UUID[Compendium.dnd5e.spells.Item.etgcR9wqmrhyZ0tx]{Grease}
+      spell in that area for 8 hours.</p>
     chat: ''
   source:
     custom: ''
@@ -56,18 +54,20 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This sticky black unguent is thick and heavy in the container, but it
+      flows quickly when poured.</p>
+    name: Unidentified Oil
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    OMSMC85UR5All9Vz:
       type: utility
       activation:
-        type: action
-        value: 1
+        type: minute
+        value: 10
         condition: ''
         override: false
       consumption:
@@ -75,19 +75,32 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: >-
+          <p>The oil can cover a Medium or smaller creature, along with the
+          equipment it's wearing and carrying (one additional vial is required
+          for each size category above Medium). Applying the oil takes [[lookup
+          @labels.activation activity=OMSMC85UR5All9Vz]]. The affected creature
+          then gains the effect of a
+          @UUID[Compendium.dnd5e.spells.Item.da0a1t2FqaTjRZGT]{Freedom of
+          Movement} spell for [[lookup @labels.duration
+          activity=OMSMC85UR5All9Vz]].</p>
       duration:
         concentration: false
         value: '8'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: 4OOm3lGF9n4bLHyt
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -100,7 +113,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -117,8 +131,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Apply Oil
       img: ''
       visibility:
         requireMagic: true
@@ -126,10 +140,144 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: OMSMC85UR5All9Vz
+    OCcBVLFoBjsgBp2r:
+      type: cast
+      name: Pour Oil Out
+      _id: OCcBVLFoBjsgBp2r
+      img: ''
+      sort: 200000
+      activation:
+        type: action
+        override: false
+      behaviors: []
+      consumption:
+        scaling:
+          allowed: false
+        spellSlot: true
+        targets: []
+      description:
+        value: >-
+          <p>This oil can be poured on the ground as an action, where it covers
+          a 10‑foot square, duplicating the effect of the
+          @UUID[Compendium.dnd5e.spells.Item.etgcR9wqmrhyZ0tx]{Grease} spell in
+          that area for 8 hours.</p>
+        chatFlavor: ''
+      duration:
+        units: hour
+        concentration: false
+        override: true
+        value: '8'
+      flags: {}
+      range:
+        units: self
+        override: false
+        special: ''
+      target:
+        template:
+          contiguous: false
+          stationary: false
+          units: ft
+          type: square
+          size: '10'
+          count: ''
+        affects:
+          choice: false
+          type: ''
+        override: true
+        prompt: true
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      spell:
+        challenge:
+          override: false
+        properties:
+          - vocal
+          - somatic
+          - material
+        spellbook: false
+        uuid: Compendium.dnd5e.spells.Item.etgcR9wqmrhyZ0tx
+        ability: ''
+        level: 1
   attuned: false
   identifier: oil-of-slipperiness
-effects: []
+effects:
+  - name: Alchemical Slipperiness
+    origin: Compendium.dnd5e.items.Item.FIDyR0kZnxGy7bj8
+    duration:
+      value: 8
+      units: hours
+      expiry: turnStart
+      expired: false
+    disabled: false
+    _id: 4OOm3lGF9n4bLHyt
+    description: >-
+      <p>Your movement is unaffected by &amp;reference[difficult terrain], and
+      spells and other magical effects can neither reduce your speed nor cause
+      you to be &amp;reference[Paralyzed apply=false] or
+      &amp;reference[Restrained apply=false].</p><p>You can also spend 5 feet of
+      Movement to automatically escape from nonmagical restraints, such as
+      Manacles or a creature that has you &amp;reference[Grappled apply=false].
+      Finally, being Underwater imposes no penalties on your movement or
+      attacks.</p>
+    transfer: false
+    statuses: []
+    flags:
+      dnd5e:
+        riders: {}
+    tint: '#ffffff'
+    _stats:
+      compendiumSource: >-
+        Compendium.dnd5e.spells.Item.da0a1t2FqaTjRZGT.ActiveEffect.OnWa3f4IQ3pneB5T
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783375150202
+      modifiedTime: 1783376644491
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    img: icons/skills/movement/arrow-upward-yellow.webp
+    type: base
+    system:
+      changes:
+        - key: system.traits.di.value
+          value: paralyzed
+          priority: null
+          type: add
+          phase: initial
+        - key: system.traits.di.value
+          value: restrained
+          priority: null
+          type: add
+          phase: initial
+        - key: system.attributes.movement.ignoredDifficultTerrain
+          value: all
+          priority: null
+          type: add
+          phase: initial
+      rider:
+        statuses: []
+      magical: true
+    sort: 0
+    start: null
+    showIcon: 1
+    folder: null
+    _key: '!items.effects!FIDyR0kZnxGy7bj8.4OOm3lGF9n4bLHyt'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -137,11 +285,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037142391
-  modifiedTime: 1764619463583
+  modifiedTime: 1783375200344
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!FIDyR0kZnxGy7bj8'

--- a/packs/_source/items/potion/philter-of-love.yml
+++ b/packs/_source/items/potion/philter-of-love.yml
@@ -6,14 +6,12 @@ system:
   description:
     value: >-
       <p><em>This potion's rose-hued, effervescent liquid contains one
-      easy-to-miss bubble shaped like a heart.</em></p>
-
-      <p>The next time you see a creature within 10 minutes after drinking this
-      philter, you become charmed by that creature for 1 hour. If the creature
-      is of a species and gender you are normally attracted to, you regard it as
-      your true love while you are charmed.</p>
-
-      <p> </p>
+      easy-to-miss bubble shaped like a heart.</em></p><p>The next time you see
+      a creature within 10 minutes after drinking this philter, you become
+      &amp;reference[charmed] by that creature for [[lookup @labels.duration
+      activity=PQa875kavCObYkw7]]. If the creature is of a species and gender
+      you are normally attracted to, you regard it as your true love while you
+      are charmed.</p>
     chat: ''
   source:
     custom: ''
@@ -51,14 +49,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This potion's rose-hued, effervescent liquid contains one easy-to-miss
+      bubble shaped like a heart.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    PQa875kavCObYkw7:
       type: utility
       activation:
         type: action
@@ -70,19 +70,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: VGNePB21bqJfLsCr
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +127,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: PQa875kavCObYkw7
   attuned: false
   identifier: philter-of-love
-effects: []
+effects:
+  - name: Alchemical Love
+    img: icons/consumables/potions/potion-flask-corked-labeled-pink.webp
+    origin: Compendium.dnd5e.items.Item.63nb14yQRJMc4bIn
+    transfer: false
+    _id: VGNePB21bqJfLsCr
+    type: base
+    system:
+      changes: []
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>You become &amp;reference[charmed apply=false] for 1 hour by the first
+      creature you see within 10 minutes after drinking this potion. If the
+      creature is of a species and gender you are normally attracted to, you
+      regard it as your true love while you are charmed.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783374813073
+      modifiedTime: 1783374967437
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!63nb14yQRJMc4bIn.VGNePB21bqJfLsCr'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +182,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037103044
-  modifiedTime: 1764618993827
+  modifiedTime: 1783374961687
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!63nb14yQRJMc4bIn'

--- a/packs/_source/items/potion/potion-of-acid-resistance.yml
+++ b/packs/_source/items/potion/potion-of-acid-resistance.yml
@@ -6,14 +6,13 @@ system:
   description:
     value: >-
       <p><em>The potion is a plain indescriminate color and smells slightly
-      foul.</em></p>
-
-      <p>When you drink this potion, you gain resistance to Acidic type damage
-      for 1 hour.</p>
-
-      <p>For other potions of resistance, roll on the
+      foul.</em></p><p>When you drink this potion, you gain resistance to acid
+      damage for [[lookup @labels.duration
+      activity=bo78O7W2RFsL6v3I]].</p><section id="secret-E2GV78Rq05t85x7n"
+      class="secret"><p><strong>Foundry Note</strong></p><p>For other potions of
+      resistance, roll on the
       @UUID[Compendium.dnd5e.tables.RollTable.JzLOE4IxcmxjLLuz]{Potion of
-      Resistance} table.</p>
+      Resistance} table.</p></section>
     chat: ''
   source:
     custom: ''
@@ -51,14 +50,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion is a plain indescriminate color and smells slightly
+      foul.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    bo78O7W2RFsL6v3I:
       type: utility
       activation:
         type: action
@@ -70,19 +71,23 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: 7bDbdK6YYorswEGe
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +127,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      flags: {}
+      _id: bo78O7W2RFsL6v3I
   attuned: false
   identifier: potion-of-acid-resistance
-effects: []
+effects:
+  - name: Acid Resistance
+    img: icons/magic/acid/projectile-faceted-glob.webp
+    origin: Compendium.dnd5e.items.Item.zgZkJAyFAfYmyn11
+    transfer: false
+    _id: 7bDbdK6YYorswEGe
+    type: base
+    system:
+      changes:
+        - key: system.traits.dr.value
+          type: add
+          value: acid
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You have resistance to acid damage.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781978736902
+      modifiedTime: 1781979125455
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!zgZkJAyFAfYmyn11.7bDbdK6YYorswEGe'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +182,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037330779
-  modifiedTime: 1764621462176
+  modifiedTime: 1783372186340
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!zgZkJAyFAfYmyn11'

--- a/packs/_source/items/potion/potion-of-animal-friendship.yml
+++ b/packs/_source/items/potion/potion-of-animal-friendship.yml
@@ -6,11 +6,11 @@ system:
   description:
     value: >-
       <p><em>Agitating this muddy liquid brings little bits into view: a fish
-      scale, hummingbird tongue, a cat claw, or a squirrel hair.</em></p>
-
-      <p>When you drink this potion, you can cast the
-      @UUID[Compendium.dnd5e.spells.Item.hDOENzjuj5WpLq7B]{Animal Friendship} 
-      spell (save DC 13) for 1 hour at will.</p>
+      scale, hummingbird tongue, a cat claw, or a squirrel hair.</em></p><p>When
+      you drink this potion, you can cast the
+      @UUID[Compendium.dnd5e.spells.Item.hDOENzjuj5WpLq7B]{animal friendship}
+      spell (save DC 13) for [[lookup @labels.duration
+      activity=f3MtbdmZa35oIm67]] at will.</p>
     chat: ''
   source:
     custom: ''
@@ -48,83 +48,124 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>Agitating this muddy liquid brings little bits into view: a fish scale,
+      hummingbird tongue, a cat claw, or a squirrel hair.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
-      type: save
+    f3MtbdmZa35oIm67:
+      type: utility
+      name: Drink
+      _id: f3MtbdmZa35oIm67
+      img: ''
+      sort: 100000
       activation:
         type: action
-        value: 1
-        condition: Beast must have an Intelligence of 3 or lower.
         override: false
+        condition: ''
+      behaviors: []
       consumption:
+        scaling:
+          allowed: false
+        spellSlot: true
         targets:
           - type: itemUses
             value: '1'
             target: ''
-        scaling:
-          allowed: false
-          max: ''
-        spellSlot: true
+            scaling: {}
       description:
+        value: ''
         chatFlavor: ''
       duration:
-        concentration: false
-        value: '1'
         units: hour
-        special: ''
+        concentration: false
         override: false
-      effects: []
+        value: '1'
+      effects:
+        - _id: U6yBzHzpfZRh3yZY
+          uuid: null
+          level: {}
+      flags: {}
       range:
         units: touch
-        special: ''
         override: false
+        special: ''
       target:
         template:
-          count: ''
           contiguous: false
+          stationary: false
+          units: ft
           type: ''
-          size: ''
-          width: ''
-          height: ''
-          units: ''
         affects:
-          count: '1'
-          type: creature
           choice: false
+          type: creature
+          count: '1'
           special: ''
-        prompt: true
         override: false
-      damage:
-        onSave: half
-        parts: []
-      save:
-        ability: wis
-        dc:
-          calculation: ''
-          formula: '13'
+        prompt: true
       uses:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
-      img: ''
       visibility:
-        requireMagic: true
         level:
           min: null
           max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
         identifier: ''
-      appliedEffects: []
+      roll:
+        prompt: false
+        visible: false
+        name: ''
+        formula: ''
   attuned: false
   identifier: potion-of-animal-friendship
-effects: []
+effects:
+  - name: Animal Friend
+    img: icons/creatures/abilities/paw-print-yellow.webp
+    origin: Compendium.dnd5e.items.Item.nXWevqtV6p484N59
+    transfer: false
+    _id: U6yBzHzpfZRh3yZY
+    type: base
+    system:
+      changes: []
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>For the duration, you can cast the
+      @UUID[Compendium.dnd5e.spells.Item.hDOENzjuj5WpLq7B]{Animal Friendship}
+      (save DC 13) spell at will.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783374644795
+      modifiedTime: 1783374722882
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!nXWevqtV6p484N59.U6yBzHzpfZRh3yZY'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +173,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037282716
-  modifiedTime: 1764620913757
+  modifiedTime: 1783377156497
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!nXWevqtV6p484N59'

--- a/packs/_source/items/potion/potion-of-animal-friendship.yml
+++ b/packs/_source/items/potion/potion-of-animal-friendship.yml
@@ -88,7 +88,9 @@ system:
       effects:
         - _id: U6yBzHzpfZRh3yZY
           uuid: null
-          level: {}
+          level:
+            min: null
+            max: null
       flags: {}
       range:
         units: touch
@@ -117,7 +119,7 @@ system:
           max: null
         requireAttunement: false
         requireIdentification: false
-        requireMagic: false
+        requireMagic: true
         identifier: ''
       roll:
         prompt: false
@@ -177,7 +179,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037282716
-  modifiedTime: 1783377156497
+  modifiedTime: 1783646399495
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!nXWevqtV6p484N59'

--- a/packs/_source/items/potion/potion-of-clairvoyance.yml
+++ b/packs/_source/items/potion/potion-of-clairvoyance.yml
@@ -6,10 +6,9 @@ system:
   description:
     value: >-
       <p><em>An eyeball bobs in this yellowish liquid but vanishes when the
-      potion is opened.</em></p>
-
-      <p>When you drink this potion, you gain the effect of the
-      @UUID[Compendium.dnd5e.spells.Item.cg50KpBkBdPK6vPL]{Clairvoyance}
+      potion is opened.</em></p><p>When you drink this potion, you gain the
+      effect of the
+      @UUID[Compendium.dnd5e.spells.Item.cg50KpBkBdPK6vPL]{clairvoyance}
       spell.</p>
     chat: ''
   source:
@@ -48,77 +47,74 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>An eyeball bobs in this yellowish liquid but vanishes when the potion
+      is opened.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
-      type: utility
+    8hBw81kwg8UiPHa3:
+      type: cast
+      spell:
+        uuid: Compendium.dnd5e.spells.Item.cg50KpBkBdPK6vPL
+        challenge:
+          override: false
+        properties:
+          - vocal
+          - somatic
+          - material
+        spellbook: false
+        ability: ''
+        level: 3
+      _id: 8hBw81kwg8UiPHa3
+      img: ''
+      sort: 200000
       activation:
         type: action
-        value: 1
-        condition: ''
         override: false
+      behaviors: []
       consumption:
-        targets:
-          - type: itemUses
-            value: '1'
-            target: ''
         scaling:
           allowed: false
-          max: ''
         spellSlot: true
+        targets: []
       description:
+        value: ''
         chatFlavor: ''
       duration:
-        concentration: false
-        value: '10'
         units: minute
-        special: ''
-        override: false
-      effects: []
+        concentration: false
+        override: true
+        value: '10'
+      flags: {}
       range:
-        units: touch
-        special: ''
+        units: self
         override: false
       target:
         template:
-          count: ''
           contiguous: false
-          type: ''
-          size: ''
-          width: ''
-          height: ''
-          units: ''
+          stationary: false
+          units: ft
         affects:
-          count: '1'
-          type: creature
           choice: false
-          special: ''
-        prompt: true
         override: false
-      roll:
-        formula: ''
-        name: ''
-        prompt: false
-        visible: false
+        prompt: true
       uses:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
-      img: ''
       visibility:
-        requireMagic: true
         level:
           min: null
           max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
         identifier: ''
-      appliedEffects: []
+      name: Drink
   attuned: false
   identifier: potion-of-clairvoyance
 effects: []
@@ -129,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037226301
-  modifiedTime: 1764620266037
+  modifiedTime: 1783376860177
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!bAyr7j5Peq9wIJTa'

--- a/packs/_source/items/potion/potion-of-clairvoyance.yml
+++ b/packs/_source/items/potion/potion-of-clairvoyance.yml
@@ -56,65 +56,6 @@ system:
     - mgc
   magicalBonus: null
   activities:
-    8hBw81kwg8UiPHa3:
-      type: cast
-      spell:
-        uuid: Compendium.dnd5e.spells.Item.cg50KpBkBdPK6vPL
-        challenge:
-          override: false
-        properties:
-          - vocal
-          - somatic
-          - material
-        spellbook: false
-        ability: ''
-        level: 3
-      _id: 8hBw81kwg8UiPHa3
-      img: ''
-      sort: 200000
-      activation:
-        type: action
-        override: false
-      behaviors: []
-      consumption:
-        scaling:
-          allowed: false
-        spellSlot: true
-        targets: []
-      description:
-        value: ''
-        chatFlavor: ''
-      duration:
-        units: minute
-        concentration: false
-        override: true
-        value: '10'
-      flags: {}
-      range:
-        units: self
-        override: false
-      target:
-        template:
-          contiguous: false
-          stationary: false
-          units: ft
-        affects:
-          choice: false
-        override: false
-        prompt: true
-      uses:
-        spent: 0
-        recovery: []
-        max: ''
-      visibility:
-        level:
-          min: null
-          max: null
-        requireAttunement: false
-        requireIdentification: false
-        requireMagic: false
-        identifier: ''
-      name: Drink
     3sfoi99DiGRXsmVd:
       type: utility
       name: Drink
@@ -243,7 +184,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037226301
-  modifiedTime: 1783377554562
+  modifiedTime: 1783646413499
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!bAyr7j5Peq9wIJTa'

--- a/packs/_source/items/potion/potion-of-clairvoyance.yml
+++ b/packs/_source/items/potion/potion-of-clairvoyance.yml
@@ -1,7 +1,7 @@
 _id: bAyr7j5Peq9wIJTa
 name: Potion of Clairvoyance
 type: consumable
-img: icons/consumables/potions/bottle-bulb-corked-purple.webp
+img: icons/consumables/potions/potion-flask-corked-tied-necklace-teal.webp
 system:
   description:
     value: >-
@@ -115,9 +115,123 @@ system:
         requireMagic: false
         identifier: ''
       name: Drink
+    3sfoi99DiGRXsmVd:
+      type: utility
+      name: Drink
+      _id: 3sfoi99DiGRXsmVd
+      img: ''
+      sort: 300000
+      activation:
+        type: action
+        override: false
+        condition: ''
+      behaviors: []
+      consumption:
+        scaling:
+          allowed: false
+        spellSlot: true
+        targets:
+          - type: itemUses
+            value: '1'
+            target: ''
+            scaling: {}
+      description:
+        value: ''
+        chatFlavor: ''
+      duration:
+        units: minute
+        concentration: false
+        override: false
+        value: '10'
+      effects:
+        - _id: e5WEPmqHuxJlwMmB
+          uuid: null
+          level: {}
+      flags: {}
+      range:
+        units: touch
+        override: false
+        special: ''
+      target:
+        template:
+          contiguous: false
+          stationary: false
+          units: ft
+          type: ''
+        affects:
+          choice: false
+          type: creature
+          count: '1'
+          special: ''
+        override: false
+        prompt: true
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: true
+        identifier: ''
+      roll:
+        prompt: false
+        visible: false
+        name: ''
+        formula: ''
   attuned: false
   identifier: potion-of-clairvoyance
-effects: []
+effects:
+  - name: Alchemical Clairvoyance
+    img: icons/magic/perception/eye-winged-pink.webp
+    origin: Compendium.dnd5e.items.Item.bAyr7j5Peq9wIJTa
+    transfer: false
+    _id: e5WEPmqHuxJlwMmB
+    type: base
+    system:
+      changes: []
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 10
+      units: minutes
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>You create an invisible sensor within range in a location familiar to
+      you (a place you have visited or seen before) or in an obvious location
+      that is unfamiliar to you (such as behind a door, around a corner, or in a
+      grove of trees). The sensor remains in place for the duration, and it
+      can't be attacked or otherwise interacted with.</p><p>Choose seeing or
+      hearing. You can use the chosen sense through the sensor as if you were in
+      its space. As your action, you can switch between seeing and
+      hearing.</p><p>A creature that can see the sensor (such as a creature
+      benefiting from @UUID[Compendium.dnd5e.spells.Item.DQzlB5Y3k791W5bH]{see
+      invisibility} or &amp;reference[truesight]) sees a luminous, intangible
+      orb about the size of your fist.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783377505756
+      modifiedTime: 1783377561700
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!bAyr7j5Peq9wIJTa.e5WEPmqHuxJlwMmB'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -129,7 +243,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037226301
-  modifiedTime: 1783376860177
+  modifiedTime: 1783377554562
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!bAyr7j5Peq9wIJTa'

--- a/packs/_source/items/potion/potion-of-climbing.yml
+++ b/packs/_source/items/potion/potion-of-climbing.yml
@@ -7,11 +7,10 @@ system:
     value: >-
       <p><em>The potion is separated into brown, silver, and gray layers
       resembling bands of stone. Shaking the bottle fails to mix the
-      colors.</em></p>
-
-      <p>When you drink this potion, you gain a climbing speed equal to your
-      walking speed for 1 hour. During this time, you have advantage on Strength
-      (Athletics) checks you make to climb. </p>
+      colors.</em></p><p>When you drink this potion, you gain a climbing speed
+      equal to your walking speed for [[lookup @labels.duration
+      activity=tbj9v3KiTzZwBX2E]]. During this time, you have advantage on
+      Strength (Athletics) checks you make to climb.</p>
     chat: ''
   source:
     custom: ''
@@ -49,14 +48,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion is separated into brown, silver, and gray layers resembling
+      bands of stone. Shaking the bottle fails to mix the colors.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    tbj9v3KiTzZwBX2E:
       type: utility
       activation:
         type: action
@@ -68,19 +69,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: I7ywYX94qSyb3GRk
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -93,7 +99,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -110,8 +117,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -119,10 +126,57 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: tbj9v3KiTzZwBX2E
   attuned: false
   identifier: potion-of-climbing
-effects: []
+effects:
+  - name: Alchemically Enhanced Climbing
+    img: icons/environment/wilderness/terrain-rocks-brown.webp
+    origin: Compendium.dnd5e.items.Item.aMnWi1WXWpxRHq4r
+    transfer: false
+    _id: I7ywYX94qSyb3GRk
+    type: base
+    system:
+      changes:
+        - key: system.attributes.movement.climb
+          type: upgrade
+          value: '@attributes.movement.walk'
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>For the duration, you gain a climbing speed equal to your walking speed
+      and have advantage on Strength (Athletics) checks you make to climb.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783374509128
+      modifiedTime: 1783374599231
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!aMnWi1WXWpxRHq4r.I7ywYX94qSyb3GRk'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -130,11 +184,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037222595
-  modifiedTime: 1764620243615
+  modifiedTime: 1783374612396
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!aMnWi1WXWpxRHq4r'

--- a/packs/_source/items/potion/potion-of-cloud-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-cloud-giant-strength.yml
@@ -6,10 +6,10 @@ system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p><p>When you drink
-      this potion, your Strength score changes to 27 for [[lookup
-      @labels.duration activity=eEzkwNoMj0HJmmKn]]. The potion has no effect on
-      you if your Strength is equal to or greater than that score.</p>
+      fingernail from a cloud giant.</em></p><p>When you drink this potion, your
+      Strength score changes to 27 for [[lookup @labels.duration
+      activity=eEzkwNoMj0HJmmKn]]. The potion has no effect on you if your
+      Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:
@@ -188,7 +188,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037272249
-  modifiedTime: 1783374288881
+  modifiedTime: 1783646166196
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!lAcTZgNtpmks2Mo5'

--- a/packs/_source/items/potion/potion-of-cloud-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-cloud-giant-strength.yml
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:

--- a/packs/_source/items/potion/potion-of-cloud-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-cloud-giant-strength.yml
@@ -1,18 +1,15 @@
 _id: lAcTZgNtpmks2Mo5
 name: Potion of Cloud Giant Strength
 type: consumable
-img: icons/consumables/potions/bottle-round-corked-blue.webp
+img: icons/consumables/potions/bottle-conical-corked-blue.webp
 system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p>
-
-      <p>When you drink this potion, your Strength score changes to 27 for 1
-      hour.  The potion has no effect on you if your Strength is equal to or
-      greater than that score.</p>
-
-      <p> </p>
+      fingernail from a giant of the appropriate type.</em></p><p>When you drink
+      this potion, your Strength score changes to 27 for [[lookup
+      @labels.duration activity=eEzkwNoMj0HJmmKn]]. The potion has no effect on
+      you if your Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -50,14 +47,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This potion's transparent liquid has floating in it a sliver of
+      fingernail from a giant of the appropriate type.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    eEzkwNoMj0HJmmKn:
       type: utility
       activation:
         type: action
@@ -69,19 +68,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: 0zUmrK4c8UybXZeQ
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -94,7 +98,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -111,8 +116,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -120,10 +125,58 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: eEzkwNoMj0HJmmKn
   attuned: false
   identifier: potion-of-cloud-giant-strength
-effects: []
+effects:
+  - name: Cloud Giant Strength
+    img: icons/magic/air/wind-vortex-swirl-blue-purple.webp
+    origin: Compendium.dnd5e.items.Item.lAcTZgNtpmks2Mo5
+    transfer: false
+    _id: 0zUmrK4c8UybXZeQ
+    type: base
+    system:
+      changes:
+        - key: system.abilities.str.value
+          type: upgrade
+          value: 27
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>Your Strength score changes to 27 for the duration. This has no effect
+      on you if your Strength is equal to or greater than 27.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783374208504
+      modifiedTime: 1783374233888
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: >-
+        Compendium.dnd5e.items.Item.1KMSpOSU0EliUBm2.ActiveEffect.sjbluBPTvdkkf3pv
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!lAcTZgNtpmks2Mo5.0zUmrK4c8UybXZeQ'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -131,11 +184,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037272249
-  modifiedTime: 1764620787878
+  modifiedTime: 1783374288881
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!lAcTZgNtpmks2Mo5'

--- a/packs/_source/items/potion/potion-of-cold-resistance.yml
+++ b/packs/_source/items/potion/potion-of-cold-resistance.yml
@@ -6,14 +6,13 @@ system:
   description:
     value: >-
       <p><em>The potion is a plain indescriminate color and smells slightly
-      foul.</em></p>
-
-      <p>When you drink this potion, you gain resistance to Cold type damage for
-      1 hour.</p>
-
-      <p>For other potions of resistance, roll on the
+      foul.</em></p><p>When you drink this potion, you gain resistance to cold
+      damage for [[lookup @labels.duration
+      activity=4nxLtrnFMNAK4ysZ]].</p><section id="secret-KmZbaeHrxYjAmOdL"
+      class="secret"><p><strong>Foundry Note</strong></p><p>For other potions of
+      resistance, roll on the
       @UUID[Compendium.dnd5e.tables.RollTable.JzLOE4IxcmxjLLuz]{Potion of
-      Resistance} table.</p>
+      Resistance} table.</p></section>
     chat: ''
   source:
     custom: ''
@@ -51,14 +50,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion is a plain indescriminate color and smells slightly
+      foul.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    4nxLtrnFMNAK4ysZ:
       type: utility
       activation:
         type: action
@@ -70,19 +71,23 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: iYO0o4oLErq9j3ph
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +127,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      flags: {}
+      _id: 4nxLtrnFMNAK4ysZ
   attuned: false
   identifier: potion-of-cold-resistance
-effects: []
+effects:
+  - name: Cold Resistance
+    img: icons/magic/water/snowflake-ice-blue-white.webp
+    origin: Compendium.dnd5e.items.Item.34YKlIJVVWLeBv7R
+    transfer: false
+    _id: iYO0o4oLErq9j3ph
+    type: base
+    system:
+      changes:
+        - key: system.traits.dr.value
+          type: add
+          value: cold
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You have resistance to cold damage.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781978626645
+      modifiedTime: 1781979118303
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!34YKlIJVVWLeBv7R.iYO0o4oLErq9j3ph'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +182,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037092094
-  modifiedTime: 1764618855401
+  modifiedTime: 1783372196008
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!34YKlIJVVWLeBv7R'

--- a/packs/_source/items/potion/potion-of-diminution.yml
+++ b/packs/_source/items/potion/potion-of-diminution.yml
@@ -6,18 +6,11 @@ system:
   description:
     value: >-
       <p><em>The red in the potion's liquid continuously contracts to a tiny
-      bead and then expands to color the clear liquid around it.  Shaking the
-      bottle fails to interrupt this process.</em></p>
-
-      <p>When you drink this potion, you gain the "reduce" effect of the
-      @UUID[Compendium.dnd5e.spells.Item.WahI41a3goVUg0x1]{Enlarge/Reduce} spell
-      for 1d4 hours (no concentration required). </p>
-
-      <p> </p>
-
-      <p> </p>
-
-      <p> </p>
+      bead and then expands to color the clear liquid around it. Shaking the
+      bottle fails to interrupt this process.</em></p><p>When you drink this
+      potion, you gain the "reduce" effect of the
+      @UUID[Compendium.dnd5e.spells.Item.WahI41a3goVUg0x1]{enlarge/reduce} spell
+      for 1d4 hours (no concentration required).</p>
     chat: ''
   source:
     custom: ''
@@ -55,14 +48,17 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The red in the potion's liquid continuously contracts to a tiny bead
+      and then expands to color the clear liquid around it. Shaking the bottle
+      fails to interrupt this process.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    w7wDJOmMVf9b7Cnd:
       type: utility
       activation:
         type: action
@@ -74,19 +70,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
-        value: ''
+        value: '4'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: 6sChAuK0HObortfE
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -99,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -116,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -125,10 +127,80 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: w7wDJOmMVf9b7Cnd
   attuned: false
   identifier: potion-of-diminution
-effects: []
+effects:
+  - name: Alchemically Reduced
+    img: icons/magic/control/silhouette-grow-shrink-blue.webp
+    origin: Compendium.dnd5e.items.Item.HY8duCwmvlXOruTG
+    transfer: false
+    _id: 6sChAuK0HObortfE
+    type: base
+    system:
+      changes:
+        - key: system.bonuses.mwak.damage
+          type: add
+          value: '-1d4'
+          phase: initial
+          priority: null
+        - key: system.bonuses.rwak.damage
+          type: add
+          value: '-1d4'
+          phase: initial
+          priority: null
+        - key: system.abilities.str.check.roll.mode
+          type: add
+          value: -1
+          phase: initial
+          priority: null
+        - key: system.abilities.str.save.roll.mode
+          type: add
+          value: -1
+          phase: initial
+          priority: null
+      rider:
+        statuses: []
+      magical: false
+    disabled: false
+    start: null
+    duration:
+      value: 4
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>Your size is halved in all dimensions, and your weight is reduced to
+      one-eighth of normal. This reduction decreases your size by one
+      category—from Medium to Small, for example. Until the effect ends, you
+      also has disadvantage on Strength Checks and Strength Saving
+      Throws.</p><p>Your Weapons also shrink to match your new size. While these
+      Weapons are reduced, your attacks with them deal 1d4 less damage (this
+      can't reduce the damage below 1).</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags:
+      dnd5e:
+        riders: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783376879700
+      modifiedTime: 1783376901758
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: >-
+        Compendium.dnd5e.spells.Item.WahI41a3goVUg0x1.ActiveEffect.rFRjXg3BjmTb5GOh
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!HY8duCwmvlXOruTG.6sChAuK0HObortfE'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -136,11 +208,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037150875
-  modifiedTime: 1764619536422
+  modifiedTime: 1783376939532
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!HY8duCwmvlXOruTG'

--- a/packs/_source/items/potion/potion-of-diminution.yml
+++ b/packs/_source/items/potion/potion-of-diminution.yml
@@ -165,7 +165,7 @@ effects:
           priority: null
       rider:
         statuses: []
-      magical: false
+      magical: true
     disabled: false
     start: null
     duration:
@@ -194,7 +194,7 @@ effects:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1783376879700
-      modifiedTime: 1783376901758
+      modifiedTime: 1783646456091
       lastModifiedBy: dnd5ebuilder0000
       compendiumSource: >-
         Compendium.dnd5e.spells.Item.WahI41a3goVUg0x1.ActiveEffect.rFRjXg3BjmTb5GOh

--- a/packs/_source/items/potion/potion-of-fire-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-fire-giant-strength.yml
@@ -1,18 +1,15 @@
 _id: bEZOY6uvHRweMM56
 name: Potion of Fire Giant Strength
 type: consumable
-img: icons/consumables/potions/bottle-round-corked-yellow.webp
+img: icons/consumables/potions/potion-jar-corked-labeled-red.webp
 system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p>
-
-      <p>When you drink this potion, your Strength score changes to 25 for 1
-      hour.  The potion has no effect on you if your Strength is equal to or
-      greater than that score.</p>
-
-      <p> </p>
+      fingernail from a giant of the appropriate type.</em></p><p>When you drink
+      this potion, your Strength score changes to 25 for [[lookup
+      @labels.duration activity=xT9Z6NFEEUFhxy1P]]. The potion has no effect on
+      you if your Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -50,14 +47,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This potion's transparent liquid has floating in it a sliver of
+      fingernail from a giant of the appropriate type.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    xT9Z6NFEEUFhxy1P:
       type: utility
       activation:
         type: action
@@ -69,19 +68,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: iCEYqMYew63B7ocr
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -94,7 +98,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -111,8 +116,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -120,10 +125,58 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: xT9Z6NFEEUFhxy1P
   attuned: false
   identifier: potion-of-fire-giant-strength
-effects: []
+effects:
+  - name: Fire Giant Strength
+    img: icons/magic/fire/flame-burning-fist-strike.webp
+    origin: Compendium.dnd5e.items.Item.bEZOY6uvHRweMM56
+    transfer: false
+    _id: iCEYqMYew63B7ocr
+    type: base
+    system:
+      changes:
+        - key: system.abilities.str.value
+          type: upgrade
+          value: 25
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>Your Strength score changes to 25 for the duration. This has no effect
+      on you if your Strength is equal to or greater than 25.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783374143565
+      modifiedTime: 1783374171879
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: >-
+        Compendium.dnd5e.items.Item.1KMSpOSU0EliUBm2.ActiveEffect.sjbluBPTvdkkf3pv
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!bEZOY6uvHRweMM56.iCEYqMYew63B7ocr'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -131,11 +184,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037226880
-  modifiedTime: 1764620271785
+  modifiedTime: 1783374190392
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!bEZOY6uvHRweMM56'

--- a/packs/_source/items/potion/potion-of-fire-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-fire-giant-strength.yml
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:

--- a/packs/_source/items/potion/potion-of-fire-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-fire-giant-strength.yml
@@ -6,10 +6,10 @@ system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p><p>When you drink
-      this potion, your Strength score changes to 25 for [[lookup
-      @labels.duration activity=xT9Z6NFEEUFhxy1P]]. The potion has no effect on
-      you if your Strength is equal to or greater than that score.</p>
+      fingernail from a fire giant.</em></p><p>When you drink this potion, your
+      Strength score changes to 25 for [[lookup @labels.duration
+      activity=xT9Z6NFEEUFhxy1P]]. The potion has no effect on you if your
+      Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:
@@ -188,7 +188,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037226880
-  modifiedTime: 1783374190392
+  modifiedTime: 1783646187967
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!bEZOY6uvHRweMM56'

--- a/packs/_source/items/potion/potion-of-fire-resistance.yml
+++ b/packs/_source/items/potion/potion-of-fire-resistance.yml
@@ -7,7 +7,7 @@ system:
     value: >-
       <p><em>The potion is a plain indescriminate color and smells slightly
       foul.</em></p><p>When you drink this potion, you gain resistance to fire
-      type damage for [[lookup @labels.duration
+      damage for [[lookup @labels.duration
       activity=qkJxETJ3791U09MR]].</p><section id="secret-vs12uqzX6R92PN4m"
       class="secret"><p><strong>Foundry Note</strong></p><p>For other potions of
       resistance, roll on the
@@ -87,7 +87,10 @@ system:
         override: false
       effects:
         - _id: camHDa74ZwAPUqmG
-          level: {}
+          uuid: null
+          level:
+            min: null
+            max: null
       range:
         units: touch
         special: ''
@@ -186,7 +189,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037159774
-  modifiedTime: 1783372203791
+  modifiedTime: 1783646479399
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Jj4iFQQGvckx8Wsj'

--- a/packs/_source/items/potion/potion-of-fire-resistance.yml
+++ b/packs/_source/items/potion/potion-of-fire-resistance.yml
@@ -1,19 +1,18 @@
 _id: Jj4iFQQGvckx8Wsj
 name: Potion of Fire Resistance
 type: consumable
-img: icons/consumables/potions/bottle-bulb-corked-glowing-red.webp
+img: icons/consumables/potions/potion-bottle-stopped-labeled-red.webp
 system:
   description:
     value: >-
       <p><em>The potion is a plain indescriminate color and smells slightly
-      foul.</em></p>
-
-      <p>When you drink this potion, you gain resistance to Fire type damage for
-      1 hour.</p>
-
-      <p>For other potions of resistance, roll on the
+      foul.</em></p><p>When you drink this potion, you gain resistance to fire
+      type damage for [[lookup @labels.duration
+      activity=qkJxETJ3791U09MR]].</p><section id="secret-vs12uqzX6R92PN4m"
+      class="secret"><p><strong>Foundry Note</strong></p><p>For other potions of
+      resistance, roll on the
       @UUID[Compendium.dnd5e.tables.RollTable.JzLOE4IxcmxjLLuz]{Potion of
-      Resistance} table.</p>
+      Resistance} table.</p></section>
     chat: ''
   source:
     custom: ''
@@ -51,14 +50,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion is a plain indescriminate color and smells slightly
+      foul.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    qkJxETJ3791U09MR:
       type: utility
       activation:
         type: action
@@ -70,19 +71,23 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: camHDa74ZwAPUqmG
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +127,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      flags: {}
+      _id: qkJxETJ3791U09MR
   attuned: false
   identifier: potion-of-fire-resistance
-effects: []
+effects:
+  - name: Fire Resistance
+    img: icons/magic/fire/flame-burning-earth-yellow.webp
+    origin: Compendium.dnd5e.items.Item.Jj4iFQQGvckx8Wsj
+    transfer: false
+    _id: camHDa74ZwAPUqmG
+    type: base
+    system:
+      changes:
+        - key: system.traits.dr.value
+          type: add
+          value: fire
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You have resistance to fire damage.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781978548368
+      modifiedTime: 1781979112953
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!Jj4iFQQGvckx8Wsj.camHDa74ZwAPUqmG'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +182,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037159774
-  modifiedTime: 1764619623560
+  modifiedTime: 1783372203791
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Jj4iFQQGvckx8Wsj'

--- a/packs/_source/items/potion/potion-of-flying.yml
+++ b/packs/_source/items/potion/potion-of-flying.yml
@@ -1,21 +1,16 @@
 _id: eTNc8XPtvZNe3yQs
 name: Potion of Flying
 type: consumable
-img: icons/consumables/potions/potion-tube-corked-bat-gold-red.webp
+img: icons/consumables/potions/potion-flask-corked-cyan.webp
 system:
   description:
     value: >-
       <p><em>This potion's clear liquid floats at the top of its container and
-      has cloudy white impurities drifting in it.</em></p>
-
-      <p>When you drink this potion, you gain a flying speed equal to your
-      walking speed for 1 hour and can hover. If you're in the air when the
-      potion wears off, you fall unless you have some other means of staying
-      aloft. </p>
-
-      <p> </p>
-
-      <p> </p>
+      has cloudy white impurities drifting in it.</em></p><p>When you drink this
+      potion, you gain a flying speed equal to your walking speed for [[lookup
+      @labels.duration activity=dQ5KoAo9EfRNjkIg]] and can hover. If you're in
+      the air when the potion wears off, you fall unless you have some other
+      means of staying aloft.</p>
     chat: ''
   source:
     custom: ''
@@ -53,14 +48,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This potion's clear liquid floats at the top of its container and has
+      cloudy white impurities drifting in it.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    dQ5KoAo9EfRNjkIg:
       type: utility
       activation:
         type: action
@@ -72,19 +69,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: UumpsHK33ePtvz3s
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -97,7 +99,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -114,8 +117,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -123,54 +126,63 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: dQ5KoAo9EfRNjkIg
   attuned: false
   identifier: potion-of-flying
 effects:
-  - name: Flying
-    img: icons/consumables/potions/potion-tube-corked-bat-gold-red.webp
+  - name: Alchemical Flight
+    img: icons/creatures/abilities/wings-birdlike-blue.webp
     origin: Compendium.dnd5e.items.Item.eTNc8XPtvZNe3yQs
-    _id: EfRsYOQoBVRth2Hv
+    transfer: false
+    _id: UumpsHK33ePtvz3s
     type: base
-    system: {}
-    changes:
-      - key: system.attributes.movement.fly
-        mode: 4
-        value: '@attributes.movement.walk'
-        priority: null
-      - key: system.attributes.movement.hover
-        mode: 5
-        value: 'true'
-        priority: null
+    system:
+      changes:
+        - key: system.attributes.movement.fly
+          type: upgrade
+          value: '@attributes.movement.walk'
+          phase: initial
+          priority: null
+        - key: system.attributes.movement.hover
+          type: override
+          value: 1
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
     disabled: false
+    start: null
     duration:
-      startTime: null
-      combat: null
-      seconds: null
-      rounds: null
-      turns: null
-      startRound: null
-      startTurn: null
-    description: ''
+      value: null
+      units: seconds
+      expiry: null
+      expired: false
+    description: >-
+      <p>For the duration, you gain a flying speed equal to your walking speed
+      and can hover. If you're in the air when the potion wears off, you fall
+      unless you have some other means of staying aloft.</p>
     tint: '#ffffff'
-    transfer: true
     statuses: []
+    showIcon: 1
+    folder: null
     sort: 0
-    flags:
-      dnd5e:
-        riders:
-          statuses: []
+    flags: {}
     _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783373930475
+      modifiedTime: 1783374083017
+      lastModifiedBy: dnd5ebuilder0000
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '13.350'
-      systemId: dnd5e
-      systemVersion: 5.2.0
-      createdTime: 1759793328544
-      modifiedTime: 1759793381173
-      lastModifiedBy: dnd5ebuilder0000
-    _key: '!items.effects!eTNc8XPtvZNe3yQs.EfRsYOQoBVRth2Hv'
+    _key: '!items.effects!eTNc8XPtvZNe3yQs.UumpsHK33ePtvz3s'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -178,11 +190,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037241439
-  modifiedTime: 1764620454112
+  modifiedTime: 1783374202146
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!eTNc8XPtvZNe3yQs'

--- a/packs/_source/items/potion/potion-of-force-resistance.yml
+++ b/packs/_source/items/potion/potion-of-force-resistance.yml
@@ -1,19 +1,18 @@
 _id: kKGJjVVlJVoakWgQ
 name: Potion of Force Resistance
 type: consumable
-img: icons/consumables/potions/bottle-bulb-corked-labeled-blue.webp
+img: icons/consumables/potions/bottle-conical-corked-labeled-shell-cyan.webp
 system:
   description:
     value: >-
       <p><em>The potion is a plain indescriminate color and smells slightly
-      foul.</em></p>
-
-      <p>When you drink this potion, you gain resistance to Force type damage
-      for 1 hour.</p>
-
-      <p>For other potions of resistance, roll on the
+      foul.</em></p><p>When you drink this potion, you gain resistance to force
+      damage for [[lookup @labels.duration
+      activity=WBQEjgocMEcDWwnO]].</p><section id="secret-aaBe78rBtxdOfhNn"
+      class="secret"><p><strong>Foundry Note</strong></p><p>For other potions of
+      resistance, roll on the
       @UUID[Compendium.dnd5e.tables.RollTable.JzLOE4IxcmxjLLuz]{Potion of
-      Resistance} table.</p>
+      Resistance} table.</p></section>
     chat: ''
   source:
     custom: ''
@@ -51,14 +50,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion is a plain indescriminate color and smells slightly
+      foul.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    WBQEjgocMEcDWwnO:
       type: utility
       activation:
         type: action
@@ -70,19 +71,23 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: d8PTXF30xWHZcQGt
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +127,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      flags: {}
+      _id: WBQEjgocMEcDWwnO
   attuned: false
   identifier: potion-of-force-resistance
-effects: []
+effects:
+  - name: Force Resistance
+    img: icons/magic/lightning/orb-ball-purple.webp
+    origin: Compendium.dnd5e.items.Item.kKGJjVVlJVoakWgQ
+    transfer: false
+    _id: d8PTXF30xWHZcQGt
+    type: base
+    system:
+      changes:
+        - key: system.traits.dr.value
+          type: add
+          value: force
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You have resistance to force damage.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781978458621
+      modifiedTime: 1781984551077
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!kKGJjVVlJVoakWgQ.d8PTXF30xWHZcQGt'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +182,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037268091
-  modifiedTime: 1764620693366
+  modifiedTime: 1783372213457
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!kKGJjVVlJVoakWgQ'

--- a/packs/_source/items/potion/potion-of-frost-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-frost-giant-strength.yml
@@ -6,13 +6,10 @@ system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p>
-
-      <p>When you drink this potion, your Strength score changes to 23 for 1
-      hour.  The potion has no effect on you if your Strength is equal to or
-      greater than that score.</p>
-
-      <p> </p>
+      fingernail from a giant of the appropriate type.</em></p><p>When you drink
+      this potion, your Strength score changes to 23 for [[lookup
+      @labels.duration activity=pE7C9XIq67aoCkGp]]. The potion has no effect on
+      you if your Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -50,14 +47,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This potion's transparent liquid has floating in it a sliver of
+      fingernail from a giant of the appropriate type.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    pE7C9XIq67aoCkGp:
       type: utility
       activation:
         type: action
@@ -69,19 +68,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: ZPO6fKaUX5z0opim
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -94,7 +98,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -111,8 +116,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -120,10 +125,58 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: pE7C9XIq67aoCkGp
   attuned: false
   identifier: potion-of-frost-giant-strength
-effects: []
+effects:
+  - name: Frost Giant Strength
+    img: icons/magic/water/strike-ice-blade-axe.webp
+    origin: Compendium.dnd5e.items.Item.TevMHicE3A70AlmP
+    transfer: false
+    _id: ZPO6fKaUX5z0opim
+    type: base
+    system:
+      changes:
+        - key: system.abilities.str.value
+          type: upgrade
+          value: 29
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>Your Strength score changes to 23 for the duration. This has no effect
+      on you if your Strength is equal to or greater than 23.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783373808723
+      modifiedTime: 1783376582422
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: >-
+        Compendium.dnd5e.items.Item.1KMSpOSU0EliUBm2.ActiveEffect.sjbluBPTvdkkf3pv
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!TevMHicE3A70AlmP.ZPO6fKaUX5z0opim'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -131,11 +184,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037193843
-  modifiedTime: 1764619990107
+  modifiedTime: 1783373878847
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!TevMHicE3A70AlmP'

--- a/packs/_source/items/potion/potion-of-frost-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-frost-giant-strength.yml
@@ -6,10 +6,10 @@ system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p><p>When you drink
-      this potion, your Strength score changes to 23 for [[lookup
-      @labels.duration activity=pE7C9XIq67aoCkGp]]. The potion has no effect on
-      you if your Strength is equal to or greater than that score.</p>
+      fingernail from a frost giant.</em></p><p>When you drink this potion, your
+      Strength score changes to 23 for [[lookup @labels.duration
+      activity=pE7C9XIq67aoCkGp]]. The potion has no effect on you if your
+      Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:
@@ -188,7 +188,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037193843
-  modifiedTime: 1783373878847
+  modifiedTime: 1783646202884
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!TevMHicE3A70AlmP'

--- a/packs/_source/items/potion/potion-of-frost-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-frost-giant-strength.yml
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:

--- a/packs/_source/items/potion/potion-of-gaseous-form.yml
+++ b/packs/_source/items/potion/potion-of-gaseous-form.yml
@@ -1,19 +1,15 @@
 _id: bqZ6NTLDCUB98YjV
 name: Potion of Gaseous Form
 type: consumable
-img: icons/consumables/potions/potion-bottle-skull-label-poison-teal.webp
+img: icons/consumables/potions/bottle-conical-corked-cyan.webp
 system:
   description:
     value: >-
       <p><em>This potion's container seems to hold fog that moves and pours like
-      water.</em></p>
-
-      <p>When you drink this potion, you gain the effect of the
-      @UUID[Compendium.dnd5e.spells.Item.2IWiZAJtOGDoKjiz]{Gaseous Form} spell
-      for 1 hour (no concentration required) or until you end the effect as a
-      bonus action. </p>
-
-      <p> </p>
+      water.</em></p><p>When you drink this potion, you gain the effect of the
+      @UUID[Compendium.dnd5e.spells.Item.2IWiZAJtOGDoKjiz]{gaseous form} spell
+      for [[lookup @labels.duration activity=CvPLbEm6AY14aSst]] (no
+      concentration required) or until you end the effect as a bonus action.</p>
     chat: ''
   source:
     custom: ''
@@ -51,14 +47,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This potion's container seems to hold fog that moves and pours like
+      water.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    CvPLbEm6AY14aSst:
       type: utility
       activation:
         type: action
@@ -70,19 +68,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: SffmmlIyQEG7jM0r
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +98,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +116,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +125,128 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: CvPLbEm6AY14aSst
   attuned: false
   identifier: potion-of-gaseous-form
-effects: []
+effects:
+  - name: Gaseous Form
+    img: icons/magic/air/wind-tornado-cyclone-white.webp
+    origin: Compendium.dnd5e.items.Item.bqZ6NTLDCUB98YjV
+    transfer: false
+    _id: SffmmlIyQEG7jM0r
+    type: base
+    system:
+      changes:
+        - key: system.abilities.str.save.roll.mode
+          type: add
+          value: ''
+          phase: initial
+          priority: null
+        - key: system.abilities.dex.save.roll.mode
+          type: add
+          value: ''
+          phase: initial
+          priority: null
+        - key: system.abilities.con.save.roll.mode
+          type: add
+          value: ''
+          phase: initial
+          priority: null
+        - key: system.attributes.movement.fly
+          type: override
+          value: 10
+          phase: initial
+          priority: null
+        - key: system.attributes.movement.walk
+          type: override
+          value: 0
+          phase: initial
+          priority: null
+        - key: system.attributes.movement.swim
+          type: override
+          value: 0
+          phase: initial
+          priority: null
+        - key: system.attributes.movement.climb
+          type: override
+          value: 0
+          phase: initial
+          priority: null
+        - key: system.attributes.movement.burrow
+          type: override
+          value: 0
+          phase: initial
+          priority: null
+        - key: system.traits.dr.value
+          type: add
+          value: bludgeoning
+          phase: initial
+          priority: null
+        - key: system.traits.dr.value
+          type: add
+          value: piercing
+          phase: initial
+          priority: null
+        - key: system.traits.dr.value
+          type: add
+          value: slashing
+          phase: initial
+          priority: null
+        - key: system.traits.dr.bypasses
+          type: add
+          value: mgc
+          phase: initial
+          priority: null
+      rider:
+        statuses: []
+      magical: true
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>You have been transformed, along with everything you are wearing and
+      carrying, into a misty cloud for the duration. This effect ends if you
+      drop to 0 hit points.</p><p>While in this form, your only method of
+      movement is a flying speed of 10 feet. You can enter and occupy the space
+      of another creature. You have resistance to nonmagical damage, and you
+      have advantage on Strength, Dexterity, and Constitution saving throws. You
+      can pass through small holes, narrow openings, and even mere cracks,
+      though you treat liquids as though they were solid surfaces. You can't
+      fall and remain hovering in the air even when &amp;reference[stunned
+      apply=false] or otherwise &amp;reference[incapacitated
+      apply=false].</p><p>While in the form of a misty cloud, you can't talk or
+      manipulate objects, and any objects you were carrying or holding can't be
+      dropped, used, or otherwise interacted with. You can't attack or cast
+      spells.</p>
+    tint: '#ffffff'
+    statuses:
+      - transformed
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags:
+      dnd5e:
+        riders: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783373753012
+      modifiedTime: 1783376576756
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: >-
+        Compendium.dnd5e.spells.Item.2IWiZAJtOGDoKjiz.ActiveEffect.gICakgyAi1hrs8ug
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!bqZ6NTLDCUB98YjV.SffmmlIyQEG7jM0r'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +254,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037229250
-  modifiedTime: 1764620298092
+  modifiedTime: 1783377141305
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!bqZ6NTLDCUB98YjV'

--- a/packs/_source/items/potion/potion-of-greater-healing.yml
+++ b/packs/_source/items/potion/potion-of-greater-healing.yml
@@ -6,7 +6,7 @@ system:
   description:
     value: >-
       <p><em>The potion's red liquid glimmers when agitated.</em></p><p>You
-      regain 4d4+4 hit points when you drink this potion.</p>
+      regain [[/healing]] when you drink this potion.</p>
     chat: ''
   source:
     custom: ''
@@ -49,14 +49,14 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: <p>The potion's red liquid glimmers when agitated.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    fWvDOSK8Cpfx6EkF:
       type: heal
       activation:
         type: action
@@ -68,12 +68,14 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
@@ -93,7 +95,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -114,12 +117,13 @@ system:
           mode: whole
           number: null
           formula: ''
+        modifiers: []
       uses:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -127,7 +131,11 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: fWvDOSK8Cpfx6EkF
   attuned: false
   identifier: potion-of-greater-healing
 effects: []
@@ -138,11 +146,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037164386
-  modifiedTime: 1764619665798
+  modifiedTime: 1783373715631
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!L887NdWEP5NqHCrQ'

--- a/packs/_source/items/potion/potion-of-growth.yml
+++ b/packs/_source/items/potion/potion-of-growth.yml
@@ -6,11 +6,10 @@ system:
   description:
     value: >-
       <p><em>The red in the potion's liquid continuously expands from a tiny
-      bead to color the clear liquid around it and then contracts.  Shaking the
-      bottle fails to interrupt this process.</em></p>
-
-      <p>When you drink this potion, you gain the "enlarge" effect of the
-      @UUID[Compendium.dnd5e.spells.Item.WahI41a3goVUg0x1]{Enlarge/Reduce} spell
+      bead to color the clear liquid around it and then contracts. Shaking the
+      bottle fails to interrupt this process.</em></p><p>When you drink this
+      potion, you gain the "enlarge" effect of the
+      @UUID[Compendium.dnd5e.spells.Item.WahI41a3goVUg0x1]{enlarge/reduce} spell
       for 1d4 hours (no concentration required).</p>
     chat: ''
   source:
@@ -49,14 +48,17 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The red in the potion's liquid continuously expands from a tiny bead to
+      color the clear liquid around it and then contracts. Shaking the bottle
+      fails to interrupt this process.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    ZgATJF7ZjCGRyL10:
       type: utility
       activation:
         type: action
@@ -68,19 +70,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
-        value: ''
+        value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: HAuNLWE4FAG5lpup
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -93,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -110,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -119,10 +127,80 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: ZgATJF7ZjCGRyL10
   attuned: false
   identifier: potion-of-growth
-effects: []
+effects:
+  - name: Alchemically Enlarged
+    img: icons/magic/control/silhouette-grow-shrink-tan.webp
+    origin: Compendium.dnd5e.items.Item.gTRFQLdVD1gsKtPi
+    transfer: false
+    _id: HAuNLWE4FAG5lpup
+    type: base
+    system:
+      changes:
+        - key: system.bonuses.mwak.damage
+          type: add
+          value: 1d4
+          phase: initial
+          priority: null
+        - key: system.bonuses.rwak.damage
+          type: add
+          value: 1d4
+          phase: initial
+          priority: null
+        - key: system.abilities.str.check.roll.mode
+          type: add
+          value: 1
+          phase: initial
+          priority: null
+        - key: system.abilities.str.save.roll.mode
+          type: add
+          value: 1
+          phase: initial
+          priority: null
+      rider:
+        statuses: []
+      magical: true
+    disabled: false
+    start: null
+    duration:
+      value: 4
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>Your size doubles in all dimensions, and your weight is multiplied by
+      eight. This growth increases your size by one category—from Medium to
+      Large, for example. If there isn't enough room for you to double its size,
+      you attain the maximum possible size in the space available. You also have
+      advantage on Strength Checks and Strength Saving Throws.</p><p>Your
+      Weapons also grow to match your new size. While these Weapons are
+      enlarged, your attacks with them deal 1d4 extra damage.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags:
+      dnd5e:
+        riders: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783373369437
+      modifiedTime: 1783376558286
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: >-
+        Compendium.dnd5e.spells.Item.WahI41a3goVUg0x1.ActiveEffect.iVWIbqSzCYFAQzV6
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!gTRFQLdVD1gsKtPi.HAuNLWE4FAG5lpup'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -130,11 +208,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037251967
-  modifiedTime: 1764620524351
+  modifiedTime: 1783377130140
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!gTRFQLdVD1gsKtPi'

--- a/packs/_source/items/potion/potion-of-healing.yml
+++ b/packs/_source/items/potion/potion-of-healing.yml
@@ -6,7 +6,7 @@ system:
   description:
     value: >-
       <p><em>The potion's red liquid glimmers when agitated.</em></p><p>You
-      regain 2d4+2 hit points when you drink this potion.</p>
+      regain [[/healing]] when you drink this potion.</p>
     chat: ''
   source:
     custom: ''
@@ -49,14 +49,14 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: <p>The potion's red liquid glimmers when agitated.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    33TpG8uDHXtjcaUE:
       type: heal
       activation:
         type: action
@@ -68,16 +68,18 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
@@ -93,7 +95,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -114,12 +117,13 @@ system:
           mode: whole
           number: null
           formula: ''
+        modifiers: []
       uses:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -127,7 +131,11 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: 33TpG8uDHXtjcaUE
   attuned: false
   identifier: potion-of-healing
 effects: []
@@ -138,11 +146,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037327576
-  modifiedTime: 1764621434784
+  modifiedTime: 1783373342252
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!ytlsBjYsZ7OBSEBs'

--- a/packs/_source/items/potion/potion-of-heroism.yml
+++ b/packs/_source/items/potion/potion-of-heroism.yml
@@ -1,18 +1,16 @@
 _id: wNKYbKYwOHbA7SH8
 name: Potion of Heroism
 type: consumable
-img: icons/consumables/potions/potion-bottle-corked-fancy-orange.webp
+img: icons/consumables/potions/potion-flask-capped-yellow-green.webp
 system:
   description:
     value: >-
-      <p><em>This blue potion bubbles and steams as if boiling.</em></p><p>For 1
-      hour after drinking it, you gain 10 temporary hit points that last for 1
-      hour. For the same duration, you are under the effect of the
-      @UUID[Compendium.dnd5e.spells.Item.8dzaICjGy6mTUaUr]{Bless} spell (no
-      concentration required)</p><section class="secret foundry-note"
-      id="secret-bF4l2V0GJ0rrbVZK"><p><strong>Foundry Note</strong></p><p>The
-      Other Formula button can be used to roll the bonus 1d4 received from
-      Bless.</p></section>
+      <p><em>This blue potion bubbles and steams as if boiling.</em></p><p>For
+      [[lookup @labels.duration activity=HXZpxqQDRfm5EL0r]] after drinking it,
+      you gain 10 temporary hit points that last for [[lookup @labels.duration
+      activity=HXZpxqQDRfm5EL0r]]. For the same duration, you are under the
+      effect of the @UUID[Compendium.dnd5e.spells.Item.8dzaICjGy6mTUaUr]{bless}
+      spell (no concentration required)</p>
     chat: ''
   source:
     custom: ''
@@ -55,14 +53,14 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: <p>This blue potion bubbles and steams as if boiling.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    HXZpxqQDRfm5EL0r:
       type: heal
       activation:
         type: action
@@ -74,19 +72,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: KKcIKvHCHET79fEp
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -99,7 +102,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -120,12 +124,13 @@ system:
           mode: whole
           number: null
           formula: ''
+        modifiers: []
       uses:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -133,75 +138,81 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
-    dnd5eactivity300:
-      _id: dnd5eactivity300
-      type: utility
-      activation:
-        type: action
-        value: 1
-        condition: ''
-        override: false
-      consumption:
-        targets:
-          - type: itemUses
-            value: '1'
-            target: ''
-        scaling:
-          allowed: false
-          max: ''
-        spellSlot: true
-      description:
-        chatFlavor: ''
-      duration:
-        concentration: false
-        value: '1'
-        units: hour
-        special: ''
-        override: false
-      effects: []
-      range:
-        units: touch
-        special: ''
-        override: false
-      target:
-        template:
-          count: ''
-          contiguous: false
-          type: ''
-          size: ''
-          width: ''
-          height: ''
-          units: ''
-        affects:
-          count: '1'
-          type: creature
-          choice: false
-          special: ''
-        prompt: true
-        override: false
-      roll:
-        formula: 1d4
-        name: ''
-        prompt: false
-        visible: false
-      uses:
-        spent: 0
-        recovery: []
-        max: ''
-      sort: 0
-      name: ''
-      img: ''
-      visibility:
-        requireMagic: true
-        level:
-          min: null
-          max: null
-        identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: HXZpxqQDRfm5EL0r
   attuned: false
   identifier: potion-of-heroism
-effects: []
+effects:
+  - _id: KKcIKvHCHET79fEp
+    flags:
+      dnd5e:
+        riders: {}
+    disabled: false
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    origin: Compendium.dnd5e.items.Item.wNKYbKYwOHbA7SH8
+    tint: '#ffffff'
+    transfer: false
+    name: Blessed
+    description: >-
+      <p>For the duration, whenever you make an attack roll or a saving throw,
+      you can roll 1d4 and add the number rolled to the attack roll or saving
+      throw.</p>
+    statuses: []
+    _stats:
+      compendiumSource: >-
+        Compendium.dnd5e.spells.Item.8dzaICjGy6mTUaUr.ActiveEffect.8rP3gwmXVTgZqYZE
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783376977839
+      modifiedTime: 1783377070359
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    img: icons/magic/symbols/runes-carved-stone-yellow.webp
+    type: base
+    system:
+      changes:
+        - key: system.bonuses.abilities.save
+          value: 1d4
+          priority: null
+          type: add
+          phase: initial
+        - key: system.bonuses.mwak.attack
+          value: 1d4
+          priority: null
+          type: add
+          phase: initial
+        - key: system.bonuses.msak.attack
+          value: 1d4
+          priority: null
+          type: add
+          phase: initial
+        - key: system.bonuses.rsak.attack
+          value: 1d4
+          priority: null
+          type: add
+          phase: initial
+        - key: system.bonuses.rwak.attack
+          value: 1d4
+          priority: null
+          type: add
+          phase: initial
+      rider:
+        statuses: []
+      magical: false
+    sort: 0
+    start: null
+    showIcon: 1
+    folder: null
+    _key: '!items.effects!wNKYbKYwOHbA7SH8.KKcIKvHCHET79fEp'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -209,11 +220,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037318297
-  modifiedTime: 1764621300816
+  modifiedTime: 1783377090084
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!wNKYbKYwOHbA7SH8'

--- a/packs/_source/items/potion/potion-of-heroism.yml
+++ b/packs/_source/items/potion/potion-of-heroism.yml
@@ -173,7 +173,7 @@ effects:
       systemId: dnd5e
       systemVersion: 6.0.0
       createdTime: 1783376977839
-      modifiedTime: 1783377070359
+      modifiedTime: 1783646540715
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     img: icons/magic/symbols/runes-carved-stone-yellow.webp
@@ -207,7 +207,7 @@ effects:
           phase: initial
       rider:
         statuses: []
-      magical: false
+      magical: true
     sort: 0
     start: null
     showIcon: 1

--- a/packs/_source/items/potion/potion-of-hill-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-hill-giant-strength.yml
@@ -6,13 +6,10 @@ system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p>
-
-      <p>When you drink this potion, your Strength score changes to 21 for 1
-      hour.  The potion has no effect on you if your Strength is equal to or
-      greater than that score.</p>
-
-      <p> </p>
+      fingernail from a giant of the appropriate type.</em></p><p>When you drink
+      this potion, your Strength score changes to 21 for [[lookup
+      @labels.duration activity=UDIImot28uvAlkHv]]. The potion has no effect on
+      you if your Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -50,14 +47,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This potion's transparent liquid has floating in it a sliver of
+      fingernail from a giant of the appropriate type.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    UDIImot28uvAlkHv:
       type: utility
       activation:
         type: action
@@ -69,19 +68,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: Ee51dNBilkLQhVr9
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -94,7 +98,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -111,8 +116,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -120,10 +125,58 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: UDIImot28uvAlkHv
   attuned: false
   identifier: potion-of-hill-giant-strength
-effects: []
+effects:
+  - name: Hill Giant Strength
+    img: icons/environment/wilderness/arch-stone.webp
+    origin: Compendium.dnd5e.items.Item.mhFBTY0egW8AeCHe
+    transfer: false
+    _id: Ee51dNBilkLQhVr9
+    type: base
+    system:
+      changes:
+        - key: system.abilities.str.value
+          type: upgrade
+          value: 21
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>Your Strength score changes to 21 for the duration. This has no effect
+      on you if your Strength is equal to or greater than 21.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783373214167
+      modifiedTime: 1783376544824
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: >-
+        Compendium.dnd5e.items.Item.1KMSpOSU0EliUBm2.ActiveEffect.sjbluBPTvdkkf3pv
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!mhFBTY0egW8AeCHe.Ee51dNBilkLQhVr9'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -131,11 +184,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037279377
-  modifiedTime: 1764620893217
+  modifiedTime: 1783373303057
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!mhFBTY0egW8AeCHe'

--- a/packs/_source/items/potion/potion-of-hill-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-hill-giant-strength.yml
@@ -6,10 +6,10 @@ system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p><p>When you drink
-      this potion, your Strength score changes to 21 for [[lookup
-      @labels.duration activity=UDIImot28uvAlkHv]]. The potion has no effect on
-      you if your Strength is equal to or greater than that score.</p>
+      fingernail from a hill giant.</em></p><p>When you drink this potion, your
+      Strength score changes to 21 for [[lookup @labels.duration
+      activity=UDIImot28uvAlkHv]]. The potion has no effect on you if your
+      Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:
@@ -188,7 +188,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037279377
-  modifiedTime: 1783373303057
+  modifiedTime: 1783646216316
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!mhFBTY0egW8AeCHe'

--- a/packs/_source/items/potion/potion-of-hill-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-hill-giant-strength.yml
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:

--- a/packs/_source/items/potion/potion-of-invisibility.yml
+++ b/packs/_source/items/potion/potion-of-invisibility.yml
@@ -6,13 +6,10 @@ system:
   description:
     value: >-
       <p><em>This potion's container looks empty but feels as though it holds
-      liquid. </em></p>
-
-      <p>When you drink it, you become invisible for 1 hour. Anything you wear
-      or carry is invisible with you. The effect ends early if you attack or
-      cast a spell.</p>
-
-      <p> </p>
+      liquid.</em></p><p>When you drink it, you become &amp;reference[invisible]
+      for [[lookup @labels.duration activity=V2JumDYJgM7ktIzw]]. Anything you
+      wear or carry is invisible with you. The effect ends early if you attack
+      or cast a spell.</p>
     chat: ''
   source:
     custom: ''
@@ -50,14 +47,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This potion's container looks empty but feels as though it holds
+      liquid.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    V2JumDYJgM7ktIzw:
       type: utility
       activation:
         type: action
@@ -69,19 +68,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: oGWqgNUAzC2P3E2m
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -94,7 +98,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -111,8 +116,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -120,10 +125,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: V2JumDYJgM7ktIzw
   attuned: false
   identifier: potion-of-invisibility
-effects: []
+effects:
+  - name: Invisibility
+    img: icons/creatures/magical/spirit-undead-ghost-blue.webp
+    origin: Compendium.dnd5e.items.Item.rTn4p9nJr4Aq2GPB
+    transfer: false
+    _id: oGWqgNUAzC2P3E2m
+    type: base
+    system:
+      changes: []
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>For the duration, you are &amp;reference[invisible apply=false].
+      Anything you wear or carry is invisible with you. This effect ends early
+      if you attack or cast a spell.</p>
+    tint: '#ffffff'
+    statuses:
+      - invisible
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783373118688
+      modifiedTime: 1783376537990
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!rTn4p9nJr4Aq2GPB.oGWqgNUAzC2P3E2m'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -131,11 +180,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037299390
-  modifiedTime: 1764621070892
+  modifiedTime: 1783373205562
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!rTn4p9nJr4Aq2GPB'

--- a/packs/_source/items/potion/potion-of-lightning-resistance.yml
+++ b/packs/_source/items/potion/potion-of-lightning-resistance.yml
@@ -1,19 +1,18 @@
 _id: 8MPnSrvEeZhPhtTi
 name: Potion of Lightning Resistance
 type: consumable
-img: icons/consumables/potions/bottle-round-corked-yellow.webp
+img: icons/consumables/potions/potion-bottle-corked-fancy-blue.webp
 system:
   description:
     value: >-
       <p><em>The potion is a plain indescriminate color and smells slightly
-      foul.</em></p>
-
-      <p>When you drink this potion, you gain resistance to Lightning type
-      damage for 1 hour.</p>
-
-      <p>For other potions of resistance, roll on the
+      foul.</em></p><p>When you drink this potion, you gain resistance to
+      lightning damage for [[lookup @labels.duration
+      activity=pKltvikkvHLlLjXo]].</p><section id="secret-hGgZvWraAwH7ge8U"
+      class="secret"><p><strong>Foundry Note</strong></p><p>For other potions of
+      resistance, roll on the
       @UUID[Compendium.dnd5e.tables.RollTable.JzLOE4IxcmxjLLuz]{Potion of
-      Resistance} table.</p>
+      Resistance} table.</p></section>
     chat: ''
   source:
     custom: ''
@@ -51,14 +50,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion is a plain indescriminate color and smells slightly
+      foul.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    pKltvikkvHLlLjXo:
       type: utility
       activation:
         type: action
@@ -70,19 +71,23 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: o5uwUilyOmZKavPX
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +127,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      flags: {}
+      _id: pKltvikkvHLlLjXo
   attuned: false
   identifier: potion-of-lightning-resistance
-effects: []
+effects:
+  - name: Lightning Resistance
+    img: icons/magic/lightning/bolt-blue.webp
+    origin: Compendium.dnd5e.items.Item.8MPnSrvEeZhPhtTi
+    transfer: false
+    _id: o5uwUilyOmZKavPX
+    type: base
+    system:
+      changes:
+        - key: system.traits.dr.value
+          type: add
+          value: lightning
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You have resistance to lightning damage.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781978361056
+      modifiedTime: 1781979102507
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!8MPnSrvEeZhPhtTi.o5uwUilyOmZKavPX'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +182,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037113266
-  modifiedTime: 1764619111962
+  modifiedTime: 1783372273564
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!8MPnSrvEeZhPhtTi'

--- a/packs/_source/items/potion/potion-of-mind-reading.yml
+++ b/packs/_source/items/potion/potion-of-mind-reading.yml
@@ -7,8 +7,8 @@ system:
     value: >-
       <p><em>The potion's dense, purple liquid has an ovoid cloud of pink
       floating in it.</em></p><p>When you drink this potion, you gain the effect
-      of the @UUID[Compendium.dnd5e.spells.Item.ppWAAEul0QHtm4er]{Detect
-      Thoughts} spell (save DC 13).</p>
+      of the @UUID[Compendium.dnd5e.spells.Item.ppWAAEul0QHtm4er]{detect
+      thoughts} spell (save DC 13).</p>
     chat: ''
   source:
     custom: ''
@@ -55,51 +55,49 @@ system:
     - mgc
   magicalBonus: null
   activities:
-    DN8gzY6YObgBtXba:
-      type: cast
-      spell:
-        uuid: Compendium.dnd5e.spells.Item.ppWAAEul0QHtm4er
-        challenge:
-          override: true
-          attack: ''
-          save: 13
-        properties:
-          - vocal
-          - somatic
-          - material
-        spellbook: false
-        ability: ''
-        level: 2
-      _id: DN8gzY6YObgBtXba
-      sort: 0
+    pZiGEv6ugCZX3Agp:
+      type: utility
+      name: Drink
+      _id: pZiGEv6ugCZX3Agp
+      img: ''
+      sort: 100000
       activation:
         type: action
         override: false
+        condition: ''
+      behaviors: []
       consumption:
         scaling:
           allowed: false
         spellSlot: true
-        targets:
-          - type: itemUses
-            value: '1'
-            target: ''
-            scaling: {}
+        targets: []
       description:
+        value: ''
         chatFlavor: ''
       duration:
         units: inst
         concentration: false
         override: false
+      effects:
+        - _id: sGtB63gv4o99IFMT
+          uuid: null
+          level:
+            min: null
+            max: null
       flags: {}
       range:
         units: self
         override: false
+        special: ''
       target:
         template:
           contiguous: false
+          stationary: false
           units: ft
+          type: ''
         affects:
           choice: false
+          type: ''
         override: false
         prompt: true
       uses:
@@ -112,13 +110,80 @@ system:
           max: null
         requireAttunement: false
         requireIdentification: false
-        requireMagic: false
+        requireMagic: true
         identifier: ''
-      name: Drink
-      img: ''
+      roll:
+        prompt: false
+        visible: false
+        name: ''
+        formula: ''
   attuned: false
   identifier: potion-of-mind-reading
-effects: []
+effects:
+  - name: Alchemical Mind Reading
+    img: icons/magic/perception/third-eye-blue-red.webp
+    origin: Compendium.dnd5e.items.Item.Ct9LR9Ft1FG4a6Y1
+    transfer: false
+    _id: sGtB63gv4o99IFMT
+    type: base
+    system:
+      changes: []
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: minutes
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>For the duration, you can read the thoughts of certain creatures. When
+      you drink this potion and as your action on each turn until the effect
+      ends, you can focus your mind on any one creature that you can see within
+      30 feet of you. If the creature you choose has an Intelligence of 3 or
+      lower or doesn't speak any language, the creature is unaffected.</p><p>You
+      initially learn the surface thoughts of the creature—what is most on its
+      mind in that moment. As an action, you can either shift your attention to
+      another creature's thoughts or attempt to probe deeper into the same
+      creature's mind. If you probe deeper, the target must make a [[/save wis
+      13]] saving throw. If it fails, you gain insight into its reasoning (if
+      any), its emotional state, and something that looms large in its mind
+      (such as something it worries over, loves, or hates). If it succeeds, the
+      effect ends. Either way, the target knows that you are probing into its
+      mind, and unless you shift your attention to another creature's thoughts,
+      the creature can use its action on its turn to make an Intelligence check
+      contested by your Intelligence check; if it succeeds, the effect
+      ends.</p><p>Questions verbally directed at the target creature naturally
+      shape the course of its thoughts, so this effect is particularly effective
+      as part of an interrogation.</p><p>You can also use this effect to detect
+      the presence of thinking creatures you can't see. When you drink the
+      potion or as your action during the duration, you can search for thoughts
+      within 30 feet of you. Theis effect can penetrate barriers, but 2 feet of
+      rock, 2 inches of any metal other than lead, or a thin sheet of lead
+      blocks you. You can't detect a creature with an Intelligence of 3 or lower
+      or one that doesn't speak any language.</p><p>Once you detect the presence
+      of a creature in this way, you can read its thoughts for the rest of the
+      duration as described above, even if you can't see it, but it must still
+      be within range.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783377579024
+      modifiedTime: 1783377745198
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!Ct9LR9Ft1FG4a6Y1.sGtB63gv4o99IFMT'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -130,7 +195,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037129606
-  modifiedTime: 1783373070029
+  modifiedTime: 1783377780767
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Ct9LR9Ft1FG4a6Y1'

--- a/packs/_source/items/potion/potion-of-mind-reading.yml
+++ b/packs/_source/items/potion/potion-of-mind-reading.yml
@@ -6,11 +6,9 @@ system:
   description:
     value: >-
       <p><em>The potion's dense, purple liquid has an ovoid cloud of pink
-      floating in it.</em></p>
-
-      <p>When you drink this potion, you gain the effect of the
-      @UUID[Compendium.dnd5e.spells.Item.ppWAAEul0QHtm4er]{Detect Thoughts}
-      spell (save DC 13). </p>
+      floating in it.</em></p><p>When you drink this potion, you gain the effect
+      of the @UUID[Compendium.dnd5e.spells.Item.ppWAAEul0QHtm4er]{Detect
+      Thoughts} spell (save DC 13).</p>
     chat: ''
   source:
     custom: ''
@@ -48,7 +46,10 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion's dense, purple liquid has an ovoid cloud of pink floating
+      in it.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
@@ -60,13 +61,13 @@ system:
         uuid: Compendium.dnd5e.spells.Item.ppWAAEul0QHtm4er
         challenge:
           override: true
-          attack: null
+          attack: ''
           save: 13
         properties:
           - vocal
           - somatic
           - material
-        spellbook: true
+        spellbook: false
         ability: ''
         level: 2
       _id: DN8gzY6YObgBtXba
@@ -80,6 +81,9 @@ system:
         spellSlot: true
         targets:
           - type: itemUses
+            value: '1'
+            target: ''
+            scaling: {}
       description:
         chatFlavor: ''
       duration:
@@ -110,7 +114,7 @@ system:
         requireIdentification: false
         requireMagic: false
         identifier: ''
-      name: ''
+      name: Drink
       img: ''
   attuned: false
   identifier: potion-of-mind-reading
@@ -122,11 +126,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037129606
-  modifiedTime: 1764619315594
+  modifiedTime: 1783373070029
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Ct9LR9Ft1FG4a6Y1'

--- a/packs/_source/items/potion/potion-of-necrotic-resistance.yml
+++ b/packs/_source/items/potion/potion-of-necrotic-resistance.yml
@@ -1,19 +1,18 @@
 _id: xw99pcqPBVwtMOLw
 name: Potion of Necrotic Resistance
 type: consumable
-img: icons/consumables/potions/bottle-round-corked-pink.webp
+img: icons/consumables/potions/potion-bottle-labeled-stopped-purple.webp
 system:
   description:
     value: >-
       <p><em>The potion is a plain indescriminate color and smells slightly
-      foul.</em></p>
-
-      <p>When you drink this potion, you gain resistance to Necrotic type damage
-      for 1 hour.</p>
-
-      <p>For other potions of resistance, roll on the
+      foul.</em></p><p>When you drink this potion, you gain resistance to
+      necrotic damage for [[lookup @labels.duration
+      activity=CYyNHqO1SdtnOY8t]].</p><section id="secret-pkDMfde7TkXiyLYD"
+      class="secret"><p><strong>Foundry Note</strong></p><p>For other potions of
+      resistance, roll on the
       @UUID[Compendium.dnd5e.tables.RollTable.JzLOE4IxcmxjLLuz]{Potion of
-      Resistance} table.</p>
+      Resistance} table.</p></section>
     chat: ''
   source:
     custom: ''
@@ -51,14 +50,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion is a plain indescriminate color and smells slightly
+      foul.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    CYyNHqO1SdtnOY8t:
       type: utility
       activation:
         type: action
@@ -70,19 +71,23 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: MKFIbvGusGUaKtav
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +127,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      flags: {}
+      _id: CYyNHqO1SdtnOY8t
   attuned: false
   identifier: potion-of-necrotic-resistance
-effects: []
+effects:
+  - name: Necrotic Resistance
+    img: icons/magic/death/hand-withered-gray.webp
+    origin: Compendium.dnd5e.items.Item.xw99pcqPBVwtMOLw
+    transfer: false
+    _id: MKFIbvGusGUaKtav
+    type: base
+    system:
+      changes:
+        - key: system.traits.dr.value
+          type: add
+          value: necrotic
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You have resistance to necrotic damage.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781978163324
+      modifiedTime: 1781979096620
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!xw99pcqPBVwtMOLw.MKFIbvGusGUaKtav'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +182,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037324863
-  modifiedTime: 1764621405342
+  modifiedTime: 1783372265647
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!xw99pcqPBVwtMOLw'

--- a/packs/_source/items/potion/potion-of-poison-resistance.yml
+++ b/packs/_source/items/potion/potion-of-poison-resistance.yml
@@ -1,19 +1,18 @@
 _id: f5chGcpQCi1HYPQw
 name: Potion of Poison Resistance
 type: consumable
-img: icons/consumables/potions/bottle-bulb-corked-green.webp
+img: icons/consumables/potions/potion-tube-corked-tied-green.webp
 system:
   description:
     value: >-
       <p><em>The potion is a plain indescriminate color and smells slightly
-      foul.</em></p>
-
-      <p>When you drink this potion, you gain resistance to Poison type damage
-      for 1 hour.</p>
-
-      <p>For other potions of resistance, roll on the
+      foul.</em></p><p>When you drink this potion, you gain resistance to poison
+      damage for [[lookup @labels.duration
+      activity=AqP9tNv6zZ2N6PLi]].</p><section id="secret-bqCNFf2zrQ0N0kKC"
+      class="secret"><p><strong>Foundry Note</strong></p><p>For other potions of
+      resistance, roll on the
       @UUID[Compendium.dnd5e.tables.RollTable.JzLOE4IxcmxjLLuz]{Potion of
-      Resistance} table.</p>
+      Resistance} table.</p></section>
     chat: ''
   source:
     custom: ''
@@ -51,14 +50,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion is a plain indescriminate color and smells slightly
+      foul.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    AqP9tNv6zZ2N6PLi:
       type: utility
       activation:
         type: action
@@ -70,19 +71,23 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: vkhMbnwDVjFzcSsl
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +127,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      flags: {}
+      _id: AqP9tNv6zZ2N6PLi
   attuned: false
   identifier: potion-of-poison-resistance
-effects: []
+effects:
+  - name: Poison Resistance
+    img: icons/skills/toxins/cauldron-bubbles-overflow-green.webp
+    origin: Compendium.dnd5e.items.Item.f5chGcpQCi1HYPQw
+    transfer: false
+    _id: vkhMbnwDVjFzcSsl
+    type: base
+    system:
+      changes:
+        - key: system.traits.dr.value
+          type: add
+          value: poison
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You have resistance to poison damage.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781978082511
+      modifiedTime: 1781979090769
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!f5chGcpQCi1HYPQw.vkhMbnwDVjFzcSsl'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +182,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037245805
-  modifiedTime: 1764620485301
+  modifiedTime: 1783372256612
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!f5chGcpQCi1HYPQw'

--- a/packs/_source/items/potion/potion-of-psychic-resistance.yml
+++ b/packs/_source/items/potion/potion-of-psychic-resistance.yml
@@ -1,19 +1,18 @@
 _id: c0luemOP0iW8L23R
 name: Potion of Psychic Resistance
 type: consumable
-img: icons/consumables/potions/bottle-round-corked-pink.webp
+img: icons/consumables/potions/bottle-conical-corked-purple.webp
 system:
   description:
     value: >-
       <p><em>The potion is a plain indescriminate color and smells slightly
-      foul.</em></p>
-
-      <p>When you drink this potion, you gain resistance to Psychic type damage
-      for 1 hour.</p>
-
-      <p>For other potions of resistance, roll on the
+      foul.</em></p><p>When you drink this potion, you gain resistance to
+      psychic damage for [[lookup @labels.duration
+      activity=of7MLaNWoYfQedkv]].</p><section id="secret-BCZFMmzfFNU0IIhw"
+      class="secret"><p><strong>Foundry Note</strong></p><p>For other potions of
+      resistance, roll on the
       @UUID[Compendium.dnd5e.tables.RollTable.JzLOE4IxcmxjLLuz]{Potion of
-      Resistance} table.</p>
+      Resistance} table.</p></section>
     chat: ''
   source:
     custom: ''
@@ -51,14 +50,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion is a plain indescriminate color and smells slightly
+      foul.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    of7MLaNWoYfQedkv:
       type: utility
       activation:
         type: action
@@ -70,19 +71,23 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: uvppImdMsIuq4DrH
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +127,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      flags: {}
+      _id: of7MLaNWoYfQedkv
   attuned: false
   identifier: potion-of-psychic-resistance
-effects: []
+effects:
+  - name: Psychic Resistance
+    img: icons/magic/lightning/bolt-strike-purple.webp
+    origin: Compendium.dnd5e.items.Item.c0luemOP0iW8L23R
+    transfer: false
+    _id: uvppImdMsIuq4DrH
+    type: base
+    system:
+      changes:
+        - key: system.traits.dr.value
+          type: add
+          value: psychic
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You have resistance to psychic damage.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781977974179
+      modifiedTime: 1781979085714
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!c0luemOP0iW8L23R.uvppImdMsIuq4DrH'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +182,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037229512
-  modifiedTime: 1764620302713
+  modifiedTime: 1783372245696
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!c0luemOP0iW8L23R'

--- a/packs/_source/items/potion/potion-of-radiant-resistance.yml
+++ b/packs/_source/items/potion/potion-of-radiant-resistance.yml
@@ -1,19 +1,18 @@
 _id: LBQWNqX6hZOKhQ8a
 name: Potion of Radiant Resistance
 type: consumable
-img: icons/consumables/potions/bottle-round-corked-yellow.webp
+img: icons/consumables/potions/potion-vial-tube-yellow.webp
 system:
   description:
     value: >-
       <p><em>The potion is a plain indescriminate color and smells slightly
-      foul.</em></p>
-
-      <p>When you drink this potion, you gain resistance to Radiant type damage
-      for 1 hour.</p>
-
-      <p>For other potions of resistance, roll on the
+      foul.</em></p><p>When you drink this potion, you gain resistance to
+      radiant damage for [[lookup @labels.duration
+      activity=y2q1JJGZ4PCRK6VZ]].</p><section id="secret-UdU2gEVdjQRqLLCP"
+      class="secret"><p><strong>Foundry Note</strong></p><p>For other potions of
+      resistance, roll on the
       @UUID[Compendium.dnd5e.tables.RollTable.JzLOE4IxcmxjLLuz]{Potion of
-      Resistance} table.</p>
+      Resistance} table.</p></section>
     chat: ''
   source:
     custom: ''
@@ -51,14 +50,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion is a plain indescriminate color and smells slightly
+      foul.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    y2q1JJGZ4PCRK6VZ:
       type: utility
       activation:
         type: action
@@ -70,19 +71,23 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: eEef3fb2MpkTeguM
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +127,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      flags: {}
+      _id: y2q1JJGZ4PCRK6VZ
   attuned: false
   identifier: potion-of-radiant-resistance
-effects: []
+effects:
+  - name: Radiant Resistance
+    img: icons/magic/light/explosion-glow-spiral-yellow.webp
+    origin: Compendium.dnd5e.items.Item.LBQWNqX6hZOKhQ8a
+    transfer: false
+    _id: eEef3fb2MpkTeguM
+    type: base
+    system:
+      changes:
+        - key: system.traits.dr.value
+          type: add
+          value: radiant
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You have resistance to radiant damage.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781977561671
+      modifiedTime: 1781979079576
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!LBQWNqX6hZOKhQ8a.eEef3fb2MpkTeguM'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +182,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037164971
-  modifiedTime: 1764619684376
+  modifiedTime: 1783372237444
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!LBQWNqX6hZOKhQ8a'

--- a/packs/_source/items/potion/potion-of-speed.yml
+++ b/packs/_source/items/potion/potion-of-speed.yml
@@ -6,13 +6,10 @@ system:
   description:
     value: >-
       <p><em>The potion's yellow fluid is streaked with black and swirls on its
-      own.</em></p>
-
-      <p>When you drink this potion, you gain the effect of the
-      @UUID[Compendium.dnd5e.spells.Item.Szvk5FEVQW3uhJi5]{Haste} spell for 1
-      minute (no concentration required).</p>
-
-      <p> </p>
+      own.</em></p><p>When you drink this potion, you gain the effect of the
+      @UUID[Compendium.dnd5e.spells.Item.Szvk5FEVQW3uhJi5]{haste} spell for
+      [[lookup @labels.duration activity=Hy33WqORkn5GhlSZ]] (no concentration
+      required).</p>
     chat: ''
   source:
     custom: ''
@@ -50,14 +47,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion's yellow fluid is streaked with black and swirls on its
+      own.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    Hy33WqORkn5GhlSZ:
       type: utility
       activation:
         type: action
@@ -69,19 +68,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: minute
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: PXMOx6wnEh05eAKY
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -94,7 +98,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -111,8 +116,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -120,10 +125,94 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: Hy33WqORkn5GhlSZ
   attuned: false
   identifier: potion-of-speed
-effects: []
+effects:
+  - name: Hastened
+    origin: Compendium.dnd5e.items.Item.ctKfjHjk9gs9UtZI
+    duration:
+      value: 1
+      units: minutes
+      expiry: turnStart
+      expired: false
+    disabled: false
+    _id: PXMOx6wnEh05eAKY
+    description: >-
+      <p>For the duration, your speed is doubled, you gain a +2 bonus to AC,
+      have advantage on Dexterity Saving Throws, and gain an additional action
+      on each of your turns. This action can be used only to take the
+      &amp;reference[Attack] (one weapon attack only), &amp;reference[Dash],
+      &amp;reference[Disengage], &amp;reference[Hide], or &amp;reference[Use an
+      Object] action.</p>
+    transfer: false
+    statuses: []
+    flags:
+      dnd5e:
+        riders: {}
+    tint: '#ffffff'
+    _stats:
+      compendiumSource: >-
+        Compendium.dnd5e.spells.Item.yqUDoxk4x0NWG5Bz.ActiveEffect.YtN8kTDQyxFaxpEx
+      duplicateSource: null
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783372973770
+      modifiedTime: 1783376504952
+      lastModifiedBy: dnd5ebuilder0000
+      exportSource: null
+    img: icons/skills/movement/feet-winged-boots-glowing-yellow.webp
+    type: base
+    system:
+      changes:
+        - key: system.attributes.ac.bonus
+          type: add
+          value: 2
+          phase: initial
+          priority: null
+        - key: system.attributes.movement.burrow
+          type: multiply
+          value: 2
+          phase: initial
+          priority: null
+        - key: system.attributes.movement.climb
+          type: multiply
+          value: 2
+          phase: initial
+          priority: null
+        - key: system.attributes.movement.fly
+          type: multiply
+          value: 2
+          phase: initial
+          priority: null
+        - key: system.attributes.movement.swim
+          type: multiply
+          value: 2
+          phase: initial
+          priority: null
+        - key: system.attributes.movement.walk
+          type: multiply
+          value: 2
+          phase: initial
+          priority: null
+        - key: system.abilities.dex.save.roll.mode
+          type: add
+          value: 1
+          phase: initial
+          priority: null
+      rider:
+        statuses: []
+      magical: true
+    sort: 0
+    start: null
+    showIcon: 1
+    folder: null
+    _key: '!items.effects!ctKfjHjk9gs9UtZI.PXMOx6wnEh05eAKY'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -131,11 +220,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037232045
-  modifiedTime: 1764620345399
+  modifiedTime: 1783377115773
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!ctKfjHjk9gs9UtZI'

--- a/packs/_source/items/potion/potion-of-stone-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-stone-giant-strength.yml
@@ -6,13 +6,10 @@ system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p>
-
-      <p>When you drink this potion, your Strength score changes to 23 for 1
-      hour.  The potion has no effect on you if your Strength is equal to or
-      greater than that score.</p>
-
-      <p> </p>
+      fingernail from a giant of the appropriate type.</em></p><p>When you drink
+      this potion, your Strength score changes to 23 for [[lookup
+      @labels.duration activity=0S5O1JqFRIlf9gik]]. The potion has no effect on
+      you if your Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -50,14 +47,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This potion's transparent liquid has floating in it a sliver of
+      fingernail from a giant of the appropriate type.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    0S5O1JqFRIlf9gik:
       type: utility
       activation:
         type: action
@@ -69,19 +68,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: qz2SZ5RcpuR5rOO4
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -94,7 +98,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -111,8 +116,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -120,10 +125,58 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: 0S5O1JqFRIlf9gik
   attuned: false
   identifier: potion-of-stone-giant-strength
-effects: []
+effects:
+  - name: Stone Giant Strength
+    img: icons/magic/earth/strike-fist-stone-gray.webp
+    origin: Compendium.dnd5e.items.Item.4ZiJsDTRA1GgcWKP
+    transfer: false
+    _id: qz2SZ5RcpuR5rOO4
+    type: base
+    system:
+      changes:
+        - key: system.abilities.str.value
+          type: upgrade
+          value: 23
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>Your Strength score changes to 23 for the duration. This has no effect
+      on you if your Strength is equal to or greater than 23.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783372839475
+      modifiedTime: 1783376495018
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: >-
+        Compendium.dnd5e.items.Item.1KMSpOSU0EliUBm2.ActiveEffect.sjbluBPTvdkkf3pv
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!4ZiJsDTRA1GgcWKP.qz2SZ5RcpuR5rOO4'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -131,11 +184,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037099251
-  modifiedTime: 1764618947393
+  modifiedTime: 1783372948526
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!4ZiJsDTRA1GgcWKP'

--- a/packs/_source/items/potion/potion-of-stone-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-stone-giant-strength.yml
@@ -6,10 +6,10 @@ system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p><p>When you drink
-      this potion, your Strength score changes to 23 for [[lookup
-      @labels.duration activity=0S5O1JqFRIlf9gik]]. The potion has no effect on
-      you if your Strength is equal to or greater than that score.</p>
+      fingernail from a stone giant.</em></p><p>When you drink this potion, your
+      Strength score changes to 23 for [[lookup @labels.duration
+      activity=0S5O1JqFRIlf9gik]]. The potion has no effect on you if your
+      Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:
@@ -188,7 +188,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037099251
-  modifiedTime: 1783372948526
+  modifiedTime: 1783646235617
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!4ZiJsDTRA1GgcWKP'

--- a/packs/_source/items/potion/potion-of-stone-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-stone-giant-strength.yml
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:

--- a/packs/_source/items/potion/potion-of-storm-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-storm-giant-strength.yml
@@ -6,13 +6,10 @@ system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p>
-
-      <p>When you drink this potion, your Strength score changes to 29 for 1
-      hour.  The potion has no effect on you if your Strength is equal to or
-      greater than that score.</p>
-
-      <p> </p>
+      fingernail from a giant of the appropriate type.</em></p><p>When you drink
+      this potion, your Strength score changes to 29 for [[lookup
+      @labels.duration activity=2cOOq5vkw0u763Px]]. The potion has no effect on
+      you if your Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -50,14 +47,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This potion's transparent liquid has floating in it a sliver of
+      fingernail from a giant of the appropriate type.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    2cOOq5vkw0u763Px:
       type: utility
       activation:
         type: action
@@ -69,19 +68,24 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: sjbluBPTvdkkf3pv
+          uuid: null
+          level: {}
       range:
         units: touch
         special: ''
@@ -94,7 +98,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -111,8 +116,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -120,10 +125,57 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: 2cOOq5vkw0u763Px
   attuned: false
   identifier: potion-of-storm-giant-strength
-effects: []
+effects:
+  - name: Storm Giant Strength
+    img: icons/magic/lightning/bolts-salvo-clouds-sky.webp
+    origin: Compendium.dnd5e.items.Item.1KMSpOSU0EliUBm2
+    transfer: false
+    _id: sjbluBPTvdkkf3pv
+    type: base
+    system:
+      changes:
+        - key: system.abilities.str.value
+          type: upgrade
+          value: 29
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: >-
+      <p>Your Strength score changes to 29 for the duration. This has no effect
+      on you if your Strength is equal to or greater than 29.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1783372709925
+      modifiedTime: 1783374087871
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!1KMSpOSU0EliUBm2.sjbluBPTvdkkf3pv'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -131,11 +183,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037085351
-  modifiedTime: 1764618711482
+  modifiedTime: 1783372804970
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!1KMSpOSU0EliUBm2'

--- a/packs/_source/items/potion/potion-of-storm-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-storm-giant-strength.yml
@@ -6,10 +6,10 @@ system:
   description:
     value: >-
       <p><em>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</em></p><p>When you drink
-      this potion, your Strength score changes to 29 for [[lookup
-      @labels.duration activity=2cOOq5vkw0u763Px]]. The potion has no effect on
-      you if your Strength is equal to or greater than that score.</p>
+      fingernail from a storm giant.</em></p><p>When you drink this potion, your
+      Strength score changes to 29 for [[lookup @labels.duration
+      activity=2cOOq5vkw0u763Px]]. The potion has no effect on you if your
+      Strength is equal to or greater than that score.</p>
     chat: ''
   source:
     custom: ''
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:
@@ -187,7 +187,7 @@ _stats:
   systemId: dnd5e
   systemVersion: 6.0.0
   createdTime: 1725037085351
-  modifiedTime: 1783372804970
+  modifiedTime: 1783646250895
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!1KMSpOSU0EliUBm2'

--- a/packs/_source/items/potion/potion-of-storm-giant-strength.yml
+++ b/packs/_source/items/potion/potion-of-storm-giant-strength.yml
@@ -49,7 +49,7 @@ system:
   unidentified:
     description: >-
       <p>This potion's transparent liquid has floating in it a sliver of
-      fingernail from a giant of the appropriate type.</p>
+      fingernail.</p>
     name: Unidentified Potion
   container: null
   properties:

--- a/packs/_source/items/potion/potion-of-superior-healing.yml
+++ b/packs/_source/items/potion/potion-of-superior-healing.yml
@@ -4,9 +4,9 @@ type: consumable
 img: icons/consumables/potions/bottle-round-corked-red.webp
 system:
   description:
-    value: |-
-      <p><em>The potion's red liquid glimmers when agitated.</em></p>
-      <p>You regain 8d4+8 hit points when you drink this potion.</p>
+    value: >-
+      <p><em>The potion's red liquid glimmers when agitated.</em></p><p>You
+      regain [[/healing]] when you drink this potion.</p>
     chat: ''
   source:
     custom: ''
@@ -49,14 +49,14 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: <p>The potion's red liquid glimmers when agitated.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    Kzhyy0MhTDsOwDWy:
       type: heal
       activation:
         type: action
@@ -68,16 +68,18 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
@@ -93,7 +95,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -114,12 +117,13 @@ system:
           mode: whole
           number: null
           formula: ''
+        modifiers: []
       uses:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -127,7 +131,11 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: Kzhyy0MhTDsOwDWy
   attuned: false
   identifier: potion-of-superior-healing
 effects: []
@@ -138,11 +146,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037101838
-  modifiedTime: 1764618987292
+  modifiedTime: 1783372670336
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!5m9ErO9In8Uc5yyf'

--- a/packs/_source/items/potion/potion-of-supreme-healing.yml
+++ b/packs/_source/items/potion/potion-of-supreme-healing.yml
@@ -4,9 +4,9 @@ type: consumable
 img: icons/consumables/potions/potion-flask-stopped-red.webp
 system:
   description:
-    value: |-
-      <p><em>The potion's red liquid glimmers when agitated.</em></p>
-      <p>You regain 10d4+20 hit points when you drink this potion.</p>
+    value: >-
+      <p><em>The potion's red liquid glimmers when agitated.</em></p><p>You
+      regain [[/healing]] when you drink this potion.</p>
     chat: ''
   source:
     custom: ''
@@ -49,14 +49,14 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: <p>The potion's red liquid glimmers when agitated.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    iM7JVSweoN2dwivd:
       type: heal
       activation:
         type: action
@@ -68,16 +68,18 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
@@ -93,7 +95,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -114,12 +117,13 @@ system:
           mode: whole
           number: null
           formula: ''
+        modifiers: []
       uses:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -127,7 +131,11 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: iM7JVSweoN2dwivd
   attuned: false
   identifier: potion-of-supreme-healing
 effects: []
@@ -138,11 +146,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037158925
-  modifiedTime: 1764619606067
+  modifiedTime: 1783372633133
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!JFiSlgcm3uSSBM5t'

--- a/packs/_source/items/potion/potion-of-thunder-resistance.yml
+++ b/packs/_source/items/potion/potion-of-thunder-resistance.yml
@@ -1,19 +1,18 @@
 _id: zBX8LLC2CjC89Dzl
 name: Potion of Thunder Resistance
 type: consumable
-img: icons/consumables/potions/bottle-round-corked-yellow.webp
+img: icons/consumables/potions/potion-vial-corked-purple.webp
 system:
   description:
     value: >-
       <p><em>The potion is a plain indescriminate color and smells slightly
-      foul.</em></p>
-
-      <p>When you drink this potion, you gain resistance to Thunder type damage
-      for 1 hour.</p>
-
-      <p>For other potions of resistance, roll on the
+      foul.</em></p><p>When you drink this potion, you gain resistance to
+      thunder damage for [[lookup @labels.duration
+      activity=sphH4mVrVY0W7Plg]].</p><section id="secret-Y18F2aGMVSA64GXJ"
+      class="secret"><p><strong>Foundry Note</strong></p><p>For other potions of
+      resistance, roll on the
       @UUID[Compendium.dnd5e.tables.RollTable.JzLOE4IxcmxjLLuz]{Potion of
-      Resistance} table.</p>
+      Resistance} table.</p></section>
     chat: ''
   source:
     custom: ''
@@ -51,14 +50,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>The potion is a plain indescriminate color and smells slightly
+      foul.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    sphH4mVrVY0W7Plg:
       type: utility
       activation:
         type: action
@@ -70,19 +71,23 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: QlQh25ywP4LsgKtg
+          level: {}
       range:
         units: touch
         special: ''
@@ -95,7 +100,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -112,8 +118,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -121,10 +127,54 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      flags: {}
+      _id: sphH4mVrVY0W7Plg
   attuned: false
   identifier: potion-of-thunder-resistance
-effects: []
+effects:
+  - name: Thunder Resistance
+    img: icons/magic/sonic/explosion-shock-wave-teal.webp
+    origin: Compendium.dnd5e.items.Item.zBX8LLC2CjC89Dzl
+    transfer: false
+    _id: QlQh25ywP4LsgKtg
+    type: base
+    system:
+      changes:
+        - key: system.traits.dr.value
+          type: add
+          value: thunder
+          phase: initial
+          priority: null
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You have resistance to thunder damage.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781977395377
+      modifiedTime: 1781979072809
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!zBX8LLC2CjC89Dzl.QlQh25ywP4LsgKtg'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -132,11 +182,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037329169
-  modifiedTime: 1764621440570
+  modifiedTime: 1783372225860
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!zBX8LLC2CjC89Dzl'

--- a/packs/_source/items/potion/potion-of-water-breathing.yml
+++ b/packs/_source/items/potion/potion-of-water-breathing.yml
@@ -1,16 +1,14 @@
 _id: CAZMwFBWp9VC0ZCg
 name: Potion of Water Breathing
 type: consumable
-img: icons/consumables/potions/potion-bottle-corked-labeled-green.webp
+img: icons/consumables/potions/potion-flask-corked-blue.webp
 system:
   description:
     value: >-
       <p><em>Its cloudy green fluid smells of the sea and has a jellyfish-like
-      bubble floating in it.</em></p>
-
-      <p>You can breathe underwater for 1 hour after drinking this potion. </p>
-
-      <p> </p>
+      bubble floating in it.</em></p><p>You can breathe underwater for [[lookup
+      @labels.duration activity=nAaV0R1Qxq5syAlT]] after drinking this
+      potion.</p>
     chat: ''
   source:
     custom: ''
@@ -48,14 +46,16 @@ system:
     value: potion
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>Its cloudy green fluid smells of the sea and has a jellyfish-like
+      bubble floating in it.</p>
+    name: Unidentified Potion
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    nAaV0R1Qxq5syAlT:
       type: utility
       activation:
         type: action
@@ -67,19 +67,25 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: '1'
         units: hour
         special: ''
         override: false
-      effects: []
+      effects:
+        - _id: YfuBxNfhlPfQX8Ua
+          level:
+            min: null
+            max: null
       range:
         units: touch
         special: ''
@@ -92,7 +98,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -109,8 +116,8 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Drink
       img: ''
       visibility:
         requireMagic: true
@@ -118,10 +125,49 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      flags: {}
+      _id: nAaV0R1Qxq5syAlT
   attuned: false
   identifier: potion-of-water-breathing
-effects: []
+effects:
+  - name: Alchemical Water Breathing
+    img: icons/magic/water/orb-ice-opaque.webp
+    origin: Compendium.dnd5e.items.Item.CAZMwFBWp9VC0ZCg
+    transfer: false
+    _id: YfuBxNfhlPfQX8Ua
+    type: base
+    system:
+      changes: []
+      magical: true
+      rider:
+        statuses: []
+    disabled: false
+    start: null
+    duration:
+      value: 1
+      units: hours
+      expiry: turnStart
+      expired: false
+    description: <p>You can breathe underwater for the duration.</p>
+    tint: '#ffffff'
+    statuses: []
+    showIcon: 1
+    folder: null
+    sort: 0
+    flags: {}
+    _stats:
+      coreVersion: '14.361'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1781977219022
+      modifiedTime: 1783376479980
+      lastModifiedBy: dnd5ebuilder0000
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+    _key: '!items.effects!CAZMwFBWp9VC0ZCg.YfuBxNfhlPfQX8Ua'
 folder: gyBZp72zKb56Da84
 sort: 0
 ownership:
@@ -129,11 +175,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037127300
-  modifiedTime: 1764619252967
+  modifiedTime: 1783372577648
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!CAZMwFBWp9VC0ZCg'

--- a/packs/_source/items/potion/restorative-ointment.yml
+++ b/packs/_source/items/potion/restorative-ointment.yml
@@ -5,16 +5,16 @@ img: icons/commodities/materials/liquid-orange.webp
 system:
   description:
     value: >-
-      <p><em>Wondrous item</em></p><p>This glass jar, 3 inches in diameter,
-      contains 1d4 + 1 doses of a thick mixture that smells faintly of aloe. The
-      jar and its contents weigh 1/2 pound.</p><p>As an action, one dose of the
-      ointment can be swallowed or applied to the skin. The creature that
-      receives it regains 2d8 + 2 hit points, ceases to be poisoned, and is
-      cured of any disease.</p><section class="secret foundry-note"
-      id="secret-hzyPBoWppRXYnf9A"><p><strong>Foundry Note</strong></p><p>The 5
-      charges reflect the maximum number of doses possible. Similarly, the guide
-      price of 600 gp is calculated at 120 gp per dose. Adjust both as
-      required.</p></section>
+      <p>This glass jar, 3 inches in diameter, contains 1d4 + 1 doses of a thick
+      mixture that smells faintly of aloe. The jar and its contents weigh 1/2
+      pound.</p><p>As an action, one dose of the ointment can be swallowed or
+      applied to the skin. The creature that receives it regains [[/healing
+      activity=gRkokZZM4WWwqjEu]], ceases to be &amp;reference[poisoned
+      apply=false], and is cured of any disease.</p><section
+      id="secret-hzyPBoWppRXYnf9A" class="secret
+      foundry-note"><p><strong>Foundry Note</strong></p><p>The 5 charges reflect
+      the maximum number of doses possible. Similarly, the guide price of 600 gp
+      is calculated at 120 gp per dose. Adjust both as required.</p></section>
     chat: ''
   source:
     custom: ''
@@ -54,17 +54,20 @@ system:
         formula: ''
     replace: false
   type:
-    value: potion
+    value: wondrous
     subtype: ''
   unidentified:
-    description: ''
+    description: >-
+      <p>This glass jar, 3 inches in diameter, contains 1d4 + 1 doses of a thick
+      mixture that smells faintly of aloe. The jar and its contents weigh 1/2
+      pound.</p>
+    name: Unidentified Mixture
   container: null
   properties:
     - mgc
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    gRkokZZM4WWwqjEu:
       type: heal
       activation:
         type: action
@@ -76,12 +79,18 @@ system:
           - type: itemUses
             value: '1'
             target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
         spellSlot: true
       description:
         chatFlavor: ''
+        value: >-
+          <p>As an action, one dose of the ointment can be swallowed or applied
+          to the skin. The creature that receives it regains [[/healing
+          activity=gRkokZZM4WWwqjEu]], ceases to be &amp;reference[poisoned
+          apply=false], and is cured of any disease.</p>
       duration:
         concentration: false
         value: ''
@@ -101,7 +110,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: '1'
           type: creature
@@ -122,12 +132,13 @@ system:
           mode: whole
           number: null
           formula: ''
+        modifiers: []
       uses:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
-      name: ''
+      sort: 100000
+      name: Apply Ointment
       img: ''
       visibility:
         requireMagic: true
@@ -135,7 +146,11 @@ system:
           min: null
           max: null
         identifier: ''
-      appliedEffects: []
+        requireAttunement: false
+        requireIdentification: false
+      behaviors: []
+      flags: {}
+      _id: gRkokZZM4WWwqjEu
   attuned: false
   identifier: restorative-ointment
 effects: []
@@ -146,11 +161,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.351'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 5.2.0
+  systemVersion: 6.0.0
   createdTime: 1725037202727
-  modifiedTime: 1764620092338
+  modifiedTime: 1783372539472
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!VmcgAIsRCyrjBguC'


### PR DESCRIPTION
Some updates to the `Potions` folder in the items compendium for the 5.1 SRD. Includes active effects and some few fixes to activation times. Also included unidentified descriptions and labels (Unidentified Potion / Oil, etc) to all of the items, based on the already existing descriptions in the potions themselves.

Related Issue #6731 