### PR TITLE
[#6315] Expand rule bonuses to checks & saves

### DIFF
--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -306,8 +306,8 @@ export default class ItemDataModel extends SystemDataModel {
    * @param {RollDataOptions} [options]
    * @returns {ItemRollData}
    */
-  getRollData({ deterministic=false }={}) {
-    const actorRollData = this.parent.actor?.getRollData({ deterministic }) ?? {};
+  getRollData(options={}) {
+    const actorRollData = this.parent.actor?.getRollData(options) ?? {};
     const data = { ...actorRollData, item: { ...this } };
     return data;
   }

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -373,6 +373,7 @@ export default class BaseAttackActivityData extends BaseActivityData {
   getRollData(options={}) {
     const rollData = super.getRollData(options);
     if ( rollData.roll ) {
+      rollData.roll.ability = this.ability;
       rollData.roll.attack ??= {};
       rollData.roll.attack.classification = this.attack.type.classification;
       rollData.roll.attack.type = rollData.roll.attack.mode?.includes("thrown") ? "ranged" : this.attack.type.value;

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -1,5 +1,6 @@
 import ActiveEffect5e from "../../../documents/active-effect.mjs";
 import Proficiency from "../../../documents/actor/proficiency.mjs";
+import AppliedRules from "../../../documents/applied-rules.mjs";
 import { convertLength, convertWeight, defaultUnits, replaceFormulaData, simplifyBonus } from "../../../utils.mjs";
 import AdvantageModeField from "../../fields/advantage-mode-field.mjs";
 import ConditionData from "../../active-effect/condition.mjs";
@@ -508,11 +509,18 @@ export default class AttributesFields {
       AdvantageModeField.setMode(this, "attributes.init.roll.mode", -1);
     }
 
+    // Complete roll data
+    rollData = { ...rollData };
+    rollData.roll = { ability: abilityId, proficient: init.prof.multiplier >= 1, type: "initiative" };
+
     // Total initiative includes all numeric terms
     const initBonus = simplifyBonus(init.bonus, rollData);
     const abilityBonus = simplifyBonus(ability.bonuses?.check, rollData);
+    const ruleBonus = simplifyBonus(
+      AppliedRules.collect("check:bonus", this.parent).filterWith(rollData).toFormula(), rollData
+    );
     const quality = this.attributes.quality?.value ?? 0;
-    init.total = init.mod + initBonus + abilityBonus + globalCheckBonus + quality
+    init.total = init.mod + initBonus + abilityBonus + globalCheckBonus + ruleBonus + quality
       + (flags.initiativeAlert && isLegacy ? 5 : 0)
       + (Number.isNumeric(init.prof.term) ? init.prof.flat : 0);
     init.score = CONFIG.DND5E.skillPassive.base + init.total + (init.roll.mode * CONFIG.DND5E.skillPassive.modifier);

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -168,7 +168,7 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
       const checkBonusRules = simplifyBonus(
         AppliedRules.collect("check:bonus", this.parent).filterWith(rollData).toFormula(), rollData
       );
-      abl.checkBonus = checkBonusAbl + checkBonus;
+      abl.checkBonus = checkBonusAbl + checkBonusRules + checkBonus;
 
       const saveBonusAbl = simplifyBonus(abl.bonuses?.save, rollData);
       const cover = id === "dex" ? Math.max(ac?.cover ?? 0, this.parent.coverBonus) : 0;

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -1,4 +1,5 @@
 import Proficiency from "../../../documents/actor/proficiency.mjs";
+import AppliedRules from "../../../documents/applied-rules.mjs";
 import { simplifyBonus } from "../../../utils.mjs";
 import ActorDataModel from "../../abstract/actor-data-model.mjs";
 import AdvantageModeField from "../../fields/advantage-mode-field.mjs";
@@ -158,14 +159,24 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
       const calculatedProf = this.calculateAbilityCheckProficiency(0, id);
       abl.checkProf = originalAbility?.checkProf?.multiplier > calculatedProf.multiplier
         ? originalAbility.checkProf.clone() : calculatedProf;
-      const saveBonusAbl = simplifyBonus(abl.bonuses?.save, rollData);
-
-      const cover = id === "dex" ? Math.max(ac?.cover ?? 0, this.parent.coverBonus) : 0;
-      abl.saveBonus = saveBonusAbl + saveBonus + cover;
-
       abl.saveProf = abl.merged ? originalAbility.saveProf.clone() : new Proficiency(prof, abl.proficient);
+
+      rollData = { ...rollData };
+      rollData.roll = { ability: id, proficient: abl.checkProf.multiplier >= 1, type: "ability" };
+
       const checkBonusAbl = simplifyBonus(abl.bonuses?.check, rollData);
+      const checkBonusRules = simplifyBonus(
+        AppliedRules.collect("check:bonus", this.parent).filterWith(rollData).toFormula(), rollData
+      );
       abl.checkBonus = checkBonusAbl + checkBonus;
+
+      const saveBonusAbl = simplifyBonus(abl.bonuses?.save, rollData);
+      const cover = id === "dex" ? Math.max(ac?.cover ?? 0, this.parent.coverBonus) : 0;
+      rollData.roll.proficient = abl.saveProf.multiplier >= 1;
+      const saveBonusRules = simplifyBonus(
+        AppliedRules.collect("save:bonus", this.parent).filterWith(rollData).toFormula(), rollData
+      );
+      abl.saveBonus = saveBonusAbl + saveBonusRules + saveBonus + cover;
 
       abl.save.value = abl.mod + abl.saveBonus;
       if ( Number.isNumeric(abl.saveProf.term) ) abl.save.value += abl.saveProf.flat;

--- a/module/data/actor/templates/creature.mjs
+++ b/module/data/actor/templates/creature.mjs
@@ -1,4 +1,5 @@
 import * as Trait from "../../../documents/actor/trait.mjs";
+import AppliedRules from "../../../documents/applied-rules.mjs";
 import { simplifyBonus } from "../../../utils.mjs";
 import AdvantageModeField from "../../fields/advantage-mode-field.mjs";
 import FormulaField from "../../fields/formula-field.mjs";
@@ -248,23 +249,32 @@ export default class CreatureTemplate extends CommonTemplate {
     ability ??= skillData.ability;
     const abilityData = this.abilities[ability];
     skillData.ability = ability;
-    const baseBonus = simplifyBonus(skillData.bonuses?.check, rollData);
     const originalSkill = originalSkills?.[skillId];
     if ( originalSkill?.value >= 1 ) {
       skillData.merged = true;
       skillData.value = originalSkill?.value;
     }
 
-    // Compute modifier
-    const checkBonusAbl = simplifyBonus(abilityData?.bonuses?.check, rollData);
-    skillData.effectValue = skillData.value;
-    skillData.bonus = baseBonus + globalCheckBonus + checkBonusAbl + globalSkillBonus;
-    skillData.mod = abilityData?.mod ?? 0;
+    // Compute proficiency
     const calculatedProf = this.calculateAbilityCheckProficiency(
       skillData.value, skillData.ability, { skill: skillId }
     );
     skillData.prof = originalSkill?.prof?.multiplier > calculatedProf.multiplier
       ? originalSkill.prof.clone() : calculatedProf;
+
+    // Complete roll data
+    rollData = { ...rollData };
+    rollData.roll = { ability, proficient: skillData.prof.multiplier >= 1, skill: skillId, type: "skill" };
+
+    // Compute modifier
+    const checkBonusAbl = simplifyBonus(abilityData?.bonuses?.check, rollData);
+    skillData.effectValue = skillData.value;
+    const baseBonus = simplifyBonus(skillData.bonuses?.check, rollData);
+    const ruleBonus = simplifyBonus(
+      AppliedRules.collect("check:bonus", this.parent).filterWith(rollData).toFormula(), rollData
+    );
+    skillData.bonus = baseBonus + globalCheckBonus + checkBonusAbl + globalSkillBonus + ruleBonus;
+    skillData.mod = abilityData?.mod ?? 0;
     skillData.value = skillData.proficient = skillData.prof.multiplier;
     skillData.total = skillData.mod + skillData.bonus;
     if ( Number.isNumeric(skillData.prof.term) ) skillData.total += skillData.prof.flat;
@@ -304,14 +314,22 @@ export default class CreatureTemplate extends CommonTemplate {
    */
   prepareTools({ rollData={} }={}) {
     const globalCheckBonus = simplifyBonus(this.bonuses.abilities.check, rollData);
-    for ( const tool of Object.values(this.tools) ) {
+    for ( const [id, tool] of Object.entries(this.tools) ) {
       const ability = this.abilities[tool.ability];
+      tool.prof = this.calculateToolProficiency(tool.value, tool.ability);
+
+      // Complete roll data
+      rollData = { ...rollData };
+      rollData.roll = { ability: tool.ability, proficient: tool.prof.multiplier >= 1, tool: id, type: "tool" };
+
       const baseBonus = simplifyBonus(tool.bonuses.check, rollData);
       const checkBonusAbl = simplifyBonus(ability?.bonuses?.check, rollData);
+      const ruleBonus = simplifyBonus(
+        AppliedRules.collect("check:bonus", this.parent).filterWith(rollData).toFormula(), rollData
+      );
       tool.effectValue = tool.value;
-      tool.bonus = baseBonus + globalCheckBonus + checkBonusAbl;
       tool.mod = ability?.mod ?? 0;
-      tool.prof = this.calculateToolProficiency(tool.value, tool.ability);
+      tool.bonus = baseBonus + globalCheckBonus + checkBonusAbl + ruleBonus;
       tool.total = tool.mod + tool.bonus;
       if ( Number.isNumeric(tool.prof.term) ) tool.total += tool.prof.flat;
       tool.value = tool.prof.multiplier;
@@ -323,8 +341,8 @@ export default class CreatureTemplate extends CommonTemplate {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  getRollData({ deterministic=false }={}) {
-    const data = super.getRollData({ deterministic });
+  getRollData(options={}) {
+    const data = super.getRollData(options);
     data.classes = {};
     data.subclasses = {};
     for ( const [identifier, cls] of Object.entries(this.parent.classes) ) {

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -143,21 +143,10 @@
  * @property {object} activity         Object containing the activity's data.
  * @property {object} [consumed]       Information on what resources the activity's activation consumed.
  * @property {number} mod              The ability modifier value used by the activity.
- * @property {RollDescription} [roll]  Data describing a specific roll being performed.
- */
-
-/**
- * @typedef RollDescription
- * @param {object} [attack]
- * @param {"spell"|"unarmed"|"weapon"} [attack.classification]  Source of the attack.
- * @param {WeaponAttackMode} [attack.mode]  Selected weapon attack mode.
- * @param {"melee"|"ranged"} [attack.type]  Whether this is a melee or ranged attack.
- * @param {string} type                     Type of roll being performed (e.g. "attack", "skill", "tool", etc.).
  */
 
 /**
  * @typedef {RollDataOptions} ActivityRollDataOptions
- * @property {object} [data]  Arbitrary data assigned to the roll data object.
  */
 
 /**
@@ -189,12 +178,27 @@
 
 /**
  * @typedef RollData
+ * @property {RollDescription} [roll]  Data describing a specific roll being performed.
+ */
+
+/**
+ * @typedef RollDescription
+ * @param {string} [ability]                Ability associated with a D20 roll.
+ * @param {object} [attack]
+ * @param {"spell"|"unarmed"|"weapon"} [attack.classification]  Source of the attack.
+ * @param {WeaponAttackMode} [attack.mode]  Selected weapon attack mode.
+ * @param {"melee"|"ranged"} [attack.type]  Whether this is a melee or ranged attack.
+ * @param {boolean} [proficient]            Whether proficiency was added to the roll.
+ * @param {string} [skill]                  ID of skill associated with the roll.
+ * @param {string} [tool]                   ID of tool associated with the roll.
+ * @param {string} type                     Type of roll being performed (e.g. "attack", "skill", "tool", etc.).
  */
 
 /**
  * @typedef RollDataOptions
  * @property {boolean} [deterministic]  Whether to force deterministic values for data properties that could
  *                                      be either a die term or a flat term.
+ * @property {object} [data]            Arbitrary data assigned to the roll data object.
  */
 
 /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -12,6 +12,7 @@ import {
   convertTime, defaultUnits, formatLength, formatNumber, formatTime, simplifyBonus, staticID
 } from "../../utils.mjs";
 import ActiveEffect5e from "../active-effect.mjs";
+import AppliedRules from "../applied-rules.mjs";
 import Item5e from "../item.mjs";
 import SystemDocumentMixin from "../mixins/document.mjs";
 import Proficiency from "./proficiency.mjs";
@@ -526,19 +527,20 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    * @param {RollDataOptions} [options]
    * @returns {ActorRollData}
    */
-  getRollData({ deterministic=false }={}) {
-    let data;
-    if ( this.system.getRollData ) data = this.system.getRollData({ deterministic });
-    else data = {...super.getRollData()};
-    data.flags = {...this.flags};
-    data.name = this.name;
-    data.statuses = {};
+  getRollData(options={}) {
+    let rollData;
+    if ( this.system.getRollData ) rollData = this.system.getRollData(options);
+    else rollData = { ...super.getRollData() };
+    rollData.flags = { ...this.flags };
+    rollData.name = this.name;
+    if ( options.data ) Object.assign(rollData, options.data);
+    rollData.statuses = {};
     for ( const status of this.statuses ) {
-      if ( ConditionData.hasLevels(status) ) data.statuses[status] = this.system.conditions[status];
-      else if ( status === "concentrating" ) data.statuses[status] = this.concentration.effects.size;
-      else data.statuses[status] = 1;
+      if ( ConditionData.hasLevels(status) ) rollData.statuses[status] = this.system.conditions[status];
+      else if ( status === "concentrating" ) rollData.statuses[status] = this.concentration.effects.size;
+      else rollData.statuses[status] = 1;
     }
-    return data;
+    return rollData;
   }
 
   /* -------------------------------------------- */
@@ -1420,13 +1422,19 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
    */
   _buildSkillToolConfig(type, hostActor, process, config, formData, index) {
     const relevant = type === "skill" ? this.system.skills?.[process.skill] : this.system.tools?.[process.tool];
-    const rollData = this.getRollData();
     const abilityId = formData?.get("ability") ?? process.ability;
     const ability = this.system.abilities?.[abilityId];
     const { calculateSkillToolProficiency } = dnd5e.dataModels.actor.CommonTemplate;
     let prof = calculateSkillToolProficiency(this, abilityId, process);
     const originalProf = calculateSkillToolProficiency(hostActor, abilityId, process);
     if ( originalProf?.multiplier > prof.multiplier ) prof = originalProf;
+    const rollData = this.getRollData();
+    rollData.roll = {
+      ability: abilityId,
+      proficient: prof.multiplier >= 1,
+      [type]: process[type],
+      type: type
+    };
 
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: ability?.mod,
@@ -1435,7 +1443,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       extraBonus: process.bonus,
       [`${abilityId}CheckBonus`]: ability?.bonuses?.check,
       [`${type}Bonus`]: this.system.bonuses?.abilities?.[type],
-      abilityCheckBonus: this.system.bonuses?.abilities?.check
+      abilityCheckBonus: this.system.bonuses?.abilities?.check,
+      ruleBonus: AppliedRules.collect("check:bonus", this).filterWith(rollData).toFormula()
     }, { ...rollData });
 
     // Add condition reductions.
@@ -1539,11 +1548,17 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const abilityConfig = CONFIG.DND5E.abilities[config.ability];
 
     const rollData = this.getRollData();
+    rollData.roll = {
+      ability: config.ability,
+      proficient: ability?.[`${type}Prof`]?.multiplier >= 1,
+      type: config[`${type}Type`] ?? "ability"
+    };
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: ability?.mod,
       prof: ability?.[`${type}Prof`].hasProficiency ? ability[`${type}Prof`].term : null,
       [`${config.ability}${type.capitalize()}Bonus`]: ability?.bonuses[type],
       [`${type}Bonus`]: this.system.bonuses?.abilities?.[type],
+      ruleBonus: AppliedRules.collect(`${type}:bonus`, this).filterWith(rollData).toFormula(),
       cover: (config.ability === "dex") && (type === "save") ? this.system.attributes?.ac?.cover : null
     }, rollData);
     const options = {
@@ -1645,7 +1660,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     // Death save bonus
     if ( death.bonuses.save ) parts.push(death.bonuses.save);
 
-    const rollConfig = foundry.utils.mergeObject({ target: 10 }, config);
+    const rollConfig = foundry.utils.mergeObject({ saveType: "death", target: 10 }, config);
     rollConfig.hookNames = [...(config.hookNames ?? []), "deathSave"];
     rollConfig.rolls = [
       CONFIG.Dice.D20Roll.mergeConfigs({ parts, data, options }, config.rolls?.shift())
@@ -1784,6 +1799,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const rollConfig = foundry.utils.mergeObject({
       ability: (conc.ability in CONFIG.DND5E.abilities) ? conc.ability : CONFIG.DND5E.defaultAbilities.concentration,
       isConcentration: true,
+      saveType: "concentration",
       target: 10
     }, config);
     rollConfig.hookNames = [...(config.hookNames ?? []), "concentration"];
@@ -1855,12 +1871,18 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const ability = this.system.abilities?.[abilityId];
 
     const rollData = this.getRollData();
+    rollData.roll = {
+      ability: abilityId,
+      proficient: init.prof.multiplier >= 1,
+      type: "initiative"
+    };
     let { parts, data } = CONFIG.Dice.D20Roll.constructParts({
       mod: init?.mod,
       prof: init.prof.hasProficiency ? init.prof.term : null,
       initiativeBonus: init.bonus,
       [`${abilityId}AbilityCheckBonus`]: ability?.bonuses?.check,
       abilityCheckBonus: this.system.bonuses?.abilities?.check,
+      ruleBonus: AppliedRules.collect("check:bonus", this).filterWith(rollData).toFormula(),
       alert: flags.initiativeAlert && (dnd5e.settings.rulesVersion === "legacy") ? 5 : null
     }, rollData);
 

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -1,3 +1,5 @@
+const D20_TESTS = new Set(["attack", "check", "save"]);
+
 /**
  * @extends {Map<string, Map<string, ChangeData[]>>}
  */
@@ -48,6 +50,8 @@ export default class AppliedRules extends Map {
    * @yields {ChangeData}
    */
   static *#collect(rule, actor, item) {
+    const [category, key] = rule.split(":");
+    if ( D20_TESTS.has(category) ) yield* AppliedRules.#collect(`d20:${key}`, actor, item);
     for ( const r of actor?.appliedRules.get(rule) ?? [] ) yield r;
     for ( const r of item?.appliedRules.get(rule) ?? [] ) yield r;
   }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -883,10 +883,10 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @param {RollDataOptions} [options]
    * @returns {ItemRollData}
    */
-  getRollData({ deterministic=false }={}) {
+  getRollData(options={}) {
     let data;
-    if ( this.system.getRollData ) data = this.system.getRollData({ deterministic });
-    else data = { ...(this.actor?.getRollData({ deterministic }) ?? {}), item: { ...this.system } };
+    if ( this.system.getRollData ) data = this.system.getRollData(options);
+    else data = { ...(this.actor?.getRollData(options) ?? {}), item: { ...this.system } };
     if ( data?.item ) {
       data.item.flags = this.flags;
       data.item.name = this.name;


### PR DESCRIPTION
Adds rules bonuses to checks and saves. The `roll` object within roll data has been moved up to actor so it is available everywhere. This gets different useful data depending on the roll type:

- `ability`
- `proficient` (multiplier 1 or higher, not half-proficiency)
- `skill` or `tool`
- `type` (e.g. `ability`, `skill`, `initiative`, etc.)

Also adds the new `d20` key which applied to attack, check, and save rolls.

<img width="514" height="355" alt="Screenshot 2026-07-11 at 11 05 48" src="https://github.com/user-attachments/assets/8183ed97-72ae-4726-b1aa-d08d330922aa" />
