### PR TITLE
[#6315] Add rule bonuses to damage rolls

### DIFF
--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -284,44 +284,41 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
   /** @override */
   getDamageConfig(config={}, options={}) {
-    const rollConfig = super.getDamageConfig(config, options);
-
-    // Handle ammunition
+    // Copy properties from selected ammunition
     const ammo = config.ammunition?.system;
     if ( ammo ) {
       const properties = Array.from(ammo.properties).filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical);
       if ( this.item.system.properties?.has("mgc") && !properties.includes("mgc") ) properties.push("mgc");
+      config.properties ??= [];
+      for ( const property of properties ) {
+        if ( !config.properties.includes(property) ) config.properties.push(property);
+      }
+    }
 
-      // Add any new physical properties from the ammunition to the damage properties
-      for ( const roll of rollConfig.rolls ) {
-        for ( const property of properties ) {
-          if ( !roll.options.properties.includes(property) ) roll.options.properties.push(property);
-        }
+    options.rollData ??= this.getRollData({ roll: { attackMode: config.attackMode } });
+    const rollConfig = super.getDamageConfig(config, options);
+
+    // Add the ammunition's damage
+    if ( ammo?.damage.base.formula ) {
+      const basePartIndex = rollConfig.rolls.findIndex(i => i.base);
+      const damage = ammo.damage.base.clone(ammo.damage.base);
+
+      // If mode is "replace" and base part is present, replace the base part
+      if ( ammo.damage.replace & (basePartIndex !== -1) ) {
+        damage.base = true;
+        rollConfig.rolls.splice(
+          basePartIndex, 1,
+          this._processDamagePart(damage, config, options.rollData, basePartIndex, options.formulaOptions)
+        );
       }
 
-      // Add the ammunition's damage
-      if ( ammo.damage.base.formula ) {
-        const basePartIndex = rollConfig.rolls.findIndex(i => i.base);
-        const damage = ammo.damage.base.clone(ammo.damage.base);
-        const rollData = this.getRollData();
-
-        // If mode is "replace" and base part is present, replace the base part
-        if ( ammo.damage.replace & (basePartIndex !== -1) ) {
-          damage.base = true;
-          rollConfig.rolls.splice(
-            basePartIndex, 1,
-            this._processDamagePart(damage, config, rollData, basePartIndex, options.formulaOptions)
-          );
-        }
-
-        // Otherwise stick the ammo damage after base part (or as first part)
-        else {
-          damage.ammo = true;
-          rollConfig.rolls.splice(
-            basePartIndex + 1, 0,
-            this._processDamagePart(damage, rollConfig, rollData, basePartIndex + 1, options.formulaOptions)
-          );
-        }
+      // Otherwise stick the ammo damage after base part (or as first part)
+      else {
+        damage.ammo = true;
+        rollConfig.rolls.splice(
+          basePartIndex + 1, 0,
+          this._processDamagePart(damage, rollConfig, options.rollData, basePartIndex + 1, options.formulaOptions)
+        );
       }
     }
 
@@ -378,7 +375,8 @@ export default class BaseAttackActivityData extends BaseActivityData {
       rollData.roll.attack ??= {};
       rollData.roll.attack.classification = this.attack.type.classification;
       rollData.roll.attack.mode = options.roll.attackMode;
-      rollData.roll.attack.type = rollData.roll.attack.mode?.includes("thrown") ? "ranged" : this.attack.type.value;
+      rollData.roll.attack.type = options.roll.attackMode?.includes("thrown") || (options.roll.attackMode === "ranged")
+        ? "ranged" : this.attack.type.value;
       rollData.roll.type = "attack";
     }
     return rollData;

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -298,35 +298,37 @@ export default class BaseAttackActivityData extends BaseActivityData {
     options.rollData ??= this.getRollData({ roll: { attackMode: config.attackMode } });
     const rollConfig = super.getDamageConfig(config, options);
 
-    // Add the ammunition's damage
-    if ( ammo?.damage.base.formula ) {
-      const basePartIndex = rollConfig.rolls.findIndex(i => i.base);
-      const damage = ammo.damage.base.clone(ammo.damage.base);
-
-      // If mode is "replace" and base part is present, replace the base part
-      if ( ammo.damage.replace & (basePartIndex !== -1) ) {
-        damage.base = true;
-        rollConfig.rolls.splice(
-          basePartIndex, 1,
-          this._processDamagePart(damage, config, options.rollData, basePartIndex, options.formulaOptions)
-        );
-      }
-
-      // Otherwise stick the ammo damage after base part (or as first part)
-      else {
-        damage.ammo = true;
-        rollConfig.rolls.splice(
-          basePartIndex + 1, 0,
-          this._processDamagePart(damage, rollConfig, options.rollData, basePartIndex + 1, options.formulaOptions)
-        );
-      }
-    }
-
     if ( this.damage.critical.bonus && rollConfig.rolls[0] && !rollConfig.rolls[0].options?.critical?.bonusDamage ) {
       foundry.utils.setProperty(rollConfig.rolls[0], "options.critical.bonusDamage", this.damage.critical.bonus);
     }
 
     return rollConfig;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _getDamageParts(config={}) {
+    const ammo = config.ammunition?.system;
+    const parts = super._getDamageParts(config);
+    if ( !ammo?.damage.base.formula ) return parts;
+
+    const basePartIndex = parts.findIndex(i => i.base);
+    const damage = ammo.damage.base.clone(ammo.damage.base);
+
+    // If mode is "replace" and base part is present, replace the base part
+    if ( ammo.damage.replace & (basePartIndex !== -1) ) {
+      damage.base = true;
+      parts.splice(basePartIndex, 1, damage);
+    }
+
+    // Otherwise stick the ammo damage after base part (or as first part)
+    else {
+      damage.ammo = true;
+      parts.splice(basePartIndex + 1, 0, damage);
+    }
+
+    return parts;
   }
 
   /* -------------------------------------------- */

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -295,7 +295,6 @@ export default class BaseAttackActivityData extends BaseActivityData {
       }
     }
 
-    options.rollData ??= this.getRollData({ roll: { attackMode: config.attackMode } });
     const rollConfig = super.getDamageConfig(config, options);
 
     if ( this.damage.critical.bonus && rollConfig.rolls[0] && !rollConfig.rolls[0].options?.critical?.bonusDamage ) {

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -258,7 +258,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
    * @returns {{ data: object, parts: string[] }}
    */
   getAttackData({ ammunition, attackMode, situational }={}) {
-    const rollData = this.getRollData({ data: { roll: { attack: { mode: attackMode } } } });
+    const rollData = this.getRollData({ roll: { attackMode } });
     if ( this.attack.flat ) return CONFIG.Dice.BasicRoll.constructParts({ toHit: this.attack.bonus }, rollData);
 
     const weapon = this.item.system;
@@ -372,10 +372,12 @@ export default class BaseAttackActivityData extends BaseActivityData {
   /** @inheritDoc */
   getRollData(options={}) {
     const rollData = super.getRollData(options);
-    if ( rollData.roll ) {
+    if ( options.roll ) {
+      rollData.roll ??= {};
       rollData.roll.ability = this.ability;
       rollData.roll.attack ??= {};
       rollData.roll.attack.classification = this.attack.type.classification;
+      rollData.roll.attack.mode = options.roll.attackMode;
       rollData.roll.attack.type = rollData.roll.attack.mode?.includes("thrown") ? "ranged" : this.attack.type.value;
       rollData.roll.type = "attack";
     }

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -769,10 +769,12 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
 
     const rollConfig = foundry.utils.deepClone(config);
     rollData ??= this.getRollData({ roll: { attackMode: config.attackMode } });
-    rollData = { ...rollData, roll: foundry.utils.deepClone(rollData.roll ?? {}) };
+    rollData.roll ??= {};
     Object.assign(rollData.roll, {
       isCritical: rollConfig.isCritical,
-      properties: Array.from(this.item.system.properties ?? []).filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical)
+      properties: Array.from(this.item.system.properties ?? [])
+        .concat(config.properties ?? [])
+        .filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical)
     });
     rollConfig.rolls = this.damage.parts
       .map((d, index) => this._processDamagePart(d, rollConfig, rollData, index, formulaOptions))

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -1,5 +1,6 @@
 import aggregateDamageRolls from "../../dice/aggregate-damage-rolls.mjs";
 import simplifyRollFormula from "../../dice/simplify-roll-formula.mjs";
+import AppliedRules from "../../documents/applied-rules.mjs";
 import { safePropertyExists, staticID } from "../../utils.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import IdentifierField from "../fields/identifier-field.mjs";
@@ -767,11 +768,18 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     if ( !this.damage?.parts ) return foundry.utils.mergeObject({ rolls: [] }, config);
 
     const rollConfig = foundry.utils.deepClone(config);
-    rollData ??= this.getRollData();
+    rollData ??= this.getRollData({ roll: { attackMode: config.attackMode } });
+    rollData = { ...rollData, roll: foundry.utils.deepClone(rollData.roll ?? {}) };
+    Object.assign(rollData.roll, {
+      isCritical: rollConfig.isCritical,
+      properties: Array.from(this.item.system.properties ?? []).filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical)
+    });
     rollConfig.rolls = this.damage.parts
       .map((d, index) => this._processDamagePart(d, rollConfig, rollData, index, formulaOptions))
       .filter(d => d.parts.length)
       .concat(config.rolls ?? []);
+
+    AppliedRules.collect("damage:bonus", this.actor, this.item).reset();
 
     return rollConfig;
   }
@@ -783,12 +791,11 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    * @param {ActivityRollDataOptions} [options]
    * @returns {ActivityRollData}
    */
-  getRollData({ data, ...options }={}) {
+  getRollData(options={}) {
     const rollData = this.item.getRollData(options);
     rollData.activity = { ...this };
     rollData.consumed = this.item.flags.dnd5e?.consumed;
     rollData.mod = this.actor?.system.abilities?.[this.ability]?.mod ?? 0;
-    if ( data ) Object.assign(rollData, data);
     return rollData;
   }
 
@@ -807,7 +814,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   _processDamagePart(damage, rollConfig, rollData, index=0, options={}) {
     const scaledFormula = damage.scaledFormula(rollConfig.scaling ?? rollData.scaling, options);
     const parts = scaledFormula ? [scaledFormula] : [];
-    const data = { ...rollData };
+    const lastType = this.item.getFlag("dnd5e", `last.${this.id}.damageType.${index}`);
+    const data = { ...rollData, roll: foundry.utils.deepClone(rollData.roll ?? {}) };
+    data.roll.damageType = (damage.types.has(lastType) ? lastType : null) ?? damage.types.first();
 
     if ( index === 0 ) {
       const actionType = this.getActionType(rollConfig.attackMode);
@@ -816,15 +825,16 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       if ( this.item.system.damage?.bonus ) parts.push(String(this.item.system.damage.bonus));
     }
 
-    const lastType = this.item.getFlag("dnd5e", `last.${this.id}.damageType.${index}`);
+    const ruleBonus = AppliedRules.collect("damage:bonus", this.actor, this.item)
+      .filterWith(data).consume().toFormula();
+    if ( ruleBonus ) parts.push(ruleBonus);
 
     return {
       data, parts,
       options: {
-        type: (damage.types.has(lastType) ? lastType : null) ?? damage.types.first(),
+        type: data.roll.damageType,
         types: Array.from(damage.types),
-        properties: Array.from(this.item.system.properties ?? [])
-          .filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical)
+        properties: data.roll.properties
       }
     };
   }

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -770,18 +770,18 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     const rollConfig = foundry.utils.deepClone(config);
     rollData ??= this.getRollData({ roll: { attackMode: config.attackMode } });
     rollData.roll ??= {};
-    rollData.rules = {
-      bonus: AppliedRules.collect("damage:bonus", this.actor, this.item).toArray(),
-      consumed: new Set()
-    };
     Object.assign(rollData.roll, {
       isCritical: rollConfig.isCritical,
       properties: Array.from(this.item.system.properties ?? [])
         .concat(config.properties ?? [])
         .filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical)
     });
+    const rules = {
+      bonus: AppliedRules.collect("damage:bonus", this.actor, this.item).toArray(),
+      consumed: new Set()
+    };
     rollConfig.rolls = this._getDamageParts(config)
-      .map((d, index) => this._processDamagePart(d, rollConfig, rollData, index, formulaOptions))
+      .map((d, index) => this._processDamagePart(d, rollConfig, rollData, index, { formulaOptions, rules }))
       .filter(d => d.parts.length)
       .concat(config.rolls ?? []);
 
@@ -822,12 +822,14 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
    * @param {Partial<DamageRollProcessConfiguration>} rollConfig  Roll configuration being built.
    * @param {ActivityRollData} rollData                           Roll data to populate with damage data.
    * @param {number} [index=0]                                    Index of the damage part.
-   * @param {DamageFormulaOptions} [options={}]                   Options to configure the formula.
+   * @param {object} [options={}]
+   * @param {DamageFormulaOptions} [options.formulaOptions]       Options to configure the formula.
+   * @param {object} [options.rules]                              Data used to apply rules to each part.
    * @returns {DamageRollConfiguration}
    * @protected
    */
-  _processDamagePart(damage, rollConfig, rollData, index=0, options={}) {
-    const scaledFormula = damage.scaledFormula(rollConfig.scaling ?? rollData.scaling, options);
+  _processDamagePart(damage, rollConfig, rollData, index=0, { formulaOptions, rules }={}) {
+    const scaledFormula = damage.scaledFormula(rollConfig.scaling ?? rollData.scaling, formulaOptions);
     const parts = scaledFormula ? [scaledFormula] : [];
     const lastType = this.item.getFlag("dnd5e", `last.${this.id}.damageType.${index}`);
     const data = { ...rollData, roll: foundry.utils.deepClone(rollData.roll ?? {}) };
@@ -840,10 +842,12 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       if ( this.item.system.damage?.bonus ) parts.push(String(this.item.system.damage.bonus));
     }
 
-    const ruleBonus = AppliedRules.createIterator(rollData.rules.bonus)
-      .filterWith(data, { consumed: rollData.rules.consumed })
-      .toFormula();
-    if ( ruleBonus ) parts.push(ruleBonus);
+    if ( rules ) {
+      const ruleBonus = AppliedRules.createIterator(rules.bonus)
+        .filterWith(data, { consumed: rules.consumed })
+        .toFormula();
+      if ( ruleBonus ) parts.push(ruleBonus);
+    }
 
     return {
       data, parts,

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -770,20 +770,33 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     const rollConfig = foundry.utils.deepClone(config);
     rollData ??= this.getRollData({ roll: { attackMode: config.attackMode } });
     rollData.roll ??= {};
+    rollData.rules = {
+      bonus: AppliedRules.collect("damage:bonus", this.actor, this.item).toArray(),
+      consumed: new Set()
+    };
     Object.assign(rollData.roll, {
       isCritical: rollConfig.isCritical,
       properties: Array.from(this.item.system.properties ?? [])
         .concat(config.properties ?? [])
         .filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical)
     });
-    rollConfig.rolls = this.damage.parts
+    rollConfig.rolls = this._getDamageParts(config)
       .map((d, index) => this._processDamagePart(d, rollConfig, rollData, index, formulaOptions))
       .filter(d => d.parts.length)
       .concat(config.rolls ?? []);
 
-    AppliedRules.collect("damage:bonus", this.actor, this.item).reset();
-
     return rollConfig;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Retrieve the damage parts and apply any necessary modification before they are prepared.
+   * @param {Partial<DamageRollProcessConfiguration>} [config={}]  Roll configuration being built.
+   * @returns {DamageData[]}
+   */
+  _getDamageParts(config={}) {
+    return Array.from(this.damage.parts);
   }
 
   /* -------------------------------------------- */
@@ -827,8 +840,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       if ( this.item.system.damage?.bonus ) parts.push(String(this.item.system.damage.bonus));
     }
 
-    const ruleBonus = AppliedRules.collect("damage:bonus", this.actor, this.item)
-      .filterWith(data).consume().toFormula();
+    const ruleBonus = AppliedRules.createIterator(rollData.rules.bonus)
+      .filterWith(data, { consumed: rollData.rules.consumed })
+      .toFormula();
     if ( ruleBonus ) parts.push(ruleBonus);
 
     return {

--- a/module/data/activity/heal-data.mjs
+++ b/module/data/activity/heal-data.mjs
@@ -1,3 +1,4 @@
+import AppliedRules from "../../documents/applied-rules.mjs";
 import DamageField from "../shared/damage-field.mjs";
 import BaseActivityData from "./base-activity.mjs";
 
@@ -46,13 +47,17 @@ export default class BaseHealActivityData extends BaseActivityData {
   /* -------------------------------------------- */
 
   /** @override */
-  getDamageConfig(config={}, options={}) {
+  getDamageConfig(config={}, { formulaOptions, rollData }={}) {
     if ( !this.healing.formula ) return foundry.utils.mergeObject({ rolls: [] }, config);
 
     const rollConfig = foundry.utils.mergeObject({ critical: { allow: false } }, config);
-    const rollData = options.rollData ?? this.getRollData();
+    rollData ??= this.getRollData({ roll: true });
+    const rules = {
+      bonus: AppliedRules.collect("healing:bonus", this.actor, this.item).toArray(),
+      consumed: new Set()
+    };
     rollConfig.rolls = [
-      this._processDamagePart(this.healing, rollConfig, rollData, options.formulaOptions)
+      this._processDamagePart(this.healing, rollConfig, rollData, 0, { formulaOptions, rules })
     ].concat(config.rolls ?? []);
 
     return rollConfig;

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -152,7 +152,7 @@ export default class BaseSaveActivityData extends BaseActivityData {
   /** @inheritDoc */
   getRollData(options={}) {
     const rollData = super.getRollData(options);
-    if ( rollData.roll ) rollData.roll.type = "save";
+    if ( options.roll ) foundry.utils.setProperty(rollData, "roll.type", "save");
     return rollData;
   }
 }

--- a/module/data/activity/save-data.mjs
+++ b/module/data/activity/save-data.mjs
@@ -146,4 +146,13 @@ export default class BaseSaveActivityData extends BaseActivityData {
 
     return rollConfig;
   }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  getRollData(options={}) {
+    const rollData = super.getRollData(options);
+    if ( rollData.roll ) rollData.roll.type = "save";
+    return rollData;
+  }
 }

--- a/module/dice/_types.mjs
+++ b/module/dice/_types.mjs
@@ -80,7 +80,7 @@
  */
 
 /**
- * @typedef {"oneHanded"|"twoHanded"|"offhand"|"thrown"|"thrown-offhand"} WeaponAttackMode
+ * @typedef {"oneHanded"|"twoHanded"|"offhand"|"thrown"|"thrown-offhand"|"ranged"} WeaponAttackMode
  */
 
 /**
@@ -106,6 +106,7 @@
  * @typedef {BasicRollProcessConfiguration} DamageRollProcessConfiguration
  * @property {DamageRollConfiguration[]} rolls         Configuration data for individual rolls.
  * @property {CriticalDamageConfiguration} [critical]  Critical configuration for all rolls.
+ * @property {string[]} [properties]                   Properties applied to all rolls.
  * @property {boolean} [isCritical]                    Treat each roll as a critical unless otherwise specified.
  * @property {number} [scaling=0]                      Scale increase above base damage.
  */

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -199,7 +199,7 @@
  * @property {boolean} [deterministic]  Whether to force deterministic values for data properties that could
  *                                      be either a die term or a flat term.
  * @property {object} [data]            Arbitrary data assigned to the roll data object.
- * @property {object} [roll]                       Configuration options for the roll.
+ * @property {object|true} [roll]                  Configuration for a roll or true to indicate data is for a roll.
  * @property {WeaponAttackMode} [roll.attackMode]  Selected weapon attack mode.
  */
 

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -199,6 +199,8 @@
  * @property {boolean} [deterministic]  Whether to force deterministic values for data properties that could
  *                                      be either a die term or a flat term.
  * @property {object} [data]            Arbitrary data assigned to the roll data object.
+ * @property {object} [roll]                       Configuration options for the roll.
+ * @property {WeaponAttackMode} [roll.attackMode]  Selected weapon attack mode.
  */
 
 /* -------------------------------------------- */

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -199,7 +199,7 @@
  * @property {boolean} [deterministic]  Whether to force deterministic values for data properties that could
  *                                      be either a die term or a flat term.
  * @property {object} [data]            Arbitrary data assigned to the roll data object.
- * @property {object|true} [roll]                  Configuration for a roll or true to indicate data is for a roll.
+ * @property {boolean|object} [roll]               Configuration for a roll or true to indicate data is for a roll.
  * @property {WeaponAttackMode} [roll.attackMode]  Selected weapon attack mode.
  */
 

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -118,7 +118,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
       rollConfig.mastery = masteryOptions?.[0]?.value;
     }
 
-    const rollData = this.getRollData({ data: { roll: { attack: { mode: rollConfig.attackMode } } } });
+    const rollData = this.getRollData({ roll: { attackMode: rollConfig.attackMode } });
     const { advantage, disadvantage } = this.actor ? AdvantageModeField.combineFields(
       this.actor.system, [],
       AppliedRules.collect("attack:advantage", this.actor, this.item).filterWith(rollData).toAdvantageCounts()

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -533,7 +533,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     else rollData = { ...super.getRollData() };
     rollData.flags = { ...this.flags };
     rollData.name = this.name;
-    if ( options.data ) Object.assign(rollData, options.data);
+    if ( options.roll ) rollData.roll ??= {};
     rollData.statuses = {};
     for ( const status of this.statuses ) {
       if ( ConditionData.hasLevels(status) ) rollData.statuses[status] = this.system.conditions[status];
@@ -1428,13 +1428,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     let prof = calculateSkillToolProficiency(this, abilityId, process);
     const originalProf = calculateSkillToolProficiency(hostActor, abilityId, process);
     if ( originalProf?.multiplier > prof.multiplier ) prof = originalProf;
-    const rollData = this.getRollData();
-    rollData.roll = {
+    const rollData = this.getRollData({ roll: true });
+    Object.assign(rollData.roll, {
       ability: abilityId,
       proficient: prof.multiplier >= 1,
       [type]: process[type],
       type: type
-    };
+    });
 
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: ability?.mod,
@@ -1547,12 +1547,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const ability = this.system.abilities?.[config.ability];
     const abilityConfig = CONFIG.DND5E.abilities[config.ability];
 
-    const rollData = this.getRollData();
-    rollData.roll = {
+    const rollData = this.getRollData({ roll: true });
+    Object.assign(rollData.roll, {
       ability: config.ability,
       proficient: ability?.[`${type}Prof`]?.multiplier >= 1,
       type: config[`${type}Type`] ?? "ability"
-    };
+    });
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: ability?.mod,
       prof: ability?.[`${type}Prof`].hasProficiency ? ability[`${type}Prof`].term : null,
@@ -1870,12 +1870,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const abilityId = init?.ability || CONFIG.DND5E.defaultAbilities.initiative;
     const ability = this.system.abilities?.[abilityId];
 
-    const rollData = this.getRollData();
-    rollData.roll = {
+    const rollData = this.getRollData({ roll: true });
+    Object.assign(rollData.roll, {
       ability: abilityId,
       proficient: init.prof.multiplier >= 1,
       type: "initiative"
-    };
+    });
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: init?.mod,
       prof: init.prof.hasProficiency ? init.prof.term : null,

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -76,6 +76,8 @@ export default class AppliedRules extends Map {
 
 /* -------------------------------------------- */
 
+const CONSUMED = Symbol("consumed");
+
 /**
  * Special iterator for rules that adds some additional helper methods.
  */
@@ -103,6 +105,16 @@ class RulesIterator extends Iterator {
   /* -------------------------------------------- */
 
   /**
+   * Mark all rules as consumed and skip any previously consumed rules.
+   * @returns {RulesIterator}
+   */
+  consume() {
+    return new RulesIterator(this.#iterator.filter(r => r[CONSUMED] ? false : r[CONSUMED] = true));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Filter rules based on effect & change conditions.
    * @param {RollData} rollData
    * @returns {RulesIterator}
@@ -113,6 +125,15 @@ class RulesIterator extends Iterator {
       if ( r.conditions?.check(rollData) === false ) return false;
       return true;
     }));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Reset the consumption for all rules.
+   */
+  reset() {
+    this.forEach(r => delete r[CONSUMED]);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -72,11 +72,20 @@ export default class AppliedRules extends Map {
   static collect(rule, actor, item) {
     return new RulesIterator(AppliedRules.#collect(rule, actor, item));
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create a rules iterator from an iterable object.
+   * @param {Iterable<ActiveEffectChangeData>} rules  Some kind of iterable object containing rules.
+   * @returns {RulesIterator}
+   */
+  static createIterator(rules) {
+    return new RulesIterator(Iterator.from(rules));
+  }
 }
 
 /* -------------------------------------------- */
-
-const CONSUMED = Symbol("consumed");
 
 /**
  * Special iterator for rules that adds some additional helper methods.
@@ -105,35 +114,20 @@ class RulesIterator extends Iterator {
   /* -------------------------------------------- */
 
   /**
-   * Mark all rules as consumed and skip any previously consumed rules.
-   * @returns {RulesIterator}
-   */
-  consume() {
-    return new RulesIterator(this.#iterator.filter(r => r[CONSUMED] ? false : r[CONSUMED] = true));
-  }
-
-  /* -------------------------------------------- */
-
-  /**
    * Filter rules based on effect & change conditions.
    * @param {RollData} rollData
+   * @param {object} [options={}]
+   * @param {Set<ActiveEffectChangeData>} [options.consumed]  Set of consumed rules to skip, selected rules added to.
    * @returns {RulesIterator}
    */
-  filterWith(rollData) {
+  filterWith(rollData, { consumed }={}) {
     return new RulesIterator(this.filter(r => {
+      if ( consumed?.has(r) ) return false;
       if ( r.effect?.system.conditions?.check(rollData) === false ) return false;
       if ( r.conditions?.check(rollData) === false ) return false;
+      if ( consumed ) consumed.add(r);
       return true;
     }));
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Reset the consumption for all rules.
-   */
-  reset() {
-    this.forEach(r => delete r[CONSUMED]);
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
To ensure bonuses are only applied once per damage roll while still allowing different filtering for each damage part, this adds a `consume()` method to `RulesIterator` that filters out any consumed rules and marks the remaining rules as consumed. Done after the filtering step this ensures that each rule can only be used once per damage roll. Calling `reset()` after all of the parts are prepared clears the consumed status.

Reworked the `roll` option passed into `getRollData` so now it is a proper options object that individual `getRollData` methods can respond to rather than data assigned to the roll data (since that can be easily handled after roll data is created).