### PR TITLE
[#6315] Implement minimum & maximum rule types

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -296,6 +296,12 @@
     },
     "Bonus": {
       "Label": "Rule: Bonus"
+    },
+    "Maximum": {
+      "Label": "Rule: Maximum"
+    },
+    "Minimum": {
+      "Label": "Rule: Minimum"
     }
   },
   "Expired": "Expired",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3917,6 +3917,18 @@ DND5E.activeEffectChangeTypes = Object.freeze({
     defaultPriority: 100,
     handler: ActiveEffect5e._applyChangeRule,
     skipConditions: true
+  },
+  "dnd5e.maximum": {
+    label: "DND5E.ACTIVEEFFECT.ChangeType.Maximum.Label",
+    defaultPriority: 100,
+    handler: ActiveEffect5e._applyChangeRule,
+    skipConditions: true
+  },
+  "dnd5e.minimum": {
+    label: "DND5E.ACTIVEEFFECT.ChangeType.Minimum.Label",
+    defaultPriority: 100,
+    handler: ActiveEffect5e._applyChangeRule,
+    skipConditions: true
   }
 });
 

--- a/module/dice/_types.mjs
+++ b/module/dice/_types.mjs
@@ -63,8 +63,8 @@
  * @property {number} [criticalFailure]  The value of the d20 die to be considered a critical failure.
  * @property {boolean} [elvenAccuracy]   Use three dice when rolling with advantage.
  * @property {boolean} [halflingLucky]   Add a re-roll once modifier to the d20 die.
- * @property {number} maximum            Maximum number the d20 die can roll.
- * @property {number} minimum            Minimum number the d20 die can roll.
+ * @property {number} [maximum]          Maximum number the d20 die can roll.
+ * @property {number} [minimum]          Minimum number the d20 die can roll.
  */
 
 /**

--- a/module/dice/_types.mjs
+++ b/module/dice/_types.mjs
@@ -55,7 +55,7 @@
 /**
  * Options that describe a d20 roll.
  *
- * @typedef {BasicRollOptions & Partial<RollRange>} D20RollOptions
+ * @typedef {BasicRollOptions} D20RollOptions
  * @property {boolean} [advantage]       Does this roll potentially have advantage?
  * @property {boolean} [disadvantage]    Does this roll potentially have disadvantage?
  * @property {D20Roll.ADV_MODE} [advantageMode]  Final advantage mode.
@@ -63,12 +63,8 @@
  * @property {number} [criticalFailure]  The value of the d20 die to be considered a critical failure.
  * @property {boolean} [elvenAccuracy]   Use three dice when rolling with advantage.
  * @property {boolean} [halflingLucky]   Add a re-roll once modifier to the d20 die.
- */
-
-/**
- * @typedef RollRange
- * @property {number} maximum  Maximum number the d20 die can roll.
- * @property {number} minimum  Minimum number the d20 die can roll.
+ * @property {number} maximum            Maximum number the d20 die can roll.
+ * @property {number} minimum            Minimum number the d20 die can roll.
  */
 
 /**

--- a/module/dice/_types.mjs
+++ b/module/dice/_types.mjs
@@ -55,7 +55,7 @@
 /**
  * Options that describe a d20 roll.
  *
- * @typedef {BasicRollOptions} D20RollOptions
+ * @typedef {BasicRollOptions & Partial<RollRange>} D20RollOptions
  * @property {boolean} [advantage]       Does this roll potentially have advantage?
  * @property {boolean} [disadvantage]    Does this roll potentially have disadvantage?
  * @property {D20Roll.ADV_MODE} [advantageMode]  Final advantage mode.
@@ -63,8 +63,12 @@
  * @property {number} [criticalFailure]  The value of the d20 die to be considered a critical failure.
  * @property {boolean} [elvenAccuracy]   Use three dice when rolling with advantage.
  * @property {boolean} [halflingLucky]   Add a re-roll once modifier to the d20 die.
- * @property {number} [maximum]          Maximum number the d20 die can roll.
- * @property {number} [minimum]          Minimum number the d20 die can roll.
+ */
+
+/**
+ * @typedef RollRange
+ * @property {number} maximum  Maximum number the d20 die can roll.
+ * @property {number} minimum  Minimum number the d20 die can roll.
  */
 
 /**

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -262,9 +262,11 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const options = {
       ...(config.options ?? {}),
       maximum: this.actor
-        ? AppliedRules.collect("attack:maximum", this.actor, this.item).filterWith(data).toSmallest() : undefined,
+        ? AppliedRules.collect("attack:maximum", this.actor, this.item).filterWith(data).resolve(data).toSmallest()
+        : undefined,
       minimum: this.actor
-        ? AppliedRules.collect("attack:minimum", this.actor, this.item).filterWith(data).toLargest() : undefined,
+        ? AppliedRules.collect("attack:minimum", this.actor, this.item).filterWith(data).resolve(data).toLargest()
+        : undefined,
     };
     if ( ammunition !== undefined ) options.ammunition = ammunition;
     if ( attackMode !== undefined ) options.attackMode = attackMode;

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -123,13 +123,11 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
       this.actor.system, [],
       AppliedRules.collect("attack:advantage", this.actor, this.item).filterWith(rollData).toAdvantageCounts()
     ) : {};
-    const { maximum, minimum } = this.actor
-      ? AppliedRules.collect("attack:range", this.actor, this.item).filterWith(rollData).toRange() : {}
 
     rollConfig.hookNames = [...(config.hookNames ?? []), "attack", "d20Test"];
     rollConfig.rolls = [CONFIG.Dice.D20Roll.mergeConfigs({
       options: {
-        advantage, disadvantage, maximum, minimum,
+        advantage, disadvantage,
         ammunition: rollConfig.ammunition,
         attackMode: rollConfig.attackMode,
         criticalSuccess: this.criticalThreshold,
@@ -261,7 +259,13 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const mastery = formData?.get("mastery") ?? process.mastery;
 
     let { parts, data } = this.getAttackData({ ammunition, attackMode });
-    const options = config.options ?? {};
+    const options = {
+      ...(config.options ?? {}),
+      maximum: this.actor
+        ? AppliedRules.collect("attack:maximum", this.actor, this.item).filterWith(data).toSmallest() : undefined,
+      minimum: this.actor
+        ? AppliedRules.collect("attack:minimum", this.actor, this.item).filterWith(data).toLargest() : undefined,
+    };
     if ( ammunition !== undefined ) options.ammunition = ammunition;
     if ( attackMode !== undefined ) options.attackMode = attackMode;
     if ( mastery !== undefined ) options.mastery = mastery;

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -259,15 +259,14 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
     const mastery = formData?.get("mastery") ?? process.mastery;
 
     let { parts, data } = this.getAttackData({ ammunition, attackMode });
-    const options = {
-      ...(config.options ?? {}),
+    const options = foundry.utils.mergeObject({
       maximum: this.actor
         ? AppliedRules.collect("attack:maximum", this.actor, this.item).filterWith(data).resolve(data).toSmallest()
         : undefined,
       minimum: this.actor
         ? AppliedRules.collect("attack:minimum", this.actor, this.item).filterWith(data).resolve(data).toLargest()
         : undefined,
-    };
+    }, config.options ?? {});
     if ( ammunition !== undefined ) options.ammunition = ammunition;
     if ( attackMode !== undefined ) options.attackMode = attackMode;
     if ( mastery !== undefined ) options.mastery = mastery;

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -123,11 +123,13 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
       this.actor.system, [],
       AppliedRules.collect("attack:advantage", this.actor, this.item).filterWith(rollData).toAdvantageCounts()
     ) : {};
+    const { maximum, minimum } = this.actor
+      ? AppliedRules.collect("attack:range", this.actor, this.item).filterWith(rollData).toRange() : {}
 
     rollConfig.hookNames = [...(config.hookNames ?? []), "attack", "d20Test"];
     rollConfig.rolls = [CONFIG.Dice.D20Roll.mergeConfigs({
       options: {
-        advantage, disadvantage,
+        advantage, disadvantage, maximum, minimum,
         ammunition: rollConfig.ammunition,
         attackMode: rollConfig.attackMode,
         criticalSuccess: this.criticalThreshold,

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1327,7 +1327,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const relevant = type === "skill" ? this.system.skills?.[config.skill] : this.system.tools?.[config.tool];
     const alternate = type === "skill" ? this.system.tools?.[config.tool] : this.system.skills?.[config.skill];
     const abilityId = config.ability ?? relevant?.ability ?? (type === "skill" ? skillConfig.ability : toolConfig.ability);
-    const ability = this.system.abilities?.[abilityId];
     const hostActor = this.isPolymorphed && this.flags?.dnd5e?.transformOptions?.mergeSkills && (type === "skill")
       ? game.actors.get(this.flags.dnd5e?.originalActor) : null;
     const buildConfig = this._buildSkillToolConfig.bind(this, type, hostActor);
@@ -1454,15 +1453,14 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     // Add condition reductions.
     this.addConditionRollReduction(parts, data);
 
-    config.options = {
-      ...(config.options ?? {}),
+    config.options = foundry.utils.mergeObject({
       maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).resolve(rollData).toSmallest(
         Math.min(relevant?.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity)
       ),
       minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).resolve(rollData).toLargest(
         Math.max(relevant?.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
       )
-    };
+    }, config.options ?? {});
     config.parts = [...(config.parts ?? []), ...parts];
     config.data = { ...data, ...(config.data ?? {}) };
     config.data.abilityId = abilityId;

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1357,12 +1357,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       reliableTalent: (relevant?.value >= 1) && this.getFlag("dnd5e", "reliableTalent")
     }, config);
     rollConfig.hookNames = [...(config.hookNames ?? []), type, "abilityCheck", "d20Test"];
-    rollConfig.rolls = [CONFIG.Dice.D20Roll.mergeConfigs({
-      options: AppliedRules.collect("check:range", this).filterWith(rollData).toRange({
-        maximum: Math.min(relevant?.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity),
-        minimum: Math.max(relevant?.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
-      })
-    }, config.rolls?.shift())].concat(config.rolls ?? []);
+    rollConfig.rolls = [CONFIG.Dice.D20Roll.mergeConfigs({ options: {} }, config.rolls?.shift())]
+      .concat(config.rolls ?? []);
     rollConfig.subject = this;
 
     const dialogConfig = foundry.utils.mergeObject({
@@ -1458,6 +1454,15 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     // Add condition reductions.
     this.addConditionRollReduction(parts, data);
 
+    config.options = {
+      ...(config.options ?? {}),
+      maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).toSmallest(
+        Math.min(relevant?.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity)
+      ),
+      minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).toLargest(
+        Math.max(relevant?.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
+      )
+    };
     config.parts = [...(config.parts ?? []), ...parts];
     config.data = { ...data, ...(config.data ?? {}) };
     config.data.abilityId = abilityId;
@@ -1570,14 +1575,13 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       cover: (config.ability === "dex") && (type === "save") ? this.system.attributes?.ac?.cover : null
     }, rollData);
 
+    const { advantage, disadvantage } = AdvantageModeField.combineFields(this.system, [
+      `abilities.${config.ability}.${type}.roll.mode`
+    ], AppliedRules.collect(`${type}:advantage`, this).filterWith(rollData).toAdvantageCounts());
     const options = {
-      ...AdvantageModeField.combineFields(this.system, [
-        `abilities.${config.ability}.${type}.roll.mode`
-      ], AppliedRules.collect(`${type}:advantage`, this).filterWith(rollData).toAdvantageCounts()),
-      ...AppliedRules.collect(`${type}:range`, this).filterWith(rollData).toRange({
-        maximum: ability?.[type]?.roll.max,
-        minimum: ability?.[type]?.roll.min
-      })
+      advantage, disadvantage,
+      maximum: AppliedRules.collect(`${type}:maximum`, this).filterWith(rollData).toSmallest(ability?.[type]?.roll.max),
+      minimum: AppliedRules.collect(`${type}:minimum`, this).filterWith(rollData).toLargest(ability?.[type]?.roll.min)
     };
 
     const rollConfig = foundry.utils.mergeObject({
@@ -1919,10 +1923,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       fixed: useScore ? init.score : undefined,
       flavor: options.flavor ?? _loc("DND5E.Initiative"),
       halflingLucky: flags.halflingLucky ?? false,
-      ...AppliedRules.collect("check:range", this).filterWith(rollData).toRange({
-        maximum: Math.min(init.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity),
-        minimum: Math.max(init.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
-      })
+      maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).toSmallest(
+        Math.min(init.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity)
+      ),
+      minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).toLargest(
+        Math.max(init.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
+      )
     }, options);
 
     const rollConfig = { parts, data, options, subject: this };

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1358,10 +1358,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }, config);
     rollConfig.hookNames = [...(config.hookNames ?? []), type, "abilityCheck", "d20Test"];
     rollConfig.rolls = [CONFIG.Dice.D20Roll.mergeConfigs({
-      options: {
+      options: AppliedRules.collect("check:range", this).filterWith(rollData).toRange({
         maximum: Math.min(relevant?.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity),
         minimum: Math.max(relevant?.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
-      }
+      })
     }, config.rolls?.shift())].concat(config.rolls ?? []);
     rollConfig.subject = this;
 
@@ -1570,13 +1570,14 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       cover: (config.ability === "dex") && (type === "save") ? this.system.attributes?.ac?.cover : null
     }, rollData);
 
-    const { advantage, disadvantage } = AdvantageModeField.combineFields(this.system, [
-      `abilities.${config.ability}.${type}.roll.mode`
-    ], AppliedRules.collect(`${type}:advantage`, this).filterWith(rollData).toAdvantageCounts());
     const options = {
-      advantage, disadvantage,
-      maximum: ability?.[type]?.roll.max,
-      minimum: ability?.[type]?.roll.min
+      ...AdvantageModeField.combineFields(this.system, [
+        `abilities.${config.ability}.${type}.roll.mode`
+      ], AppliedRules.collect(`${type}:advantage`, this).filterWith(rollData).toAdvantageCounts()),
+      ...AppliedRules.collect(`${type}:range`, this).filterWith(rollData).toRange({
+        maximum: ability?.[type]?.roll.max,
+        minimum: ability?.[type]?.roll.min
+      })
     };
 
     const rollConfig = foundry.utils.mergeObject({
@@ -1918,8 +1919,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       fixed: useScore ? init.score : undefined,
       flavor: options.flavor ?? _loc("DND5E.Initiative"),
       halflingLucky: flags.halflingLucky ?? false,
-      maximum: Math.min(init.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity),
-      minimum: Math.max(init.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
+      ...AppliedRules.collect("check:range", this).filterWith(rollData).toRange({
+        maximum: Math.min(init.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity),
+        minimum: Math.max(init.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
+      })
     }, options);
 
     const rollConfig = { parts, data, options, subject: this };

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1456,10 +1456,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     config.options = {
       ...(config.options ?? {}),
-      maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).toSmallest(
+      maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).resolve(rollData).toSmallest(
         Math.min(relevant?.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity)
       ),
-      minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).toLargest(
+      minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).resolve(rollData).toLargest(
         Math.max(relevant?.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
       )
     };
@@ -1580,8 +1580,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     ], AppliedRules.collect(`${type}:advantage`, this).filterWith(rollData).toAdvantageCounts());
     const options = {
       advantage, disadvantage,
-      maximum: AppliedRules.collect(`${type}:maximum`, this).filterWith(rollData).toSmallest(ability?.[type]?.roll.max),
-      minimum: AppliedRules.collect(`${type}:minimum`, this).filterWith(rollData).toLargest(ability?.[type]?.roll.min)
+      maximum: AppliedRules.collect(`${type}:maximum`, this).filterWith(rollData).resolve(rollData).toSmallest(
+        ability?.[type]?.roll.max
+      ),
+      minimum: AppliedRules.collect(`${type}:minimum`, this).filterWith(rollData).resolve(rollData).toLargest(
+        ability?.[type]?.roll.min
+      )
     };
 
     const rollConfig = foundry.utils.mergeObject({
@@ -1923,10 +1927,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       fixed: useScore ? init.score : undefined,
       flavor: options.flavor ?? _loc("DND5E.Initiative"),
       halflingLucky: flags.halflingLucky ?? false,
-      maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).toSmallest(
+      maximum: AppliedRules.collect("check:maximum", this).filterWith(rollData).resolve(rollData).toSmallest(
         Math.min(init.roll.max ?? Infinity, ability?.check.roll.max ?? Infinity)
       ),
-      minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).toLargest(
+      minimum: AppliedRules.collect("check:minimum", this).filterWith(rollData).resolve(rollData).toLargest(
         Math.max(init.roll.min ?? -Infinity, ability?.check.roll.min ?? -Infinity)
       )
     }, options);

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -2,6 +2,7 @@ const D20_TESTS = new Set(["attack", "check", "save"]);
 
 /**
  * @import { AdvantageModeData } from "../data/fields/_types.mjs";
+ * @import { RollRange } from "../dice/_types.mjs";
  */
 
 /**
@@ -56,6 +57,11 @@ export default class AppliedRules extends Map {
   static *#collect(rule, actor, item) {
     const [category, key] = rule.split(":");
     if ( D20_TESTS.has(category) ) yield* AppliedRules.#collect(`d20:${key}`, actor, item);
+    if ( key === "range" ) {
+      yield* AppliedRules.#collect(`${category}:maximum`, actor, item);
+      yield* AppliedRules.#collect(`${category}:minimum`, actor, item);
+      return;
+    }
     for ( const r of actor?.appliedRules.get(rule) ?? [] ) yield r;
     for ( const r of item?.appliedRules.get(rule) ?? [] ) yield r;
   }
@@ -171,6 +177,45 @@ class RulesIterator extends Iterator {
    */
   toFormula() {
     return this.values(String).toArray().join(" + ");
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Find the highest value among all of the provided rules, or `-Infinity` if no rules are available.
+   * @param {number} [initial]  Starting value to compare against.
+   * @returns {number}
+   */
+  toLargest(initial) {
+    return this.values(Number).reduce((max, value) => value > max ? value : max, initial ?? -Infinity);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Find the minimum and maximum limit among all of the provided rules.
+   * @param {Partial<RollRange>} [range]  Initial range to fine tune.
+   * @returns {RollRange}
+   */
+  toRange(range) {
+    return this.reduce((range, rule) => {
+      const value = Number(rule.value);
+      if ( !Number.isFinite(value) ) return range;
+      if ( (rule.type === "dnd5e.maximum") && (value < range.maximum) ) range.maximum = value;
+      if ( (rule.type === "dnd5e.minimum") && (value > range.minimum) ) range.minimum = value;
+      return range;
+    }, { maximum: range?.maximum ?? Infinity, minimum: range?.minimum ?? -Infinity });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Find the lowest value among all of the provided rules, or `Infinity` if no rules are available.
+   * @param {number} [initial]  Starting value to compare against.
+   * @returns {number}
+   */
+  toSmallest(initial) {
+    return this.values(Number).reduce((min, value) => value < min ? value : min, initial ?? Infinity);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -2,7 +2,6 @@ const D20_TESTS = new Set(["attack", "check", "save"]);
 
 /**
  * @import { AdvantageModeData } from "../data/fields/_types.mjs";
- * @import { RollRange } from "../dice/_types.mjs";
  */
 
 /**
@@ -57,11 +56,6 @@ export default class AppliedRules extends Map {
   static *#collect(rule, actor, item) {
     const [category, key] = rule.split(":");
     if ( D20_TESTS.has(category) ) yield* AppliedRules.#collect(`d20:${key}`, actor, item);
-    if ( key === "range" ) {
-      yield* AppliedRules.#collect(`${category}:maximum`, actor, item);
-      yield* AppliedRules.#collect(`${category}:minimum`, actor, item);
-      return;
-    }
     for ( const r of actor?.appliedRules.get(rule) ?? [] ) yield r;
     for ( const r of item?.appliedRules.get(rule) ?? [] ) yield r;
   }
@@ -188,23 +182,6 @@ class RulesIterator extends Iterator {
    */
   toLargest(initial) {
     return this.values(Number).reduce((max, value) => value > max ? value : max, initial ?? -Infinity);
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Find the minimum and maximum limit among all of the provided rules.
-   * @param {Partial<RollRange>} [range]  Initial range to fine tune.
-   * @returns {RollRange}
-   */
-  toRange(range) {
-    return this.reduce((range, rule) => {
-      const value = Number(rule.value);
-      if ( !Number.isFinite(value) ) return range;
-      if ( (rule.type === "dnd5e.maximum") && (value < range.maximum) ) range.maximum = value;
-      if ( (rule.type === "dnd5e.minimum") && (value > range.minimum) ) range.minimum = value;
-      return range;
-    }, { maximum: range?.maximum ?? Infinity, minimum: range?.minimum ?? -Infinity });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -205,7 +205,7 @@ class RulesIterator extends Iterator {
    * @returns {RulesIterator<number>}
    */
   resolve(data) {
-    return new RulesIterator(this.values(String).map(v => simplifyBonus(v, data)));
+    return new RulesIterator(this.values(String).map(v => simplifyBonus(v, data)).filter(v => v));
   }
 
   /* -------------------------------------------- */

--- a/module/documents/applied-rules.mjs
+++ b/module/documents/applied-rules.mjs
@@ -1,8 +1,10 @@
-const D20_TESTS = new Set(["attack", "check", "save"]);
+import { simplifyBonus } from "../utils.mjs";
 
 /**
  * @import { AdvantageModeData } from "../data/fields/_types.mjs";
  */
+
+const D20_TESTS = new Set(["attack", "check", "save"]);
 
 /**
  * @extends {Map<string, Map<string, ChangeData[]>>}
@@ -51,7 +53,7 @@ export default class AppliedRules extends Map {
    * @param {string} rule      Rule target and type separated by a colon (e.g. "attack:bonus").
    * @param {Actor5e} [actor]  Actor from which to fetch the rules.
    * @param {Item5e} [item]    Item from which to fetch the rules.
-   * @yields {ChangeData}
+   * @yields {ActiveEffectChangeData}
    */
   static *#collect(rule, actor, item) {
     const [category, key] = rule.split(":");
@@ -67,7 +69,7 @@ export default class AppliedRules extends Map {
    * @param {string} rule      Rule target and type separated by a colon (e.g. "attack:bonus").
    * @param {Actor5e} [actor]  Actor from which to fetch the rules.
    * @param {Item5e} [item]    Item from which to fetch the rules.
-   * @returns {RulesIterator}
+   * @returns {RulesIterator<ActiveEffectChangeData>}
    */
   static collect(rule, actor, item) {
     return new RulesIterator(AppliedRules.#collect(rule, actor, item));
@@ -78,7 +80,7 @@ export default class AppliedRules extends Map {
   /**
    * Create a rules iterator from an iterable object.
    * @param {Iterable<ActiveEffectChangeData>} rules  Some kind of iterable object containing rules.
-   * @returns {RulesIterator}
+   * @returns {RulesIterator<ActiveEffectChangeData>}
    */
   static createIterator(rules) {
     return new RulesIterator(Iterator.from(rules));
@@ -118,7 +120,7 @@ class RulesIterator extends Iterator {
    * @param {RollData} rollData
    * @param {object} [options={}]
    * @param {Set<ActiveEffectChangeData>} [options.consumed]  Set of consumed rules to skip, selected rules added to.
-   * @returns {RulesIterator}
+   * @returns {RulesIterator<ActiveEffectChangeData>}
    */
   filterWith(rollData, { consumed }={}) {
     return new RulesIterator(this.filter(r => {
@@ -198,9 +200,20 @@ class RulesIterator extends Iterator {
   /* -------------------------------------------- */
 
   /**
+   * Use `simplifyBonus` to deterministically resolve all values.
+   * @param {object} data  Data to use for replacing @ strings.
+   * @returns {RulesIterator<number>}
+   */
+  resolve(data) {
+    return new RulesIterator(this.values(String).map(v => simplifyBonus(v, data)));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Transform each rule element into its underlying value.
    * @param {Number|String} [type]  Transform value into specific primitive type.
-   * @returns {RulesIterator}
+   * @returns {RulesIterator<any>}
    */
   values(type) {
     return new RulesIterator(


### PR DESCRIPTION
Adds a new "Maximum" and "Minimum" rule change types to target D20 rolls. These can be grabbed individually, or combined into one set of rules using the `range` key. The `toRange` method is then used to combine these into a final range.

### Todo
- [ ] Implement roll ranges for non-d20 rolls (such as Hit Dice)