### PR TITLE
Implement falling automation

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -70,6 +70,7 @@ Hooks.once("init", function() {
   CONFIG.Actor.documentClass = documents.Actor5e;
   CONFIG.Adventure.documentClass = documents.Adventure5e;
   CONFIG.Canvas.layers.tokens.layerClass = canvas.layers.TokenLayer5e;
+  CONFIG.Canvas.vfx.enabled = true;
   CONFIG.ChatMessage.documentClass = documents.ChatMessage5e;
   CONFIG.Combat.documentClass = documents.Combat5e;
   CONFIG.Combatant.documentClass = documents.Combatant5e;

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -28,6 +28,7 @@ import * as inserts from "./module/inserts.mjs";
 import * as migrations from "./module/migration.mjs";
 import { registerModuleData, registerModuleRedirects, setupModulePacks } from "./module/module-registration.mjs";
 import { default as registry } from "./module/registry.mjs";
+import * as rules from "./module/rules/_module.mjs";
 import Tooltips5e from "./module/tooltips.mjs";
 import * as utils from "./module/utils.mjs";
 import DragDrop5e from "./module/drag-drop.mjs";
@@ -48,6 +49,7 @@ globalThis.dnd5e = {
   inserts,
   migrations,
   registry,
+  rules,
   ui: {},
   utils
 };

--- a/lang/en.json
+++ b/lang/en.json
@@ -6606,6 +6606,10 @@
 "SETTINGS.5eGridAlignedSquareTemplatesN": "Grid-Aligned Square Templates",
 "SETTINGS.DND5E": {
   "AUTOMATION": {
+    "Falling": {
+      "Name": "Disable Falling Automation",
+      "Hint": "Do not track the falling status of tokens."
+    },
     "Movement": {
       "Name": "Movement Automation",
       "Hint": "Configure the amount of movement automation used by the system: Full automation including token blocking, partial automation of difficult terrain only, or off entirely.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3216,6 +3216,10 @@
   }
 },
 
+"DND5E.FALLING": {
+  "DamageFlavor": "Fell {distance}"
+},
+
 "DND5E.Favorite": "Favorite",
 "DND5E.FavoriteDrop": "Drop Favorite",
 "DND5E.FavoriteRemove": "Remove Favorite",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3217,7 +3217,11 @@
 },
 
 "DND5E.FALLING": {
-  "DamageFlavor": "Fell {distance}"
+  "DamageFlavor": "Fell {distance}",
+  "MovementAction": "Fall",
+  "Warning": {
+    "NoLandingSurface": "Cannot plummet {name}, there is no surface below them."
+  }
 },
 
 "DND5E.Favorite": "Favorite",

--- a/module/canvas/_module.mjs
+++ b/module/canvas/_module.mjs
@@ -1,7 +1,7 @@
 export {default as BasePlacement} from "./api/base-placement.mjs";
 export * as detectionModes from "./detection-modes/_module.mjs";
 export * as layers from "./layers/_module.mjs";
-export {playLandingVfx} from "./landing-vfx.mjs";
+export * as vfx from "./vfx/_module.mjs";
 export {default as MapLocationControlIcon} from "./map-location-control-icon.mjs";
 export {default as Note5e} from "./note.mjs";
 export {default as TemplatePlacement} from "./template-placement.mjs";

--- a/module/canvas/_module.mjs
+++ b/module/canvas/_module.mjs
@@ -1,6 +1,7 @@
 export {default as BasePlacement} from "./api/base-placement.mjs";
 export * as detectionModes from "./detection-modes/_module.mjs";
 export * as layers from "./layers/_module.mjs";
+export {playLandingVfx} from "./landing-vfx.mjs";
 export {default as MapLocationControlIcon} from "./map-location-control-icon.mjs";
 export {default as Note5e} from "./note.mjs";
 export {default as TemplatePlacement} from "./template-placement.mjs";

--- a/module/canvas/landing-vfx.mjs
+++ b/module/canvas/landing-vfx.mjs
@@ -1,0 +1,79 @@
+/**
+ * @import TokenDocument5e from "../documents/token.mjs";
+ */
+
+/**
+ * Tint particles so that they look like dust.
+ * @type {number[]}
+ */
+const DUST_TINTS = [0x6B5238, 0x4A3826, 0x2A1E14];
+
+/* -------------------------------------------- */
+
+/**
+ * Play a dust-burst and camera shake when a token lands after a plummet.
+ * @param {TokenDocument5e} token  The token that just landed.
+ * @param {number} distance        The distance fallen, in scene grid units.
+ * @returns {Promise<boolean>|void}
+ */
+export function playLandingVfx(token, distance) {
+  if ( !canvas.ready || !CONFIG.Canvas.vfx?.enabled ) return;
+  if ( distance <= 0 ) return;
+
+  const center = token.getCenterPoint();
+  const gridSize = canvas.grid?.size ?? 100;
+  const sceneUnitPx = gridSize / (canvas.dimensions?.distance || 5);
+  const distancePx = distance * sceneUnitPx;
+  const tokenSize = Math.max(token.width, token.height) * gridSize;
+
+  const radius = Math.clamp((tokenSize * .5) + (distancePx * .05), 40, 200);
+  const count = Math.clamp(2_500 + Math.floor(distance * 60), 2_500, 10_000);
+  const shake = {
+    amp: Math.clamp(distance * .4, 0, 18),
+    ms: Math.clamp(180 + (distance * 4), 180, 600)
+  };
+  shake.enabled = shake.amp > 1;
+
+  const components = {
+    dust: {
+      count,
+      area: { reference: "burst" },
+      config: {
+        alpha: [.95, 1],
+        manual: false,
+        onSpawn: p => {
+          p.texture = PIXI.Texture.WHITE;
+          p.tint = DUST_TINTS[(Math.random() * DUST_TINTS.length) | 0];
+        },
+        rotation: [0, 360],
+        velocity: { angle: [0, 360], speed: [10, 50] }
+      },
+      duration: 200,
+      fade: { in: 50, out: 400 },
+      initial: 1,
+      lifetime: { max: 950, min: 450 },
+      mode: "effect",
+      // PIXI.Texture.WHITE is 16x16, so rendered size = scale * 16. This range yields ~1-2 px grains.
+      scale: { max: .15, min: .1 },
+      // Required to satisfy VFXParticleGeneratorComponent's 'no valid textures' guard. The actual texture used at
+      // render time is set per-particle to PIXI.Texture.WHITE in `config.onSpawn`.
+      textures: ["ui/particles/snow.png"],
+      type: "particleGenerator"
+    }
+  };
+  const timeline = [{ component: "dust", position: 0 }];
+
+  if ( shake.enabled ) {
+    components.shake = {
+      duration: shake.ms,
+      maxDisplacement: shake.amp,
+      smoothness: .5,
+      target: "stage",
+      type: "shake"
+    };
+    timeline.push({ component: "shake", position: 0 });
+  }
+
+  const effect = new foundry.canvas.vfx.VFXEffect({ components, timeline, name: "dnd5e.landingDust" });
+  return effect.play({ burst: { radius, x: center.x, y: center.y } });
+}

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -3,6 +3,15 @@
  */
 export default class Token5e extends foundry.canvas.placeables.Token {
 
+  /** @inheritDoc */
+  static RENDER_FLAGS = {
+    ...super.RENDER_FLAGS,
+    // Elevation changes must also rescale the mesh, as tokens are scaled by their distance from the viewed level.
+    refreshElevation: { propagate: ["refreshTooltip", "refreshMesh"] }
+  };
+
+  /* -------------------------------------------- */
+
   /**
    * Update the token ring when this token is targeted.
    * @param {User5e} user         The user whose targeting has changed.
@@ -242,6 +251,23 @@ export default class Token5e extends foundry.canvas.placeables.Token {
   _configureFilterEffect(statusId, active) {
     if ( (statusId === CONFIG.specialStatusEffects.INVISIBLE) && this.hasDynamicRing ) active = false;
     return super._configureFilterEffect(statusId, active);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _refreshMeshSizeAndScale() {
+    super._refreshMeshSizeAndScale();
+    if ( !CONFIG.DND5E.elevationScaling || !canvas.level ) return;
+
+    // Calculate elevation relative to the viewed level so that tokens farther away from the 'camera' appear smaller.
+    const elevation = this.document.elevation - canvas.level.elevation.base;
+    if ( elevation >= 0 ) return; // Do not make 'closer' tokens bigger.
+
+    // Hyperbolic falloff.
+    const factor = Math.max(.5, 1 / (1 - (elevation / 90)));
+    this.mesh.scale.x *= factor;
+    this.mesh.scale.y *= factor;
   }
 
   /* -------------------------------------------- */

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -158,6 +158,7 @@ export default class Token5e extends foundry.canvas.placeables.Token {
   /** @inheritDoc */
   async _drawEffect(src, tint) {
     const icon = await super._drawEffect(src, tint);
+    if ( !game.user.isGM ) return icon;
     if ( icon && src && (src === CONFIG.statusEffects.falling?.img) ) {
       icon.eventMode = "static";
       icon.cursor = "pointer";

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -162,10 +162,13 @@ export default class Token5e extends foundry.canvas.placeables.Token {
     if ( icon && src && (src === CONFIG.statusEffects.falling?.img) ) {
       icon.eventMode = "static";
       icon.cursor = "pointer";
+      const baseTint = icon.tint;
       icon.on("pointerdown", event => {
         event.stopPropagation();
         this.document.plummet();
       });
+      icon.on("pointerover", () => icon.tint = 0xFF9500);
+      icon.on("pointerout", () => icon.tint = baseTint);
     }
     return icon;
   }

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -146,6 +146,22 @@ export default class Token5e extends foundry.canvas.placeables.Token {
 
   /* -------------------------------------------- */
 
+  /** @inheritDoc */
+  async _drawEffect(src, tint) {
+    const icon = await super._drawEffect(src, tint);
+    if ( icon && src && (src === CONFIG.statusEffects.falling?.img) ) {
+      icon.eventMode = "static";
+      icon.cursor = "pointer";
+      icon.on("pointerdown", event => {
+        event.stopPropagation();
+        this.document.plummet();
+      });
+    }
+    return icon;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * Specialized drawing function for HP bars.
    * @param {number} number      The Bar number

--- a/module/canvas/vfx/_module.mjs
+++ b/module/canvas/vfx/_module.mjs
@@ -1,0 +1,1 @@
+export { playLandingVfx } from "./landing-vfx.mjs";

--- a/module/canvas/vfx/landing-vfx.mjs
+++ b/module/canvas/vfx/landing-vfx.mjs
@@ -18,7 +18,7 @@ const DUST_TINTS = [0x6B5238, 0x4A3826, 0x2A1E14];
  */
 export function playLandingVfx(token, distance) {
   if ( !canvas.ready || !CONFIG.Canvas.vfx?.enabled ) return;
-  if ( distance <= 0 ) return;
+  if ( (distance <= 0) || matchMedia("(prefers-reduced-motion: reduce)").matches ) return;
 
   const center = token.getCenterPoint();
   const gridSize = canvas.grid?.size ?? 100;

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3933,6 +3933,14 @@ DND5E.falling = {
 /* -------------------------------------------- */
 
 /**
+ * Visually scale tokens smaller the farther they are below the viewed level, to convey depth.
+ * @type {boolean}
+ */
+DND5E.elevationScaling = true;
+
+/* -------------------------------------------- */
+
+/**
  * System provided active effect change types.
  * @enum {ActiveEffectChangeTypeConfig & { [group]: string, [skipConditions]: boolean }}
  */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3919,6 +3919,20 @@ DND5E.bloodied = {
 /* -------------------------------------------- */
 
 /**
+ * Configuration for falling damage. A creature takes `damageDie` of `damageType` damage for every whole
+ * `distancePerDie` feet it falls, up to a maximum of `maximumDice` dice.
+ * @type {{ damageDie: string, damageType: string, distancePerDie: number, maximumDice: number }}
+ */
+DND5E.falling = {
+  damageDie: "d6",
+  damageType: "bludgeoning",
+  distancePerDie: 10,
+  maximumDice: 20
+};
+
+/* -------------------------------------------- */
+
+/**
  * System provided active effect change types.
  * @enum {ActiveEffectChangeTypeConfig & { [group]: string, [skipConditions]: boolean }}
  */

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -1,6 +1,6 @@
-import ActiveEffect5e from "../../../documents/active-effect.mjs";
 import Proficiency from "../../../documents/actor/proficiency.mjs";
 import AppliedRules from "../../../documents/applied-rules.mjs";
+import { applyFallProne } from "../../../rules/falling.mjs";
 import { convertLength, convertWeight, defaultUnits, replaceFormulaData, simplifyBonus } from "../../../utils.mjs";
 import AdvantageModeField from "../../fields/advantage-mode-field.mjs";
 import ConditionData from "../../active-effect/condition.mjs";
@@ -671,6 +671,7 @@ export default class AttributesFields {
     if ( userId === game.userId ) {
       await this.parent.updateBloodied(options);
       await this.parent.updateDowned(options);
+      await applyFallProne(this.parent, options);
     }
 
     const hp = options.dnd5e?.hp;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -10,6 +10,7 @@ const TextEditor = foundry.applications.ux.TextEditor.implementation;
 const { NumberField, ObjectField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
+ * @import Actor5e from "./actor/actor.mjs";
  * @import { FavoriteData5e } from "../data/abstract/_types.mjs";
  */
 
@@ -588,10 +589,10 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /* -------------------------------------------- */
 
   /**
-   * Create conditions that are applied separately from an effect.
-   * @returns {Promise<ActiveEffect5e[]>}      Created rider effects.
+   * Gather batch entries for conditions that are applied separately from an effect.
+   * @returns {Promise<DatabaseWriteOperation[]>}  Batch entries suitable for `foundry.documents.modifyBatch`.
    */
-  async createRiderConditions() {
+  async collectRiderConditions() {
     const riders = new Set(this.system.rider?.statuses ?? []);
 
     for ( const status of this.statuses ) {
@@ -608,17 +609,19 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       return effect.toObject();
     };
 
-    const effectData = await Promise.all(Array.from(riders).map(createRider));
-    return ActiveEffect5e.createDocuments(effectData.filter(_ => _), { keepId: true, parent: this.parent });
+    const data = (await Promise.all(Array.from(riders).map(createRider))).filter(_ => _);
+    if ( !data.length ) return [];
+    return [{ action: "create", documentName: "ActiveEffect", data, parent: this.parent, keepId: true }];
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Create additional activities, effects, and items that are applied separately from an enchantment.
-   * @param {object} options  Options passed to the effect creation.
+   * Gather batch entries for additional activities, effects, and items applied separately from an enchantment.
+   * @param {object} options                       Options passed to the effect creation.
+   * @returns {Promise<DatabaseWriteOperation[]>}  Batch entries suitable for `foundry.documents.modifyBatch`.
    */
-  async createRiderEnchantments(options={}) {
+  async collectRiderEnchantments(options={}) {
     const batchedUpdates = [];
     let item;
     let profile;
@@ -643,7 +646,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       profile = activity?.effects.find(e => e._id === enchantmentProfile);
     }
 
-    if ( !profile || !item ) return;
+    if ( !profile || !item ) return [];
 
     // Create Activities
     const riderActivities = {};
@@ -698,7 +701,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       });
     }
 
-    await foundry.documents.modifyBatch(batchedUpdates);
+    return batchedUpdates;
   }
 
   /* -------------------------------------------- */
@@ -734,27 +737,14 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /* -------------------------------------------- */
 
-  /** @inheritDoc */
-  async _onCreate(data, options, userId) {
-    super._onCreate(data, options, userId);
-    if ( userId === game.userId ) {
-      if ( this.active && (this.parent instanceof Actor) ) await this.createRiderConditions();
-      if ( this.isAppliedEnchantment ) await this.createRiderEnchantments(options);
-      await this.#updateFalling();
-    }
-  }
-
-  /* -------------------------------------------- */
-
   /**
-   * Re-evaluate whether the actor should be falling after this effect was applied or removed. A creature that becomes
-   * prone or incapacitated while airborne starts falling unless it can hover.
+   * Re-evaluate whether an actor should have the falling status. A creature that becomes prone or incapacitated while
+   * airborne starts falling unless it can hover.
+   * @param {Actor5e} actor  The actor to re-evaluate.
    * @returns {Promise<void>}
    */
-  async #updateFalling() {
-    if ( dnd5e.settings.disableFalling || this.statuses.has("falling") ) return;
-    const actor = this.parent;
-    if ( !(actor instanceof Actor) ) return;
+  static async #updateFalling(actor) {
+    if ( dnd5e.settings.disableFalling || !(actor instanceof Actor) ) return;
     const falling = actor.statuses.has("falling");
     if ( !falling && !actor.statuses.has("prone") && !actor.statuses.has("incapacitated") ) return;
     const shouldFall = actor.getActiveTokens(false, true).some(token => token._isFalling());
@@ -768,16 +758,22 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   static async _onCreateOperation(documents, operation, user) {
     await super._onCreateOperation(documents, operation, user);
     if ( user.id !== game.userId ) return;
-    // Prompt to end concentration at most once per actor, even when several incapacitating effects are created in the
-    // same operation.
+    const batch = [];
+    const actors = new Set();
     const prompted = new Set();
     for ( const effect of documents ) {
-      if ( !effect._shouldPromptConcentrationEnd() ) continue;
-      const actor = effect.parent;
-      if ( prompted.has(actor) ) continue;
-      prompted.add(actor);
-      await actor.promptConcentrationEnd();
+      if ( effect._shouldPromptConcentrationEnd() && !prompted.has(effect.parent) ) {
+        prompted.add(effect.parent);
+        await effect.parent.promptConcentrationEnd();
+      }
+      if ( effect.active && (effect.parent instanceof Actor) ) {
+        batch.push(...await effect.collectRiderConditions());
+        actors.add(effect.parent);
+      }
+      if ( effect.isAppliedEnchantment ) batch.push(...await effect.collectRiderEnchantments(operation));
     }
+    if ( batch.length ) await foundry.documents.modifyBatch(batch);
+    for ( const actor of actors ) await ActiveEffect5e.#updateFalling(actor);
   }
 
   /* -------------------------------------------- */
@@ -831,10 +827,29 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _onDelete(options, userId) {
-    super._onDelete(options, userId);
-    if ( game.user === game.users.activeGM ) this.getDependents().forEach(e => e.delete());
-    if ( userId === game.userId ) this.#updateFalling();
+  static async _onDeleteOperation(documents, operation, user) {
+    await super._onDeleteOperation(documents, operation, user);
+    if ( game.user === game.users.activeGM ) {
+      const dependents = new Map();
+      for ( const effect of documents ) {
+        for ( const dependent of effect.getDependents() ) {
+          dependents.getOrInsert(dependent.parent, new Set()).add(dependent.id);
+        }
+      }
+      const batch = dependents.entries()
+        .map(([parent, ids]) => ({ action: "delete", documentName: "ActiveEffect", ids: [...ids], parent }))
+        .toArray();
+      if ( batch.length ) await foundry.documents.modifyBatch(batch);
+    }
+
+    if ( user.id !== game.userId ) return;
+
+    // Re-evaluate falling once per affected actor, since removing prone or incapacitating effects can end a fall.
+    const actors = new Set();
+    for ( const effect of documents ) {
+      if ( !effect.statuses.has("falling") && (effect.parent instanceof Actor) ) actors.add(effect.parent);
+    }
+    for ( const actor of actors ) await ActiveEffect5e.#updateFalling(actor);
   }
 
   /* -------------------------------------------- */
@@ -1261,5 +1276,44 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     }, dialogOptions);
     if ( sheet ) return sheet._confirmDialog(config);
     return foundry.applications.api.DialogV2.confirm(config);
+  }
+
+  /* -------------------------------------------- */
+  /*  Deprecations                                */
+  /* -------------------------------------------- */
+
+  /**
+   * Create conditions that are applied separately from an effect.
+   * @returns {Promise<ActiveEffect5e[]>}      Created rider effects.
+   * @deprecated since DnD5e 6.0
+   */
+  async createRiderConditions() {
+    foundry.utils.logCompatibilityWarning(
+      "The `createRiderConditions` method has been deprecated in favor of `collectRiderConditions`, which returns "
+      + "batch entries rather than creating documents.",
+      { since: "DnD5e 6.0", until: "DnD5e 6.2", once: true }
+    );
+    const created = [];
+    for ( const { data, keepId, parent } of await this.collectRiderConditions() ) {
+      created.push(...await ActiveEffect5e.createDocuments(data, { keepId, parent }));
+    }
+    return created;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Create additional activities, effects, and items that are applied separately from an enchantment.
+   * @param {object} options  Options passed to the effect creation.
+   * @deprecated since DnD5e 6.0
+   */
+  async createRiderEnchantments(options={}) {
+    foundry.utils.logCompatibilityWarning(
+      "The `createRiderEnchantments` method has been deprecated in favor of `collectRiderEnchantments`, which returns "
+      + "batch entries rather than applying them.",
+      { since: "DnD5e 6.0", until: "DnD5e 6.2", once: true }
+    );
+    const batch = await this.collectRiderEnchantments(options);
+    if ( batch.length ) await foundry.documents.modifyBatch(batch);
   }
 }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -740,7 +740,26 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( userId === game.userId ) {
       if ( this.active && (this.parent instanceof Actor) ) await this.createRiderConditions();
       if ( this.isAppliedEnchantment ) await this.createRiderEnchantments(options);
+      await this.#updateFalling();
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Re-evaluate whether the actor should be falling after this effect was applied or removed. A creature that becomes
+   * prone or incapacitated while airborne starts falling unless it can hover.
+   * @returns {Promise<void>}
+   */
+  async #updateFalling() {
+    if ( dnd5e.settings.disableFalling || this.statuses.has("falling") ) return;
+    const actor = this.parent;
+    if ( !(actor instanceof Actor) ) return;
+    const falling = actor.statuses.has("falling");
+    if ( !falling && !actor.statuses.has("prone") && !actor.statuses.has("incapacitated") ) return;
+    const shouldFall = actor.getActiveTokens(false, true).some(token => token._isFalling());
+    if ( shouldFall === falling ) return;
+    await actor.toggleStatusEffect("falling", { active: shouldFall });
   }
 
   /* -------------------------------------------- */
@@ -815,6 +834,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   _onDelete(options, userId) {
     super._onDelete(options, userId);
     if ( game.user === game.users.activeGM ) this.getDependents().forEach(e => e.delete());
+    if ( userId === game.userId ) this.#updateFalling();
   }
 
   /* -------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -769,7 +769,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       isBar: true
     }, updates) === false ) return this;
 
-    await this.update(updates);
+    const context = options.origin?.getFlag?.("dnd5e", "context");
+    await this.update(updates, context ? { dnd5e: context } : {});
 
     /**
      * A hook event that fires after damage has been applied to an actor.

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -363,6 +363,20 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Determine whether this token should be considered falling after its movement. Movement that ends with a fly or
+   * burrow action does not leave the token falling, regardless of elevation.
+   * @param {TokenMovementOperation} movement  The concluded movement.
+   * @returns {boolean}
+   */
+  #shouldFall(movement) {
+    const { action } = movement.passed.waypoints.at(-1) ?? {};
+    if ( (action === "fly") || (action === "burrow") ) return false;
+    return this._isHoveringAboveSurface({ position: movement.destination });
+  }
+
+  /* -------------------------------------------- */
   /*  Ring Animations                             */
   /* -------------------------------------------- */
 
@@ -449,6 +463,19 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
     if ( !this.parent?.isView ) return;
     this.reset();
     this.object?.initializeVisionSource();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onUpdateMovement(movement, operation, user) {
+    await super._onUpdateMovement(movement, operation, user);
+    if ( !user.isSelf || dnd5e.settings.disableFalling ) return;
+    const { actor } = this;
+    if ( !actor ) return;
+    const shouldFall = this.#shouldFall(movement);
+    if ( shouldFall === actor.statuses.has("falling") ) return;
+    await actor.toggleStatusEffect("falling", { active: shouldFall });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -1,4 +1,4 @@
-import { playLandingVfx } from "../canvas/landing-vfx.mjs";
+import { playLandingVfx } from "../canvas/vfx/landing-vfx.mjs";
 import { postFallDamage } from "../rules/falling.mjs";
 import SystemFlagsMixin from "./mixins/flags.mjs";
 
@@ -348,32 +348,31 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
   /* -------------------------------------------- */
 
   /**
-   * Determine whether this token is hovering above a movement-restricting surface in the current scene. Returns false
-   * when the token is on the ground, over a void with no surface below it, or is otherwise exempt from falling.
+   * Determine whether this token should be considered falling given a position and its actor's condition. A creature
+   * suspended in the air falls unless it can keep itself aloft, i.e. has a fly speed.
    * @param {object} [options]
    * @param {TokenCoordinates} [options.position]  The position to evaluate against. Defaults to the token's source
    *                                               position.
    * @returns {boolean}
    * @internal
    */
-  _isHoveringAboveSurface({ position=this._source }={}) {
+  _isFalling({ position=this._source }={}) {
     const { actor } = this;
     if ( !actor ) return false;
-    const { BURROW, FLY, HOVER } = CONFIG.specialStatusEffects;
-    let exempt = actor.statuses.has(BURROW);
-    exempt ||= actor.statuses.has(FLY);
-    exempt ||= actor.statuses.has(HOVER);
-    exempt ||= foundry.utils.getProperty(actor, "system.traits.ci.value")?.has("falling");
-    if ( exempt ) return false;
     const surface = this._findSupportingSurface({ position });
-    return !!surface && (surface.elevation < position.elevation);
+    if ( !surface || (surface.elevation >= position.elevation) ) return false;
+    if ( foundry.utils.getProperty(actor, "system.traits.ci.value")?.has("falling") ) return false;
+    const { hover, speeds } = actor.system.attributes?.movement ?? {};
+    if ( actor.statuses.has("prone") || actor.statuses.has("incapacitated") ) return !hover;
+    return !speeds?.fly;
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Plummet this token straight down to the highest movement-restricting surface beneath it, knocking it prone and
-   * posting fall damage to chat.
+   * Plummet this token straight down to the highest movement-restricting surface beneath it and post fall damage to
+   * chat. Landing prone is deferred to the point at which that damage is applied, as a creature is only knocked prone
+   * if the fall actually deals damage.
    * @returns {Promise<void>}
    */
   async plummet() {
@@ -391,22 +390,39 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
     if ( surface.level && (surface.level.id !== this._source.level) ) waypoint.level = surface.level.id;
     await this.move(waypoint, { animate: false, dnd5e: { fall: { distance } } });
     await actor.toggleStatusEffect("falling", { active: false });
-    await actor.toggleStatusEffect("prone", { active: true });
     await postFallDamage([this], distance);
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Determine whether this token should be considered falling after its movement. Movement that ends with a fly or
-   * burrow action does not leave the token falling, regardless of elevation.
+   * Determine whether this token should be considered falling after its movement. Movement that ends with a climb
+   * action, or that takes place while transiting a level-change region, is a deliberate reposition and does not leave
+   * the token falling.
    * @param {TokenMovementOperation} movement  The concluded movement.
    * @returns {boolean}
    */
   #shouldFall(movement) {
-    const { action } = movement.passed.waypoints.at(-1) ?? {};
-    if ( (action === "fly") || (action === "burrow") ) return false;
-    return this._isHoveringAboveSurface({ position: movement.destination });
+    if ( movement.passed.waypoints.at(-1)?.action === "climb" ) return false;
+    if ( this.#inLevelChangeRegion() ) return false;
+    return this._isFalling({ position: movement.destination });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Whether this token currently occupies a region that relocates tokens between levels, such as a ladder or
+   * stairwell. Such a region moves the token through open space to reach the destination level, and those transient
+   * airborne positions are part of the relocation rather than a fall.
+   * @returns {boolean}
+   */
+  #inLevelChangeRegion() {
+    for ( const region of this.regions ?? [] ) {
+      for ( const behavior of region.behaviors ) {
+        if ( !behavior.disabled && (behavior.type === "changeLevel") ) return true;
+      }
+    }
+    return false;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -1,3 +1,4 @@
+import { postFallDamage } from "../rules/falling.mjs";
 import SystemFlagsMixin from "./mixins/flags.mjs";
 
 /**
@@ -219,6 +220,20 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
     };
     CONFIG.Token.movement.actions.jump.deriveTerrainDifficulty = () => 1;
     CONFIG.Token.movement.actions.jump.getCostFunction = () => cost => cost;
+
+    // Falling is involuntary, so it cannot be selected by the user and never consumes movement.
+    CONFIG.Token.movement.actions.fall = {
+      canSelect: false,
+      costMultiplier: 0,
+      icon: "fa-solid fa-arrow-down-long",
+      img: "systems/dnd5e/icons/svg/statuses/falling.svg",
+      label: "DND5E.FALLING.MovementAction",
+      measure: false,
+      order: 9,
+      teleport: false,
+      terrainAction: null,
+      visualize: true
+    };
   }
 
   /* -------------------------------------------- */
@@ -240,6 +255,111 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
     return noAutomation || !actor?.system.isCreature || !hasMovement || speed || (!speed && !walkFallback)
       ? cost => cost
       : (cost, _from, _to, distance) => cost + distance;
+  }
+
+  /* -------------------------------------------- */
+  /*  Falling                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Find the highest movement-restricting surface at or below the given elevation whose 2D footprint contains at least
+   * 75% of this token's containment points. This is the surface the token is either standing on (when its elevation
+   * matches it) or hovering above. When no defined surface is found beneath the token, the floor of the lowest level
+   * visible from the token's own level is returned as a synthetic surface.
+   * @param {object} [options]
+   * @param {TokenCoordinates} [options.position]  The position to evaluate against. Defaults to the token's source
+   *                                               position.
+   * @returns {RegionSurface|{ region: null, elevation: number }|null}
+   * @internal
+   */
+  _findSupportingSurface({ position=this._source }={}) {
+    const scene = this.parent;
+    if ( !scene ) return null;
+    const { elevation, level } = position;
+    const surfaces = scene.getSurfaces({ level, type: "move" });
+
+    // Walk surfaces from highest to lowest and return the first whose footprint contains the required share of the
+    // token. Scene#getSurfaces already orders surfaces by elevation.
+    if ( surfaces.length ) {
+      const points = this.getContainmentTestPoints(position);
+      const required = Math.ceil(points.length * .75);
+      const allowedMisses = points.length - required;
+
+      for ( let i = surfaces.length; i--; ) {
+        const surface = surfaces[i];
+        if ( surface.elevation > elevation ) continue;
+        let inside = 0;
+        let missed = 0;
+        for ( const p of points ) {
+          if ( surface.region.polygonTree.testPoint(p) ) {
+            if ( ++inside >= required ) return surface;
+          } else if ( ++missed > allowedMisses ) {
+            break;
+          }
+        }
+      }
+    }
+
+    // No defined surface was found beneath the token. Fall back to the floor of the lowest level visible from the
+    // token's own level.
+    const ownLevel = scene.levels.get(level);
+    if ( !ownLevel ) return null;
+    let { base } = ownLevel.elevation;
+    for ( const id of ownLevel.visibility.levels ) {
+      const visible = scene.levels.get(id);
+      if ( visible ) base = Math.min(base, visible.elevation.base);
+    }
+    return elevation > base ? { region: null, elevation: base } : null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Determine whether this token is hovering above a movement-restricting surface in the current scene. Returns false
+   * when the token is on the ground, over a void with no surface below it, or is otherwise exempt from falling.
+   * @param {object} [options]
+   * @param {TokenCoordinates} [options.position]  The position to evaluate against. Defaults to the token's source
+   *                                               position.
+   * @returns {boolean}
+   * @internal
+   */
+  _isHoveringAboveSurface({ position=this._source }={}) {
+    const { actor } = this;
+    if ( !actor ) return false;
+    const { BURROW, FLY, HOVER } = CONFIG.specialStatusEffects;
+    let exempt = actor.statuses.has(BURROW);
+    exempt ||= actor.statuses.has(FLY);
+    exempt ||= actor.statuses.has(HOVER);
+    exempt ||= foundry.utils.getProperty(actor, "system.traits.ci.value")?.has("falling");
+    if ( exempt ) return false;
+    const surface = this._findSupportingSurface({ position });
+    return !!surface && (surface.elevation < position.elevation);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Plummet this token straight down to the highest movement-restricting surface beneath it, knocking it prone and
+   * posting fall damage to chat.
+   * @returns {Promise<void>}
+   */
+  async plummet() {
+    const { actor } = this;
+    if ( !actor?.statuses.has("falling") || !actor.canUserModify(game.user, "update") ) return;
+
+    const surface = this._findSupportingSurface();
+    if ( !surface || (surface.elevation >= this.elevation) ) {
+      ui.notifications.warn("DND5E.FALLING.Warning.NoLandingSurface", { format: { name: this.name } });
+      return;
+    }
+
+    const distance = this.elevation - surface.elevation;
+    await this.move({ action: "fall", elevation: surface.elevation }, {
+      animate: false, dnd5e: { fall: { distance } }
+    });
+    await actor.toggleStatusEffect("falling", { active: false });
+    await actor.toggleStatusEffect("prone", { active: true });
+    await postFallDamage([this], distance);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -263,25 +263,25 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
   /* -------------------------------------------- */
 
   /**
-   * Find the highest movement-restricting surface at or below the given elevation whose 2D footprint contains at least
-   * 75% of this token's containment points. This is the surface the token is either standing on (when its elevation
-   * matches it) or hovering above. When no defined surface is found beneath the token, the floor of the lowest level
-   * visible from the token's own level is returned as a synthetic surface.
+   * Find the supporting surface this token rests on or would fall onto, and the level it comes to rest on. A scene that
+   * defines any movement surface uses those surfaces as its only floors. As a heuristic to accommodate older scenes
+   * without levels or surfaces, the base of each level is considered a floor in scenes with no surfaces.
    * @param {object} [options]
    * @param {TokenCoordinates} [options.position]  The position to evaluate against. Defaults to the token's source
    *                                               position.
-   * @returns {RegionSurface|{ region: null, elevation: number }|null}
+   * @returns {{ elevation: number, region: RegionDocument|null, level: Level }|null}
    * @internal
    */
   _findSupportingSurface({ position=this._source }={}) {
     const scene = this.parent;
     if ( !scene ) return null;
     const { elevation, level } = position;
-    const surfaces = scene.getSurfaces({ level, type: "move" });
 
     // Walk surfaces from highest to lowest and return the first whose footprint contains the required share of the
     // token. Scene#getSurfaces already orders surfaces by elevation.
-    if ( surfaces.length ) {
+    if ( scene.getSurfaces({ type: "move" }).length ) {
+      const surfaces = scene.getSurfaces({ level, type: "move" });
+      if ( !surfaces.length ) return null;
       const points = this.getContainmentTestPoints(position);
       const required = Math.ceil(points.length * .75);
       const allowedMisses = points.length - required;
@@ -293,24 +293,56 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
         let missed = 0;
         for ( const p of points ) {
           if ( surface.region.polygonTree.testPoint(p) ) {
-            if ( ++inside >= required ) return surface;
+            if ( ++inside >= required ) return {
+              elevation: surface.elevation,
+              level: this.#findRestingLevel(surface.region, surface.elevation, level),
+              region: surface.region
+            };
           } else if ( ++missed > allowedMisses ) {
             break;
           }
         }
       }
+      return null;
     }
 
-    // No defined surface was found beneath the token. Fall back to the floor of the lowest level visible from the
-    // token's own level.
-    const ownLevel = scene.levels.get(level);
-    if ( !ownLevel ) return null;
-    let { base } = ownLevel.elevation;
-    for ( const id of ownLevel.visibility.levels ) {
-      const visible = scene.levels.get(id);
-      if ( visible ) base = Math.min(base, visible.elevation.base);
+    // With no surfaces defined, the base of every level is an implied floor. The supporting surface is the highest
+    // level base at or below the token.
+    let floorLevel = null;
+    for ( const l of scene.levels ) {
+      if ( l.elevation.base > elevation ) continue;
+      if ( !floorLevel || (l.elevation.base > floorLevel.elevation.base) ) floorLevel = l;
     }
-    return elevation > base ? { region: null, elevation: base } : null;
+    if ( !floorLevel ) return null;
+    return { elevation: floorLevel.elevation.base, level: floorLevel, region: null };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Resolve the level a token comes to rest on when landing on a surface region at a given elevation. Checks every
+   * level the surface region belongs to. The result is the single candidate whose elevation range is home to the
+   * landing elevation, or the current level when there is no unambiguous home.
+   * @param {RegionDocument} region  The landed surface's region.
+   * @param {number} elevation       The landing elevation.
+   * @param {string} levelId         The token's current level ID.
+   * @returns {Level|null}           The level the token rests on.
+   */
+  #findRestingLevel(region, elevation, levelId) {
+    const scene = this.parent;
+    const current = scene.levels.get(levelId) ?? null;
+    const candidates = region.levels.size
+      ? Array.from(region.levels, id => scene.levels.get(id))
+      : scene.levels.contents;
+    let home = null;
+    for ( const level of candidates ) {
+      if ( !level ) continue;
+      if ( (elevation >= level.elevation.bottom) && (elevation < level.elevation.top) ) {
+        if ( home ) return current; // Ambiguous: more than one candidate level is home to this elevation.
+        home = level;
+      }
+    }
+    return home ?? current;
   }
 
   /* -------------------------------------------- */
@@ -355,9 +387,9 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
     }
 
     const distance = this.elevation - surface.elevation;
-    await this.move({ action: "fall", elevation: surface.elevation }, {
-      animate: false, dnd5e: { fall: { distance } }
-    });
+    const waypoint = { action: "fall", elevation: surface.elevation };
+    if ( surface.level && (surface.level.id !== this._source.level) ) waypoint.level = surface.level.id;
+    await this.move(waypoint, { animate: false, dnd5e: { fall: { distance } } });
     await actor.toggleStatusEffect("falling", { active: false });
     await actor.toggleStatusEffect("prone", { active: true });
     await postFallDamage([this], distance);
@@ -471,7 +503,9 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
   /** @inheritDoc */
   async _onUpdateMovement(movement, operation, user) {
     await super._onUpdateMovement(movement, operation, user);
-    if ( !user.isSelf || dnd5e.settings.disableFalling ) return;
+    if ( !user.isSelf || dnd5e.settings.disableFalling || (movement.passed.waypoints.at(-1)?.action === "fall") ) {
+      return;
+    }
     const { actor } = this;
     if ( !actor ) return;
     const shouldFall = this.#shouldFall(movement);

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -1,3 +1,4 @@
+import { playLandingVfx } from "../canvas/landing-vfx.mjs";
 import { postFallDamage } from "../rules/falling.mjs";
 import SystemFlagsMixin from "./mixins/flags.mjs";
 
@@ -476,6 +477,15 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
     const shouldFall = this.#shouldFall(movement);
     if ( shouldFall === actor.statuses.has("falling") ) return;
     await actor.toggleStatusEffect("falling", { active: shouldFall });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onUpdate(changed, options, userId) {
+    super._onUpdate(changed, options, userId);
+    const distance = foundry.utils.getProperty(options, "dnd5e.fall.distance");
+    if ( distance ) playLandingVfx(this, distance);
   }
 
   /* -------------------------------------------- */

--- a/module/rules/_module.mjs
+++ b/module/rules/_module.mjs
@@ -1,0 +1,1 @@
+export * from "./falling.mjs";

--- a/module/rules/falling.mjs
+++ b/module/rules/falling.mjs
@@ -1,0 +1,62 @@
+import { convertLength, formatLength, getTargetDescriptors } from "../utils.mjs";
+
+/**
+ * @import Token5e from "../canvas/token.mjs";
+ * @import DamageRoll from "../dice/damage-roll.mjs";
+ * @import TokenDocument5e from "../documents/token.mjs";
+ */
+
+/* -------------------------------------------- */
+/*  Public API                                  */
+/* -------------------------------------------- */
+
+/**
+ * Determine the fall damage formula for a given distance.
+ * @param {number} distance  The distance fallen.
+ * @param {string} units     The units `distance` is expressed in.
+ * @returns {string|null}    The damage formula, or `null` if the fall is too short to deal damage.
+ */
+export function getFallDamageFormula(distance, units) {
+  const { damageDie, distancePerDie, maximumDice } = CONFIG.DND5E.falling;
+  const feet = convertLength(distance, units, "ft", { strict: false });
+  const dice = Math.min(maximumDice, Math.floor(feet / distancePerDie));
+  return dice ? `${dice}${damageDie}` : null;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Post a fall damage chat card with the damage tray targets pre-filled. Falls too short to deal damage post no card.
+ * @param {Iterable<Token5e|TokenDocument5e>} targets  The tokens that fell.
+ * @param {number} distance                            The distance fallen, in scene grid units.
+ * @returns {Promise<DamageRoll[]|void>}               The resulting rolls, if any damage was rolled.
+ */
+export async function postFallDamage(targets, distance) {
+  const units = canvas.grid.units;
+  if ( !(units in CONFIG.DND5E.movementUnits) ) {
+    console.warn(`Cannot post fall damage as the scene units "${units}" are not a known distance unit.`);
+    return;
+  }
+
+  const formula = getFallDamageFormula(distance, units);
+  if ( !formula ) return;
+
+  const { damageType } = CONFIG.DND5E.falling;
+  const rolls = await CONFIG.Dice.DamageRoll.build({
+    hookNames: ["damage"],
+    rolls: [{ parts: [formula], options: { type: damageType, types: [damageType] } }]
+  }, { configure: false }, {
+    create: true,
+    data: {
+      flags: { dnd5e: { messageType: "roll", roll: { type: "damage" }, targets: getTargetDescriptors(targets) } },
+      flavor: game.i18n.format("DND5E.FALLING.DamageFlavor", {
+        distance: formatLength(Math.round(distance), units)
+      }),
+      speaker: ChatMessage.implementation.getSpeaker()
+    }
+  });
+  if ( !rolls?.length ) return;
+  Hooks.callAll("dnd5e.rollDamage", rolls);
+  Hooks.callAll("dnd5e.rollDamageV2", rolls);
+  return rolls;
+}

--- a/module/rules/falling.mjs
+++ b/module/rules/falling.mjs
@@ -1,6 +1,7 @@
 import { convertLength, formatLength, getTargetDescriptors } from "../utils.mjs";
 
 /**
+ * @import Actor5e from "../documents/actor/actor.mjs";
  * @import Token5e from "../canvas/token.mjs";
  * @import DamageRoll from "../dice/damage-roll.mjs";
  * @import TokenDocument5e from "../documents/token.mjs";
@@ -48,7 +49,12 @@ export async function postFallDamage(targets, distance) {
   }, { configure: false }, {
     create: true,
     data: {
-      flags: { dnd5e: { messageType: "roll", roll: { type: "damage" }, targets: getTargetDescriptors(targets) } },
+      flags: {
+        dnd5e: {
+          context: { fall: true }, messageType: "roll", roll: { type: "damage" },
+          targets: getTargetDescriptors(targets)
+        }
+      },
       flavor: game.i18n.format("DND5E.FALLING.DamageFlavor", {
         distance: formatLength(Math.round(distance), units)
       }),
@@ -59,4 +65,16 @@ export async function postFallDamage(targets, distance) {
   Hooks.callAll("dnd5e.rollDamage", rolls);
   Hooks.callAll("dnd5e.rollDamageV2", rolls);
   return rolls;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Knock an actor prone when it takes damage from a fall.
+ * @param {Actor5e} actor                        The actor whose hit points changed.
+ * @param {DocumentModificationContext} options  The update options.
+ * @returns {Promise<ActiveEffect|boolean|void>|void}
+ */
+export function applyFallProne(actor, options) {
+  if ( options.dnd5e?.fall ) return actor.toggleStatusEffect("prone", { active: true });
 }

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -118,6 +118,16 @@ export function registerSystemSettings() {
     }
   });
 
+  // Falling automation
+  game.settings.register("dnd5e", "disableFalling", {
+    config: true,
+    default: false,
+    hint: "SETTINGS.DND5E.AUTOMATION.Falling.Hint",
+    name: "SETTINGS.DND5E.AUTOMATION.Falling.Name",
+    scope: "world",
+    type: Boolean
+  });
+
   // Sense-to-token vision sync
   game.settings.register("dnd5e", "senseVisionSync", {
     name: "SETTINGS.DND5E.AUTOMATION.SenseVision.Name",

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -758,11 +758,12 @@ export function loadingTooltip({ uuid, passive=false }={}) {
 
 /**
  * Grab the targeted tokens and return relevant information on them.
+ * @param {Iterable<Token5e|TokenDocument5e>} [tokens]  Tokens to describe. Defaults to the user's current targets.
  * @returns {TargetDescriptor5e[]}
  */
-export function getTargetDescriptors() {
+export function getTargetDescriptors(tokens=game.user.targets) {
   const targets = new Map();
-  for ( const token of game.user.targets ) {
+  for ( const token of tokens ) {
     const { name } = token;
     const { img, system, uuid, statuses } = token.actor ?? {};
     if ( uuid ) {

--- a/templates/shared/config/movement-senses-config.hbs
+++ b/templates/shared/config/movement-senses-config.hbs
@@ -3,9 +3,9 @@
     <fieldset class="card">
         {{#if legend}}<legend>{{ legend }}</legend>{{/if}}
         {{#each types}}
-        {{#if (eq field.name "fly")}}
+        {{#if (eq name "system.attributes.movement.speeds.fly")}}
         <div class="form-group split-group">
-            <label>{{ localize field.label }}</label>
+            <label>{{ localize label }}</label>
             <div class="form-fields">
                 {{ formInput field name=name value=value placeholder=placeholder label=label }}
                 {{#with @root.hover}}


### PR DESCRIPTION
Forgot I hadn't actually raised this PR. Let me know if you prefer it to be split up, though the commits should be fairly straightforward to follow.

- Adds `dnd5e.rules` helpers for calculating fall damage and showing a fall damage chat card.
- Adds the 'fall' movement action.
- Adds surface detection (check the last commit here since I made some amendments to this at the end).
- Adds `TokenDocument5e#plummet` API for sending a token to its closest resting surface & level and rolling appropriate fall damage.
- Adds interactivity to the falling status effect icon, allowing DMs to plummet tokens.
- Adds landing VFX
- Implements elevation scaling for tokens.


https://github.com/user-attachments/assets/c8f71d73-4c62-4a1b-9f18-3253c05a274b

