### PR TITLE
[#6315] Add rule for Advantage, implement for attacks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -291,6 +291,9 @@
 "DND5E.ACTIVEEFFECT": {
   "AttributeKeyTooltip": "For a list of common keys and their accepted values, see <a href=\"{url}\">the wiki</a>.",
   "ChangeType": {
+    "Advantage": {
+      "Label": "Rule: Advantage"
+    },
     "Bonus": {
       "Label": "Rule: Bonus"
     }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3906,6 +3906,12 @@ DND5E.bloodied = {
  * @enum {ActiveEffectChangeTypeConfig & { [skipConditions]: boolean }}
  */
 DND5E.activeEffectChangeTypes = Object.freeze({
+  "dnd5e.advantage": {
+    label: "DND5E.ACTIVEEFFECT.ChangeType.Advantage.Label",
+    defaultPriority: 100,
+    handler: ActiveEffect5e._applyChangeRule,
+    skipConditions: true
+  },
   "dnd5e.bonus": {
     label: "DND5E.ACTIVEEFFECT.ChangeType.Bonus.Label",
     defaultPriority: 100,

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -1,7 +1,9 @@
 import AttackSheet from "../../applications/activity/attack-sheet.mjs";
 import AttackRollConfigurationDialog from "../../applications/dice/attack-configuration-dialog.mjs";
 import BaseAttackActivityData from "../../data/activity/attack-data.mjs";
+import AdvantageModeField from "../../data/fields/advantage-mode-field.mjs";
 import { getTargetDescriptors } from "../../utils.mjs";
+import AppliedRules from "../applied-rules.mjs";
 import ActivityMixin from "./mixin.mjs";
 
 /**
@@ -116,9 +118,16 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
       rollConfig.mastery = masteryOptions?.[0]?.value;
     }
 
+    const rollData = this.getRollData({ data: { roll: { attack: { mode: rollConfig.attackMode } } } });
+    const { advantage, disadvantage } = this.actor ? AdvantageModeField.combineFields(
+      this.actor.system, [],
+      AppliedRules.collect("attack:advantage", this.actor, this.item).filterWith(rollData).toAdvantageCounts()
+    ) : {};
+
     rollConfig.hookNames = [...(config.hookNames ?? []), "attack", "d20Test"];
     rollConfig.rolls = [CONFIG.Dice.D20Roll.mergeConfigs({
       options: {
+        advantage, disadvantage,
         ammunition: rollConfig.ammunition,
         attackMode: rollConfig.attackMode,
         criticalSuccess: this.criticalThreshold,

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -1,4 +1,8 @@
 /**
+ * @import { AdvantageModeData } from "../data/fields/_types.mjs";
+ */
+
+/**
  * @extends {Map<string, Map<string, ChangeData[]>>}
  */
 export default class AppliedRules extends Map {
@@ -105,6 +109,39 @@ class RulesIterator extends Iterator {
       if ( r.conditions?.check(rollData) === false ) return false;
       return true;
     }));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Count advantage mode values into number of advantages and disadvantages.
+   * @param {Partial<AdvantageModeData>} [counts]  Existing counts with which to merge rule counts.
+   * @returns {AdvantageModeData}
+   */
+  toAdvantageCounts(counts={}) {
+    return this.values(String).reduce((data, value) => {
+      switch ( value ) {
+        // 1 - Add advantage
+        case "1":
+        case "+1": data.advantages.count++; break;
+        // -1 - Add disadvantage
+        case "-1": data.disadvantages.count++; break;
+        // =1 - Always advantage
+        case "=1":
+        case "=+1": data.override = 1; break;
+        // =-1 - Always disadvantage
+        case "=-1": data.override = -1; break;
+        // >=0 - Cannot have disadvantage
+        case ">=0": data.disadvantages.suppressed = true; break;
+        // <=0 - Cannot have advantage
+        case "<=0": data.advantages.suppressed = true; break;
+      }
+      return data;
+    }, foundry.utils.mergeObject({
+      advantages: { count: 0, suppressed: false },
+      disadvantages: { count: 0, suppressed: false },
+      override: null
+    }, counts));
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Adds an `advantage` rule that works for attacks. It takes a number of values:
 - `1`/`+1` & `-1` add a source of advantage or disadvantage
 - `=1`/`=+1` & `=-1` force advantage or disadvantage
 - `>=0` & `<=0` suppress disadvantage or advantage

### Todo
- [ ] Make rule config dynamic so when "Rule: Advantage" is selected it displays a dropdown of options, rather than freeform