### PR TITLE
[#6315] Re-apply damage rule bonuses when type is changed

### DIFF
--- a/module/applications/dice/damage-configuration-dialog.mjs
+++ b/module/applications/dice/damage-configuration-dialog.mjs
@@ -78,9 +78,9 @@ export default class DamageRollConfigurationDialog extends RollConfigurationDial
 
   /** @inheritDoc */
   _buildConfig(config, formData, index) {
-    config = super._buildConfig(config, formData, index);
     const damageType = formData?.get(`roll.${index}.damageType`);
     if ( damageType ) config.options.type = damageType;
+    config = super._buildConfig(config, formData, index);
     return config;
   }
 

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -98,6 +98,14 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Category used to fetch rules for damage calculation.
+   * @type {"damage"|"healing"}
+   */
+  static damageRuleCategory = "damage";
+
+  /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
 
@@ -777,7 +785,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
         .filter(p => CONFIG.DND5E.itemProperties[p]?.isPhysical)
     });
     const rules = {
-      bonus: AppliedRules.collect("damage:bonus", this.actor, this.item).toArray(),
+      bonus: AppliedRules.collect(`${this.constructor.damageRuleCategory}:bonus`, this.actor, this.item).toArray(),
       consumed: new Set()
     };
     rollConfig.rolls = this._getDamageParts(config)
@@ -846,7 +854,10 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       const ruleBonus = AppliedRules.createIterator(rules.bonus)
         .filterWith(data, { consumed: rules.consumed })
         .toFormula();
-      if ( ruleBonus ) parts.push(ruleBonus);
+      if ( ruleBonus ) {
+        data.ruleBonus = ruleBonus;
+        parts.push("@ruleBonus");
+      }
     }
 
     return {

--- a/module/data/activity/heal-data.mjs
+++ b/module/data/activity/heal-data.mjs
@@ -21,6 +21,11 @@ export default class BaseHealActivityData extends BaseActivityData {
   }
 
   /* -------------------------------------------- */
+
+  /** @override */
+  static damageRuleCategory = "healing";
+
+  /* -------------------------------------------- */
   /*  Data Migration                              */
   /* -------------------------------------------- */
 
@@ -53,7 +58,7 @@ export default class BaseHealActivityData extends BaseActivityData {
     const rollConfig = foundry.utils.mergeObject({ critical: { allow: false } }, config);
     rollData ??= this.getRollData({ roll: true });
     const rules = {
-      bonus: AppliedRules.collect("healing:bonus", this.actor, this.item).toArray(),
+      bonus: AppliedRules.collect(`${this.constructor.damageRuleCategory}:bonus`, this.actor, this.item).toArray(),
       consumed: new Set()
     };
     rollConfig.rolls = [

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -4,6 +4,7 @@ import TemplatePlacement from "../../canvas/template-placement.mjs";
 import { ConsumptionError } from "../../data/activity/fields/consumption-targets-field.mjs";
 import { ActorDeltasField } from "../../data/chat-message/fields/deltas-field.mjs";
 import { formatNumber, getSceneTargets, getTargetDescriptors, localizeSchema } from "../../utils.mjs";
+import AppliedRules from "../applied-rules.mjs";
 import DependentDocumentMixin from "../mixins/dependent.mjs";
 import PseudoDocumentMixin from "../mixins/pseudo-document.mjs";
 
@@ -11,7 +12,8 @@ import PseudoDocumentMixin from "../mixins/pseudo-document.mjs";
  * @import { FavoriteData5e } from "../../data/abstract/_types.mjs";
  * @import { ActorDeltasData } from "../../data/chat-message/fields/_types.mjs";
  * @import {
- *   BasicRollDialogConfiguration, BasicRollMessageConfiguration, DamageRollProcessConfiguration
+ *   BasicRollDialogConfiguration, BasicRollMessageConfiguration,
+ *   DamageRollConfiguration, DamageRollProcessConfiguration
  * } from "../../dice/_types.mjs";
  * @import {
  *   ActivityConsumptionDescriptor, ActivityDialogConfiguration, ActivityMessageConfiguration, ActivityMetadata,
@@ -880,8 +882,10 @@ export default function ActivityMixin(Base) {
       rollConfig.hookNames = [...(config.hookNames ?? []), "damage"];
       rollConfig.subject = this;
 
+      const buildConfig = this._buildDamageConfig.bind(this);
       const dialogConfig = foundry.utils.mergeObject({
         options: {
+          buildConfig,
           position: {
             width: 400,
             top: config.event ? config.event.clientY - 80 : null,
@@ -935,6 +939,36 @@ export default function ActivityMixin(Base) {
       Hooks.callAll("dnd5e.rollDamageV2", rolls, { subject: this });
 
       return rolls;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Adjust rules applied to damage parts when damage type is changed.
+     * @param {DamageRollProcessConfiguration} process  Configuration for the entire rolling process.
+     * @param {DamageRollConfiguration} config          Configuration for a specific roll.
+     * @param {FormDataExtended|void} formData          Any data entered into the rolling prompt.
+     * @param {number} index                            Index of the roll within all rolls being prepared.
+     */
+    _buildDamageConfig(process, config, formData, index) {
+      if ( index === 0 ) process.rules = {
+        bonus: AppliedRules.collect(`${this.constructor.damageRuleCategory}:bonus`, this.actor, this.item).toArray(),
+        consumed: new Set()
+      };
+
+      config.data.roll.damageType = config.options.type;
+      const ruleBonus = AppliedRules.createIterator(process.rules.bonus)
+        .filterWith(config.data, { consumed: process.rules.consumed })
+        .toFormula();
+      const rulePartIndex = config.parts.findIndex(p => p === "@ruleBonus");
+      if ( ruleBonus ) {
+        config.data.ruleBonus = ruleBonus;
+        if ( rulePartIndex < 0 ) config.parts.push("@ruleBonus");
+      } else if ( rulePartIndex >= 0 ) {
+        config.parts.splice(rulePartIndex, 1);
+      }
+
+      return config;
     }
 
     /* -------------------------------------------- */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -956,6 +956,7 @@ export default function ActivityMixin(Base) {
         consumed: new Set()
       };
 
+      config.data.roll ??= {};
       config.data.roll.damageType = config.options.type;
       const ruleBonus = AppliedRules.createIterator(process.rules.bonus)
         .filterWith(config.data, { consumed: process.rules.consumed })


### PR DESCRIPTION
Adds `_buildDamageConfig` that is passed to the damage roll dialog so that the rule bonus can be re-calculated when the damage type is changed within the dialog.