### PR TITLE
Coerce strings that look like bools or numbers into booleans or numbers when applying unguided AEs

### DIFF
--- a/module/applications/active-effect/effect-change-config.mjs
+++ b/module/applications/active-effect/effect-change-config.mjs
@@ -156,6 +156,9 @@ export default class EffectChangeConfig extends DocumentSheet5e {
     const change = changes.find(c => c._id === this.options.changeId);
     if ( !change ) return;
     foundry.utils.mergeObject(change, foundry.utils.expandObject(formData.object));
+    try {
+      if (typeof change.value === "string") change.value &&= JSON.parse(change.value);
+    } catch{}
     this.effect.update({ "system.changes": changes });
   }
 }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -498,12 +498,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       return { [change.key]: this.applyChangeField(actor, change, { field }) };
     }
 
-    // Coerce boolean-like or number-like strings into booleans or numeric values
-    if ( change.key.startsWith("flags.") ) {
-      if ( ["true", "false"].includes(change.value) ) change.value = change.value === "true";
-      else if ( Number.isFinite(Number(change.value)) ) change.value = Number(change.value);
-    }
-
     super._applyChangeUnguided(actor, change, changes, { replacementData });
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -498,6 +498,12 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       return { [change.key]: this.applyChangeField(actor, change, { field }) };
     }
 
+    // Coerce boolean-like or number-like strings into booleans or numeric values
+    if ( change.key.startsWith("flags.") ) {
+      if ( ["true", "false"].includes(change.value) ) change.value = change.value === "true";
+      else if ( Number.isFinite(Number(change.value)) ) change.value = Number(change.value);
+    }
+
     super._applyChangeUnguided(actor, change, changes, { replacementData });
   }
 


### PR DESCRIPTION
Currently, using `flags.world.foo | override | true` results in `Actor#flags.world.foo === "true"` and similar applies when using numeric-like values.

~~This changes it such that if the change is unguided (not targeting a datafield) but target `flags`, it is attempted to be coerced into a boolean or number.~~

This helps with the new conditionals as currently something like this is not possible:

```
flags.world.foo | Override | true
```
and a different change with
```
k: "flags.world.foo",
o: "exact",
v: true
```

(Note: in conjunction with #7257)


e: The second commit reduces this to simply parsing effect values when submitting changes.