### PR TITLE
SRD 5.1 Update - Items (Food, Spellcasting Foci, Tools)

### DIFF
--- a/packs/_source/items/food/feed.yml
+++ b/packs/_source/items/food/feed.yml
@@ -1,6 +1,6 @@
 name: Feed
 type: consumable
-img: icons/consumables/grains/sack-rice-flour-brown.webp
+img: icons/containers/bags/sack-open-grain-tan.webp
 system:
   description:
     value: >-
@@ -59,11 +59,9 @@ system:
       consumption:
         targets:
           - type: itemUses
-            target: ''
             value: '1'
-            scaling:
-              mode: ''
-              formula: ''
+            target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
@@ -105,7 +103,15 @@ system:
       uses:
         spent: 0
         recovery: []
+        max: ''
       sort: 0
+      name: Eat
+      img: ''
+      visibility:
+        level:
+          min: null
+          max: null
+        identifier: ''
   attuned: false
   identifier: feed
 effects: []
@@ -117,11 +123,11 @@ flags: {}
 _id: KJuLguMZCThrQOEx
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037162367
-  modifiedTime: 1725992504656
+  modifiedTime: 1781985847570
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!KJuLguMZCThrQOEx'

--- a/packs/_source/items/food/rations.yml
+++ b/packs/_source/items/food/rations.yml
@@ -60,11 +60,9 @@ system:
       consumption:
         targets:
           - type: itemUses
-            target: ''
             value: '1'
-            scaling:
-              mode: ''
-              formula: ''
+            target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
@@ -106,7 +104,15 @@ system:
       uses:
         spent: 0
         recovery: []
+        max: ''
       sort: 0
+      name: Eat
+      img: ''
+      visibility:
+        level:
+          min: null
+          max: null
+        identifier: ''
   attuned: false
   identifier: rations
 effects: []
@@ -117,11 +123,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037245457
-  modifiedTime: 1725992532306
+  modifiedTime: 1781985905763
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!f4w4GxBi0nYXmhX4'

--- a/packs/_source/items/food/waterskin.yml
+++ b/packs/_source/items/food/waterskin.yml
@@ -1,7 +1,7 @@
 _id: Uv0ilmzbWvqmlCVH
 name: Waterskin
 type: consumable
-img: icons/sundries/survival/wetskin-leather-purple.webp
+img: icons/sundries/survival/wetskin-leather-red.webp
 system:
   description:
     value: >-
@@ -61,11 +61,9 @@ system:
       consumption:
         targets:
           - type: itemUses
-            target: ''
             value: '1'
-            scaling:
-              mode: ''
-              formula: ''
+            target: ''
+            scaling: {}
         scaling:
           allowed: false
           max: ''
@@ -107,7 +105,15 @@ system:
       uses:
         spent: 0
         recovery: []
+        max: ''
       sort: 0
+      name: Drink
+      img: ''
+      visibility:
+        level:
+          min: null
+          max: null
+        identifier: ''
   attuned: false
   identifier: waterskin
 effects: []
@@ -118,11 +124,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037199639
-  modifiedTime: 1725992517233
+  modifiedTime: 1781985926717
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Uv0ilmzbWvqmlCVH'

--- a/packs/_source/items/spellcasting-focus/crystal.yml
+++ b/packs/_source/items/spellcasting-focus/crystal.yml
@@ -1,7 +1,7 @@
 _id: uXOT4fYbgPY8DGdd
 name: Crystal
 type: equipment
-img: icons/commodities/gems/gem-faceted-large-green.webp
+img: icons/commodities/gems/gem-rough-drop-blue.webp
 system:
   description:
     value: >-
@@ -97,11 +97,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.1.0
   createdTime: 1725037313094
-  modifiedTime: 1730324874928
+  modifiedTime: 1783650015734
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!uXOT4fYbgPY8DGdd'

--- a/packs/_source/items/spellcasting-focus/rod.yml
+++ b/packs/_source/items/spellcasting-focus/rod.yml
@@ -1,7 +1,7 @@
 _id: OojyyGfh91iViuMF
 name: Rod
 type: equipment
-img: icons/weapons/staves/staff-blue-jewel.webp
+img: icons/weapons/staves/staff-obsidian.webp
 system:
   description:
     value: >-
@@ -101,11 +101,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.1.0
   createdTime: 1725037178199
-  modifiedTime: 1730324889641
+  modifiedTime: 1783649985314
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!OojyyGfh91iViuMF'

--- a/packs/_source/items/spellcasting-focus/sprig-of-mistletoe.yml
+++ b/packs/_source/items/spellcasting-focus/sprig-of-mistletoe.yml
@@ -1,7 +1,7 @@
 _id: xDK9GQd2iqOGH8Sd
 name: Sprig of Mistletoe
 type: equipment
-img: icons/consumables/plants/fern-lady-green.webp
+img: icons/consumables/fruit/huckleberry.webp
 system:
   description:
     value: >-
@@ -97,11 +97,11 @@ flags:
       effect: []
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
   systemVersion: 4.1.0
   createdTime: 1725037322071
-  modifiedTime: 1730324896046
+  modifiedTime: 1783649975374
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!xDK9GQd2iqOGH8Sd'

--- a/packs/_source/items/spellcasting-focus/staff.yml
+++ b/packs/_source/items/spellcasting-focus/staff.yml
@@ -87,8 +87,7 @@ system:
   crewed: false
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    0dfjzlgueZCUfAk8:
       type: attack
       activation:
         type: action
@@ -103,6 +102,7 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
@@ -123,7 +123,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -149,10 +150,17 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
+      sort: 100000
       name: ''
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      _id: 0dfjzlgueZCUfAk8
   attuned: false
   ammunition: {}
   identifier: staff
@@ -162,18 +170,14 @@ folder: xedn1r43VWuEBcli
 sort: 0
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 6.0.0
   createdTime: 1725037124380
-  modifiedTime: 1730324904161
+  modifiedTime: 1783649943098
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!BeKIrNIvNHRPQ4t5'

--- a/packs/_source/items/spellcasting-focus/wooden-staff.yml
+++ b/packs/_source/items/spellcasting-focus/wooden-staff.yml
@@ -87,8 +87,7 @@ system:
   crewed: false
   magicalBonus: null
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    TpF62yhnEbOxIpsJ:
       type: attack
       activation:
         type: action
@@ -103,6 +102,7 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
@@ -123,7 +123,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -149,10 +150,17 @@ system:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
+      sort: 100000
       name: ''
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      _id: TpF62yhnEbOxIpsJ
   attuned: false
   ammunition: {}
   identifier: wooden-staff
@@ -162,18 +170,14 @@ folder: xedn1r43VWuEBcli
 sort: 0
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.1.0
+  systemVersion: 6.0.0
   createdTime: 1725037141787
-  modifiedTime: 1730324925567
+  modifiedTime: 1783649911862
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!FF1ktpb2YSiyv896'

--- a/packs/_source/items/tool/alchemists-supplies.yml
+++ b/packs/_source/items/tool/alchemists-supplies.yml
@@ -1,7 +1,7 @@
 _id: SztwZhbhZeCqyAes
 name: Alchemist's Supplies
 type: tool
-img: icons/tools/cooking/mortar-herbs-yellow.webp
+img: icons/tools/laboratory/vials-blue-pink.webp
 system:
   description:
     value: >-
@@ -37,7 +37,14 @@ system:
     value: art
     baseItem: alchemist
   unidentified:
-    description: ''
+    description: >-
+      <p>These special tools include the items needed to pursue a craft or trade
+      in alchemy.</p>
+
+      <p>Proficiency with a set of artisan's tools lets you add your proficiency
+      bonus to any ability checks you make using the tools in your craft. Each
+      type of artisan's tools requires a separate proficiency.</p>
+    name: Unidentified Alchemist's Supplies
   container: null
   properties: []
   uses:
@@ -45,8 +52,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    JYiIYjfC4CdDixTE:
       type: check
       activation:
         type: ''
@@ -61,15 +67,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +87,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +98,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: JYiIYjfC4CdDixTE
+      name: Use Tools
   attuned: false
   identifier: alchemists-supplies
 effects: []
@@ -105,11 +132,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037192417
-  modifiedTime: 1725992514876
+  modifiedTime: 1783649817578
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!SztwZhbhZeCqyAes'

--- a/packs/_source/items/tool/bagpipes.yml
+++ b/packs/_source/items/tool/bagpipes.yml
@@ -46,8 +46,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    CW68axGLrRC2ZfAB:
       type: check
       activation:
         type: ''
@@ -62,15 +61,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -81,7 +81,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -91,11 +92,30 @@ system:
         override: false
       check:
         ability: cha
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: CW68axGLrRC2ZfAB
+      name: Use Tools
   attuned: false
   identifier: bagpipes
 effects: []
@@ -106,11 +126,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037327849
-  modifiedTime: 1725992560567
+  modifiedTime: 1783650777847
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!yxHi57T5mmVt0oDr'

--- a/packs/_source/items/tool/brewers-supplies.yml
+++ b/packs/_source/items/tool/brewers-supplies.yml
@@ -1,7 +1,7 @@
 _id: Y9S75go1hLMXUD48
 name: Brewer's Supplies
 type: tool
-img: icons/consumables/plants/herb-marjoram-basil-oregano-leaf-bunch-green.webp
+img: icons/consumables/drinks/wine-amphora-clay-blue.webp
 system:
   description:
     value: >-
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    J4Qbtpw2LBM5xjRS:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: wis
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: J4Qbtpw2LBM5xjRS
+      name: Use Tools
   attuned: false
   identifier: brewers-supplies
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037212822
-  modifiedTime: 1725992521609
+  modifiedTime: 1783649737998
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Y9S75go1hLMXUD48'

--- a/packs/_source/items/tool/calligraphers-supplies.yml
+++ b/packs/_source/items/tool/calligraphers-supplies.yml
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    uATnLErfx7VysRTo:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: uATnLErfx7VysRTo
+      name: Use Tools
   attuned: false
   identifier: calligraphers-supplies
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037265832
-  modifiedTime: 1725992539160
+  modifiedTime: 1783649715267
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!jhjo20QoiD5exf09'

--- a/packs/_source/items/tool/carpenters-tools.yml
+++ b/packs/_source/items/tool/carpenters-tools.yml
@@ -1,7 +1,7 @@
 _id: 8NS6MSOdXtUqD7Ib
 name: Carpenter's Tools
 type: tool
-img: icons/tools/hand/saw-steel-grey.webp
+img: icons/tools/hand/saw-steel.webp
 system:
   description:
     value: >-
@@ -37,7 +37,14 @@ system:
     value: art
     baseItem: carpenter
   unidentified:
-    description: ''
+    description: >-
+      <p>These special tools include the items needed to pursue a craft or trade
+      in carpentry.</p>
+
+      <p>Proficiency with a set of artisan's tools lets you add your proficiency
+      bonus to any ability checks you make using the tools in your craft. Each
+      type of artisan's tools requires a separate proficiency.</p>
+    name: Unidentified Carpenter's Tools
   container: null
   properties: []
   uses:
@@ -45,8 +52,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    5gV1FklPzCP5ncIc:
       type: check
       activation:
         type: ''
@@ -61,15 +67,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +87,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +98,30 @@ system:
         override: false
       check:
         ability: str
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: 5gV1FklPzCP5ncIc
+      name: Use Tools
   attuned: false
   identifier: carpenters-tools
 effects: []
@@ -105,11 +132,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037113832
-  modifiedTime: 1725992488456
+  modifiedTime: 1783649820057
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!8NS6MSOdXtUqD7Ib'

--- a/packs/_source/items/tool/cartographers-tools.yml
+++ b/packs/_source/items/tool/cartographers-tools.yml
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    Odlfa7aHWethWRuO:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: Odlfa7aHWethWRuO
+      name: Use Tools
   attuned: false
   identifier: cartographers-tools
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037246077
-  modifiedTime: 1725992532487
+  modifiedTime: 1783649685580
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!fC0lFK8P4RuhpfaU'

--- a/packs/_source/items/tool/chess-set.yml
+++ b/packs/_source/items/tool/chess-set.yml
@@ -35,9 +35,10 @@ system:
   bonus: ''
   type:
     value: game
-    baseItem: ''
+    baseItem: chess
   unidentified:
     description: ''
+    name: Unidentified Chess Set
   container: null
   properties: []
   uses:
@@ -45,8 +46,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    RUUCcFGTvTV9vhrS:
       type: check
       activation:
         type: ''
@@ -61,15 +61,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +81,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +92,30 @@ system:
         override: false
       check:
         ability: dex
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: RUUCcFGTvTV9vhrS
+      name: Play Game
   attuned: false
   identifier: chess-set
 effects: []
@@ -105,11 +126,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037087406
-  modifiedTime: 1725992479578
+  modifiedTime: 1783649832856
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!23y8FvWKf9YLcnBL'

--- a/packs/_source/items/tool/cobblers-tools.yml
+++ b/packs/_source/items/tool/cobblers-tools.yml
@@ -37,7 +37,14 @@ system:
     value: art
     baseItem: cobbler
   unidentified:
-    description: ''
+    description: >-
+      <p>These special tools include the items needed to pursue a craft or trade
+      in cobblery.</p>
+
+      <p>Proficiency with a set of artisan's tools lets you add your proficiency
+      bonus to any ability checks you make using the tools in your craft. Each
+      type of artisan's tools requires a separate proficiency.</p>
+    name: Unidentified Cobbler's Tools
   container: null
   properties: []
   uses:
@@ -45,8 +52,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    ahpYun8CZThsQxIt:
       type: check
       activation:
         type: ''
@@ -61,15 +67,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +87,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +98,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: ahpYun8CZThsQxIt
+      name: Use Tools
   attuned: false
   identifier: cobblers-tools
 effects: []
@@ -105,11 +132,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037256194
-  modifiedTime: 1725992535858
+  modifiedTime: 1783649822785
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!hM84pZnpCqKfi8XH'

--- a/packs/_source/items/tool/cooks-utensils.yml
+++ b/packs/_source/items/tool/cooks-utensils.yml
@@ -1,7 +1,7 @@
 _id: Gflnp29aEv5Lc1ZM
 name: Cook's Utensils
 type: tool
-img: icons/tools/laboratory/bowl-mixing.webp
+img: icons/tools/laboratory/cauldron-empty-black.webp
 system:
   description:
     value: >-
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    CmH1aq9qxYEhVGQm:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: wis
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: CmH1aq9qxYEhVGQm
+      name: Use Tools
   attuned: false
   identifier: cooks-utensils
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037148068
-  modifiedTime: 1725992499881
+  modifiedTime: 1783649649381
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!Gflnp29aEv5Lc1ZM'

--- a/packs/_source/items/tool/dice-set.yml
+++ b/packs/_source/items/tool/dice-set.yml
@@ -35,9 +35,16 @@ system:
   bonus: ''
   type:
     value: game
-    baseItem: ''
+    baseItem: dice
   unidentified:
-    description: ''
+    description: >-
+      <p>This item encompasses a wide range of dice, both straight and
+      weighted.</p>
+
+      <p>If you are proficient with a gaming set, you can add your proficiency
+      bonus to ability checks you make to play a game with that set. Each type
+      of gaming set requires a separate proficiency.</p>
+    name: Unidentified Dice Set
   container: null
   properties: []
   uses:
@@ -45,8 +52,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    FK4JIMNtS0jqH4oH:
       type: check
       activation:
         type: ''
@@ -61,15 +67,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +87,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +98,30 @@ system:
         override: false
       check:
         ability: dex
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        bonus: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      name: Play Game
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        identifier: ''
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      _id: FK4JIMNtS0jqH4oH
   attuned: false
   identifier: dice-set
 effects: []
@@ -105,11 +132,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037260161
-  modifiedTime: 1725992537217
+  modifiedTime: 1783649841179
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!iBuTM09KD9IoM5L8'

--- a/packs/_source/items/tool/disguise-kit.yml
+++ b/packs/_source/items/tool/disguise-kit.yml
@@ -43,8 +43,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    Nlty9899StQrmrDj:
       type: check
       activation:
         type: ''
@@ -59,15 +58,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -78,7 +78,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -88,11 +89,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: Nlty9899StQrmrDj
+      name: Use Tools
   attuned: false
   identifier: disguise-kit
 effects: []
@@ -103,11 +123,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037154887
-  modifiedTime: 1725992502178
+  modifiedTime: 1783649603816
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!IBhDAr7WkhWPYLVn'

--- a/packs/_source/items/tool/drum.yml
+++ b/packs/_source/items/tool/drum.yml
@@ -47,8 +47,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    uUV9Ua7ZnGoBQIMR:
       type: check
       activation:
         type: ''
@@ -63,15 +62,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -82,7 +82,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -92,11 +93,30 @@ system:
         override: false
       check:
         ability: cha
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: uUV9Ua7ZnGoBQIMR
+      name: Play Instrument
   attuned: false
   identifier: drum
 effects: []
@@ -107,11 +127,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037103926
-  modifiedTime: 1725992485225
+  modifiedTime: 1783649588560
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!69Dpr25pf4BjkHKb'

--- a/packs/_source/items/tool/dulcimer.yml
+++ b/packs/_source/items/tool/dulcimer.yml
@@ -46,8 +46,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    132H1oQX1HVA4QXj:
       type: check
       activation:
         type: ''
@@ -62,15 +61,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -81,7 +81,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -91,11 +92,30 @@ system:
         override: false
       check:
         ability: cha
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: 132H1oQX1HVA4QXj
+      name: Play Instrument
   attuned: false
   identifier: dulcimer
 effects: []
@@ -106,11 +126,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037175952
-  modifiedTime: 1725992509221
+  modifiedTime: 1783649564925
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!NtdDkjmpdIMiX7I2'

--- a/packs/_source/items/tool/flute.yml
+++ b/packs/_source/items/tool/flute.yml
@@ -5,7 +5,7 @@ img: icons/tools/instruments/pipe-flue-tan.webp
 system:
   description:
     value: >-
-      <p>A flue to evoke awe, wonder, or fear in your audience.</p><p>If you
+      <p>A flute to evoke awe, wonder, or fear in your audience.</p><p>If you
       have proficiency with a given musical instrument, you can add your
       proficiency bonus to any ability checks you make to play music with the
       instrument. A bard can use a musical instrument as a spellcasting focus.

--- a/packs/_source/items/tool/flute.yml
+++ b/packs/_source/items/tool/flute.yml
@@ -1,17 +1,15 @@
 _id: eJOrPcAz9EcquyRQ
 name: Flute
 type: tool
-img: icons/tools/instruments/flute-simple-wood.webp
+img: icons/tools/instruments/pipe-flue-tan.webp
 system:
   description:
     value: >-
-      <p>A lute to evoke awe, wonder, or fear in your audience.</p>
-
-      <p>If you have proficiency with a given musical instrument, you can add
-      your proficiency bonus to any ability checks you make to play music with
-      the instrument. A bard can use a musical instrument as a spellcasting
-      focus. Each type of musical instrument requires a separate proficiency.
-      </p>
+      <p>A flue to evoke awe, wonder, or fear in your audience.</p><p>If you
+      have proficiency with a given musical instrument, you can add your
+      proficiency bonus to any ability checks you make to play music with the
+      instrument. A bard can use a musical instrument as a spellcasting focus.
+      Each type of musical instrument requires a separate proficiency.</p>
     chat: ''
   source:
     custom: ''
@@ -46,8 +44,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    RrveHjfKJ3pi07f6:
       type: check
       activation:
         type: ''
@@ -62,15 +59,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -81,7 +79,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -91,11 +90,30 @@ system:
         override: false
       check:
         ability: cha
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: RrveHjfKJ3pi07f6
+      name: Play Instrument
   attuned: false
   identifier: flute
 effects: []
@@ -106,11 +124,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037238851
-  modifiedTime: 1725992530212
+  modifiedTime: 1783649554110
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!eJOrPcAz9EcquyRQ'

--- a/packs/_source/items/tool/forgery-kit.yml
+++ b/packs/_source/items/tool/forgery-kit.yml
@@ -1,7 +1,7 @@
 _id: cG3m4YlHfbQlLEOx
 name: Forgery Kit
 type: tool
-img: icons/sundries/documents/envelope-sealed-red-tan.webp
+img: icons/sundries/documents/document-sealed-brown-red.webp
 system:
   description:
     value: >-
@@ -44,8 +44,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    HXyffPwsC3sQPvbA:
       type: check
       activation:
         type: ''
@@ -60,15 +59,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -79,7 +79,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -89,11 +90,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: HXyffPwsC3sQPvbA
+      name: Use Tools
   attuned: false
   identifier: forgery-kit
 effects: []
@@ -104,11 +124,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037229779
-  modifiedTime: 1725992527220
+  modifiedTime: 1783649531177
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!cG3m4YlHfbQlLEOx'

--- a/packs/_source/items/tool/glassblowers-tools.yml
+++ b/packs/_source/items/tool/glassblowers-tools.yml
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    exr1ggiri2k6TK2n:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: exr1ggiri2k6TK2n
+      name: Use Tools
   attuned: false
   identifier: glassblowers-tools
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037299107
-  modifiedTime: 1725992550672
+  modifiedTime: 1783649510374
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!rTbVrNcwApnuTz5E'

--- a/packs/_source/items/tool/herbalism-kit.yml
+++ b/packs/_source/items/tool/herbalism-kit.yml
@@ -44,8 +44,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    XAe0ixGVdi0wcX5W:
       type: check
       activation:
         type: ''
@@ -60,15 +59,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -79,7 +79,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -89,11 +90,30 @@ system:
         override: false
       check:
         ability: wis
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: XAe0ixGVdi0wcX5W
+      name: Use Tools
   attuned: false
   identifier: herbalism-kit
 effects: []
@@ -104,11 +124,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037259581
-  modifiedTime: 1725992537016
+  modifiedTime: 1783649494682
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!i89okN7GFTWHsvPy'

--- a/packs/_source/items/tool/horn.yml
+++ b/packs/_source/items/tool/horn.yml
@@ -1,7 +1,7 @@
 _id: aa9KuBy4dst7WIW9
 name: Horn
 type: tool
-img: icons/tools/instruments/flute-simple-wood.webp
+img: icons/commodities/bones/horn-drinking-white.webp
 system:
   description:
     value: >-
@@ -47,8 +47,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    cpidFXT3UOwBjj1s:
       type: check
       activation:
         type: ''
@@ -63,15 +62,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -82,7 +82,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -92,11 +93,30 @@ system:
         override: false
       check:
         ability: cha
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: cpidFXT3UOwBjj1s
+      name: Play Instrument
   attuned: false
   identifier: horn
 effects: []
@@ -107,11 +127,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037223497
-  modifiedTime: 1725992525246
+  modifiedTime: 1783649484092
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!aa9KuBy4dst7WIW9'

--- a/packs/_source/items/tool/jewelers-tools.yml
+++ b/packs/_source/items/tool/jewelers-tools.yml
@@ -1,7 +1,7 @@
 _id: YfBwELTgPFHmQdHh
 name: Jeweler's Tools
 type: tool
-img: icons/commodities/gems/gem-rough-rose-teal.webp
+img: icons/commodities/gems/gem-fragments-teal.webp
 system:
   description:
     value: >-
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    l229ovh2WHvudt9C:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: l229ovh2WHvudt9C
+      name: Use Tools
   attuned: false
   identifier: jewelers-tools
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037215349
-  modifiedTime: 1725992522470
+  modifiedTime: 1783649454627
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!YfBwELTgPFHmQdHh'

--- a/packs/_source/items/tool/leatherworkers-tools.yml
+++ b/packs/_source/items/tool/leatherworkers-tools.yml
@@ -1,7 +1,7 @@
 _id: PUMfwyVUbtyxgYbD
 name: Leatherworker's Tools
 type: tool
-img: icons/commodities/leather/leather-buckle-steel-tan.webp
+img: icons/weapons/daggers/dagger-black.webp
 system:
   description:
     value: >-
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    HhVaM3LZOlx8GlMg:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: HhVaM3LZOlx8GlMg
+      name: Use Tools
   attuned: false
   identifier: leatherworkers-tools
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037181619
-  modifiedTime: 1725992511209
+  modifiedTime: 1783649421397
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!PUMfwyVUbtyxgYbD'

--- a/packs/_source/items/tool/lute.yml
+++ b/packs/_source/items/tool/lute.yml
@@ -46,8 +46,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    toK4Hq0S99Pl17Qg:
       type: check
       activation:
         type: ''
@@ -62,15 +61,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -81,7 +81,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -91,11 +92,30 @@ system:
         override: false
       check:
         ability: cha
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: toK4Hq0S99Pl17Qg
+      name: Play Instrument
   attuned: false
   identifier: lute
 effects: []
@@ -106,11 +126,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037292586
-  modifiedTime: 1725992548449
+  modifiedTime: 1783649335412
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!qBydtUUIkv520DT7'

--- a/packs/_source/items/tool/lyre.yml
+++ b/packs/_source/items/tool/lyre.yml
@@ -46,8 +46,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    D9aVwHAVOXxcX4xc:
       type: check
       activation:
         type: ''
@@ -62,15 +61,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -81,7 +81,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -91,11 +92,30 @@ system:
         override: false
       check:
         ability: cha
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: D9aVwHAVOXxcX4xc
+      name: Play Instrument
   attuned: false
   identifier: lyre
 effects: []
@@ -106,11 +126,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037139486
-  modifiedTime: 1725992496952
+  modifiedTime: 1783649324686
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!EwG1EtmbgR3bM68U'

--- a/packs/_source/items/tool/masons-tools.yml
+++ b/packs/_source/items/tool/masons-tools.yml
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    lyuMF4r1X67Ig9mJ:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: wis
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: lyuMF4r1X67Ig9mJ
+      name: Use Tools
   attuned: false
   identifier: masons-tools
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037303739
-  modifiedTime: 1725992552231
+  modifiedTime: 1783649296168
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!skUih6tBvcBbORzA'

--- a/packs/_source/items/tool/navigators-tools.yml
+++ b/packs/_source/items/tool/navigators-tools.yml
@@ -43,8 +43,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    yMZFTw27wRMLGAb2:
       type: check
       activation:
         type: ''
@@ -59,15 +58,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -78,7 +78,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -88,11 +89,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: yMZFTw27wRMLGAb2
+      name: Use Tools
   attuned: false
   identifier: navigators-tools
 effects: []
@@ -103,11 +123,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037213654
-  modifiedTime: 1725992521909
+  modifiedTime: 1783649280306
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!YHCmjsiXxZ9UdUhU'

--- a/packs/_source/items/tool/painters-supplies.yml
+++ b/packs/_source/items/tool/painters-supplies.yml
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    6Z0LKBeC6ip7SmXM:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: 6Z0LKBeC6ip7SmXM
+      name: Use Tools
   attuned: false
   identifier: painters-supplies
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037231482
-  modifiedTime: 1725992527819
+  modifiedTime: 1783649269432
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!ccm5xlWhx74d6lsK'

--- a/packs/_source/items/tool/pan-flute.yml
+++ b/packs/_source/items/tool/pan-flute.yml
@@ -46,8 +46,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    6ZbfAFY3D4yMNbO9:
       type: check
       activation:
         type: ''
@@ -62,15 +61,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -81,7 +81,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -91,11 +92,30 @@ system:
         override: false
       check:
         ability: cha
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: 6ZbfAFY3D4yMNbO9
+      name: Play Instrument
   attuned: false
   identifier: pan-flute
 effects: []
@@ -106,11 +126,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037146074
-  modifiedTime: 1725992499211
+  modifiedTime: 1783649257084
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!G5m5gYIx9VAUWC3J'

--- a/packs/_source/items/tool/playing-cards-set.yml
+++ b/packs/_source/items/tool/playing-cards-set.yml
@@ -35,9 +35,16 @@ system:
   bonus: ''
   type:
     value: game
-    baseItem: ''
+    baseItem: card
   unidentified:
-    description: ''
+    description: >-
+      <p>This item encompasses a wide range of playing card types, both unmarked
+      and marked.</p>
+
+      <p>If you are proficient with a gaming set, you can add your proficiency
+      bonus to ability checks you make to play a game with that set. Each type
+      of gaming set requires a separate proficiency.</p>
+    name: Unidentified Playing Cards Set
   container: null
   properties: []
   uses:
@@ -45,8 +52,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    HkDgcxCvNAnHH6Qx:
       type: check
       activation:
         type: ''
@@ -61,15 +67,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +87,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +98,30 @@ system:
         override: false
       check:
         ability: dex
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        bonus: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      name: Play Game
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        identifier: ''
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      _id: HkDgcxCvNAnHH6Qx
   attuned: false
   identifier: playing-cards-set
 effects: []
@@ -105,11 +132,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037216493
-  modifiedTime: 1725992522855
+  modifiedTime: 1783649850256
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!YwlHI3BVJapz4a3E'

--- a/packs/_source/items/tool/poisoners-kit.yml
+++ b/packs/_source/items/tool/poisoners-kit.yml
@@ -1,7 +1,7 @@
 _id: il2GNi8C0DvGLL9P
 name: Poisoner's Kit
 type: tool
-img: icons/containers/bags/pouch-gold-green.webp
+img: icons/containers/bags/sack-cloth-green-blue.webp
 system:
   description:
     value: >-
@@ -43,8 +43,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    J2duMPFbmDXPnYr9:
       type: check
       activation:
         type: ''
@@ -59,15 +58,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -78,7 +78,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -88,11 +89,30 @@ system:
         override: false
       check:
         ability: wis
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: J2duMPFbmDXPnYr9
+      name: Use Tools
   attuned: false
   identifier: poisoners-kit
 effects: []
@@ -103,11 +123,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037262700
-  modifiedTime: 1725992538099
+  modifiedTime: 1783649220819
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!il2GNi8C0DvGLL9P'

--- a/packs/_source/items/tool/potters-tools.yml
+++ b/packs/_source/items/tool/potters-tools.yml
@@ -1,7 +1,7 @@
 _id: hJS8yEVkqgJjwfWa
 name: Potter's Tools
 type: tool
-img: icons/containers/kitchenware/vase-bottle-brown.webp
+img: icons/containers/kitchenware/vase-clay-brown-large.webp
 system:
   description:
     value: >-
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    6nOvQftuoR1MGR7H:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: 6nOvQftuoR1MGR7H
+      name: Use Tools
   attuned: false
   identifier: potters-tools
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037255933
-  modifiedTime: 1725992535763
+  modifiedTime: 1783649172179
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!hJS8yEVkqgJjwfWa'

--- a/packs/_source/items/tool/shawm.yml
+++ b/packs/_source/items/tool/shawm.yml
@@ -38,7 +38,15 @@ system:
     value: music
     baseItem: shawm
   unidentified:
-    description: ''
+    description: >-
+      <p>A shawm to evoke awe, wonder, or fear in your audience.</p>
+
+      <p>If you have proficiency with a given musical instrument, you can add
+      your proficiency bonus to any ability checks you make to play music with
+      the instrument. A bard can use a musical instrument as a spellcasting
+      focus. Each type of musical instrument requires a separate proficiency.
+      </p>
+    name: Unidentified Shawm
   container: null
   properties: []
   uses:
@@ -46,8 +54,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    Hec3imxYjD3meH3G:
       type: check
       activation:
         type: ''
@@ -62,15 +69,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -81,7 +89,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -91,11 +100,30 @@ system:
         override: false
       check:
         ability: cha
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: Hec3imxYjD3meH3G
+      name: Play Instrument
   attuned: false
   identifier: shawm
 effects: []
@@ -106,11 +134,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037145765
-  modifiedTime: 1725992499120
+  modifiedTime: 1783649861879
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!G3cqbejJpfB91VhP'

--- a/packs/_source/items/tool/smiths-tools.yml
+++ b/packs/_source/items/tool/smiths-tools.yml
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    sUFM0XDYznvSxnFL:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: str
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: sUFM0XDYznvSxnFL
+      name: Use Tools
   attuned: false
   identifier: smiths-tools
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037163210
-  modifiedTime: 1725992504921
+  modifiedTime: 1783649136024
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!KndVe2insuctjIaj'

--- a/packs/_source/items/tool/thieves-tools.yml
+++ b/packs/_source/items/tool/thieves-tools.yml
@@ -43,8 +43,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    MXNHvMD2eYzzZmqy:
       type: check
       activation:
         type: ''
@@ -59,15 +58,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -78,7 +78,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -88,11 +89,30 @@ system:
         override: false
       check:
         ability: dex
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: MXNHvMD2eYzzZmqy
+      name: Use Tools
   attuned: false
   identifier: thieves-tools
 effects: []
@@ -103,11 +123,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037319908
-  modifiedTime: 1725992557712
+  modifiedTime: 1783649126284
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!woWZ1sO5IUVGzo58'

--- a/packs/_source/items/tool/tinkers-tools.yml
+++ b/packs/_source/items/tool/tinkers-tools.yml
@@ -1,7 +1,7 @@
 _id: 0d08g1i5WXnNrCNA
 name: Tinker's Tools
 type: tool
-img: icons/commodities/cloth/thread-spindle-white-needle.webp
+img: icons/tools/hand/wrench-steel.webp
 system:
   description:
     value: >-
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    rDLozXyUAOLfBvpZ:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: int
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: rDLozXyUAOLfBvpZ
+      name: Use Tools
   attuned: false
   identifier: tinkers-tools
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037083086
-  modifiedTime: 1725992478101
+  modifiedTime: 1783649116695
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!0d08g1i5WXnNrCNA'

--- a/packs/_source/items/tool/viol.yml
+++ b/packs/_source/items/tool/viol.yml
@@ -46,8 +46,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    THqapQUI2zxqzPO1:
       type: check
       activation:
         type: ''
@@ -62,15 +61,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -81,7 +81,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -91,11 +92,30 @@ system:
         override: false
       check:
         ability: cha
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        bonus: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      name: Play Instrument
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        identifier: ''
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      _id: THqapQUI2zxqzPO1
   attuned: false
   identifier: viol
 effects: []
@@ -106,11 +126,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037228112
-  modifiedTime: 1725992526673
+  modifiedTime: 1783649073840
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!baoe3U5BfMMMxhCU'

--- a/packs/_source/items/tool/weavers-tools.yml
+++ b/packs/_source/items/tool/weavers-tools.yml
@@ -1,7 +1,7 @@
 _id: ap9prThUB2y9lDyj
 name: Weaver's Tools
 type: tool
-img: icons/equipment/back/cloak-hooded-pink.webp
+img: icons/commodities/cloth/cloth-bolt-light-green.webp
 system:
   description:
     value: >-
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    Z4SNCzh2o9aNeqwc:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: dex
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: Z4SNCzh2o9aNeqwc
+      name: Use Tools
   attuned: false
   identifier: weavers-tools
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037224738
-  modifiedTime: 1725992525621
+  modifiedTime: 1783649054451
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!ap9prThUB2y9lDyj'

--- a/packs/_source/items/tool/woodcarvers-tools.yml
+++ b/packs/_source/items/tool/woodcarvers-tools.yml
@@ -45,8 +45,7 @@ system:
     recovery: []
     spent: 0
   activities:
-    dnd5eactivity000:
-      _id: dnd5eactivity000
+    xNL9m40hwk0Wno8W:
       type: check
       activation:
         type: ''
@@ -61,15 +60,16 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         concentration: false
         value: ''
-        units: ''
+        units: inst
         special: ''
         override: false
       effects: []
       range:
-        units: ''
+        units: self
         special: ''
         override: false
       target:
@@ -80,7 +80,8 @@ system:
           size: ''
           width: ''
           height: ''
-          units: ''
+          units: ft
+          stationary: false
         affects:
           count: ''
           type: ''
@@ -90,11 +91,30 @@ system:
         override: false
       check:
         ability: dex
-        dc: {}
+        dc:
+          calculation: ''
+          formula: ''
+        associated: []
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
-      sort: 0
+        max: ''
+      sort: 100000
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+        identifier: ''
+      _id: xNL9m40hwk0Wno8W
+      name: Use Tools
   attuned: false
   identifier: woodcarvers-tools
 effects: []
@@ -105,11 +125,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.361'
   systemId: dnd5e
-  systemVersion: 4.0.0
+  systemVersion: 6.0.0
   createdTime: 1725037322637
-  modifiedTime: 1725992558750
+  modifiedTime: 1783649015750
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!xKErqkLo4ASYr5EP'


### PR DESCRIPTION
Some small updates (mainly icon and activity name) to the food, tools, and spellcasting foci in the 5.1 SRD. The Playing Card Set, Dice Set, and Chess Set were not set as their tool-types (not sure if that changes anything with how the tools function, but they're set now).

Related Issue #6731