### PR TITLE
Provide specific casting token data to regions and use it for disposition resolution.

### DIFF
--- a/module/canvas/template-placement.mjs
+++ b/module/canvas/template-placement.mjs
@@ -150,7 +150,7 @@ export default class TemplatePlacement extends BasePlacement {
       highlightMode: "coverage",
       flags: {
         dnd5e: {
-          caster: activity.getUsageToken()?.uuid,
+          activity: activity.uuid,
           dimensions: {
             size: templateData.size,
             width: templateData.width,
@@ -158,7 +158,7 @@ export default class TemplatePlacement extends BasePlacement {
             units: canvas.scene.grid.units
           },
           item: activity.item.uuid,
-          origin: activity.uuid,
+          origin: activity.getUsageToken()?.uuid,
           spellLevel: rollData.item.level
         }
       }

--- a/module/canvas/template-placement.mjs
+++ b/module/canvas/template-placement.mjs
@@ -150,6 +150,7 @@ export default class TemplatePlacement extends BasePlacement {
       highlightMode: "coverage",
       flags: {
         dnd5e: {
+          caster: activity.getUsageToken()?.uuid,
           dimensions: {
             size: templateData.size,
             width: templateData.width,

--- a/module/data/region-behavior/apply-active-effect.mjs
+++ b/module/data/region-behavior/apply-active-effect.mjs
@@ -209,8 +209,8 @@ export class ApplyActiveEffectActivityBehavior extends BaseActivityBehavior {
   /* -------------------------------------------- */
 
   /** @override */
-  createBehaviorData(activity, options={}) {
-    const disposition = activity.actor?.token?.disposition ?? activity.actor?.prototypeToken?.disposition;
+  createBehaviorData(activity, { caster }={}) {
+    const { disposition } = caster ?? activity.actor?.token ?? activity.actor?.prototypeToken ?? {};
     return {
       system: {
         dispositions: this.getDispositions(activity.target, { relativeTo: disposition }),

--- a/module/data/region-behavior/apply-active-effect.mjs
+++ b/module/data/region-behavior/apply-active-effect.mjs
@@ -209,8 +209,8 @@ export class ApplyActiveEffectActivityBehavior extends BaseActivityBehavior {
   /* -------------------------------------------- */
 
   /** @override */
-  createBehaviorData(activity, { caster }={}) {
-    const { disposition } = caster ?? activity.actor?.token ?? activity.actor?.prototypeToken ?? {};
+  createBehaviorData(activity, { token }={}) {
+    const { disposition } = token ?? activity.actor?.token ?? activity.actor?.prototypeToken ?? {};
     return {
       system: {
         dispositions: this.getDispositions(activity.target, { relativeTo: disposition }),

--- a/module/data/region-behavior/difficult-terrain.mjs
+++ b/module/data/region-behavior/difficult-terrain.mjs
@@ -121,8 +121,8 @@ export class DifficultTerrainActivityBehavior extends BaseActivityBehavior {
   /* -------------------------------------------- */
 
   /** @override */
-  createBehaviorData(activity, { caster }={}) {
-    const { disposition } = caster ?? activity.actor?.token ?? activity.actor?.prototypeToken ?? {};
+  createBehaviorData(activity, { token }={}) {
+    const { disposition } = token ?? activity.actor?.token ?? activity.actor?.prototypeToken ?? {};
     return {
       system: {
         ignoredDispositions: this.getDispositions(activity.target, { ignored: true, relativeTo: disposition }),

--- a/module/data/region-behavior/difficult-terrain.mjs
+++ b/module/data/region-behavior/difficult-terrain.mjs
@@ -121,8 +121,8 @@ export class DifficultTerrainActivityBehavior extends BaseActivityBehavior {
   /* -------------------------------------------- */
 
   /** @override */
-  createBehaviorData(activity, options={}) {
-    const disposition = activity.actor?.token?.disposition ?? activity.actor?.prototypeToken?.disposition;
+  createBehaviorData(activity, { caster }={}) {
+    const { disposition } = caster ?? activity.actor?.token ?? activity.actor?.prototypeToken ?? {};
     return {
       system: {
         ignoredDispositions: this.getDispositions(activity.target, { ignored: true, relativeTo: disposition }),

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1182,7 +1182,7 @@ export default function ActivityMixin(Base) {
       const behaviors = activity?.applicableBehaviors;
       if ( !behaviors?.length ) return;
 
-      const caster = await fromUuid(region.getFlag("dnd5e", "caster"));
+      const caster = fromUuidSync(region.getFlag("dnd5e", "caster"));
       const toCreate = [];
       for ( const behavior of behaviors ) {
         const data = behavior.config.createBehaviorData(activity, { caster });

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1178,14 +1178,14 @@ export default function ActivityMixin(Base) {
     static async placeTemplateBehaviors(region, options, userId) {
       if ( !game.user.isActiveGM || (options.dnd5e?.createActivityBehaviors === false) ) return;
 
-      const activity = await fromUuid(region.getFlag("dnd5e", "origin"));
+      const activity = await fromUuid(region.getFlag("dnd5e", "activity"));
       const behaviors = activity?.applicableBehaviors;
       if ( !behaviors?.length ) return;
 
-      const caster = fromUuidSync(region.getFlag("dnd5e", "caster"));
+      const token = fromUuidSync(region.getFlag("dnd5e", "origin"));
       const toCreate = [];
       for ( const behavior of behaviors ) {
-        const data = behavior.config.createBehaviorData(activity, { caster });
+        const data = behavior.config.createBehaviorData(activity, { token });
         if ( !data ) continue;
         data.name ??= behavior.name;
         toCreate.push(data);

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1182,9 +1182,10 @@ export default function ActivityMixin(Base) {
       const behaviors = activity?.applicableBehaviors;
       if ( !behaviors?.length ) return;
 
+      const caster = await fromUuid(region.getFlag("dnd5e", "caster"));
       const toCreate = [];
       for ( const behavior of behaviors ) {
-        const data = behavior.config.createBehaviorData(activity);
+        const data = behavior.config.createBehaviorData(activity, { caster });
         if ( !data ) continue;
         data.name ??= behavior.name;
         toCreate.push(data);


### PR DESCRIPTION
As mentioned on the PR, what we have already is probably correct in most cases. I think having this data available on the region is generally useful though, and we have one concrete use here to handle edge cases where linked tokens have a temporarily different disposition to their proto token.