### PR TITLE
Add expiry events to `DurationData`, apply duration to enchantments

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -326,52 +326,6 @@
   }
 },
 
-"DND5E.ACTIVEEFFECT": {
-  "AttributeKeyTooltip": "For a list of common keys and their accepted values, see <a href=\"{url}\">the wiki</a>.",
-  "ChangeType": {
-    "Advantage": {
-      "Label": "Advantage Mode"
-    },
-    "Bonus": {
-      "Label": "Bonus"
-    },
-    "Group": {
-      "Custom": "Custom",
-      "Rules": "Rules",
-      "Standard": "Standard"
-    },
-    "Maximum": {
-      "Label": "Roll Maximum"
-    },
-    "Minimum": {
-      "Label": "Roll Minimum"
-    }
-  },
-  "Expired": "Expired",
-  "Expiry": {
-    "Abbreviation": {
-      "End": "End",
-      "Start": "Start"
-    },
-    "GROUPS": {
-      "General": "General",
-      "Specific": "Specific"
-    },
-    "SourceStart": "Start of Source's Next Turn",
-    "SourceEnd": "End of Source's Next Turn",
-    "TargetStart": "Start of Target's Next Turn",
-    "TargetEnd": "End of Target's Next Turn",
-    "YourStart": "Start of Your Next Turn",
-    "YourEnd": "End of Your Next Turn"
-  },
-  "FIELDS": {
-    "statuses": {
-      "label": "Status Conditions",
-      "hint": "While affected by this Active Effect, the target will be treated as having these additional status conditions."
-    }
-  }
-},
-
 "DND5E.ACTIVITY": {
   "Action": {
     "Create": "Create Activity",
@@ -2634,6 +2588,10 @@
         "label": "Concentration",
         "hint": "Creature must maintain concentration while active."
       },
+      "expiry": {
+        "label": "Expiry Event",
+        "hint": "Event that triggers the end of the usage."
+      },
       "override": {
         "label": "Override Duration",
         "hint": "Use these duration values instead of the item's when using this activity."
@@ -2692,6 +2650,7 @@
       "Ownership": "Effects cannot be applied to tokens you are not the owner of."
     }
   },
+  "AttributeKeyTooltip": "For a list of common keys and their accepted values, see <a href=\"{url}\">the wiki</a>.",
   "BASE": {
     "FIELDS": {
       "changes": {
@@ -2740,8 +2699,27 @@
   },
   "Change": {
     "Configuration": "Change Configuration",
+    "Group": {
+      "Custom": "Custom",
+      "Rules": "Rules",
+      "Standard": "Standard"
+    },
     "Label": "Change",
-    "Title": "{effect} Change #{number}"
+    "Title": "{effect} Change #{number}",
+    "Type": {
+      "Advantage": {
+        "Label": "Advantage Mode"
+      },
+      "Bonus": {
+        "Label": "Bonus"
+      },
+      "Maximum": {
+        "Label": "Roll Maximum"
+      },
+      "Minimum": {
+        "Label": "Roll Minimum"
+      }
+    }
   },
   "DisabledTooltip": {
     "Disabled": "This effect is currently selected in one or more of its Item's Activities, and therefore cannot be suspended.",
@@ -2749,9 +2727,32 @@
   },
   "DropHint": "Drop an Active Effect here",
   "Empty": "No associated effects. Use the <i class=\"fas fa-plus\"></i> button above to create one, or select an existing effect from the drop-down.",
+  "Expired": "Expired",
   "Expiry": {
-    "LongRest": "End of Long Rest",
-    "ShortRest": "End of Short Rest"
+    "Abbreviation": {
+      "End": "End",
+      "Start": "Start"
+    },
+    "Group": {
+      "General": "General",
+      "Specific": "Specific"
+    },
+    "Type": {
+      "LongRest": "End of Long Rest",
+      "ShortRest": "End of Short Rest",
+      "SourceEnd": "End of Source's Next Turn",
+      "SourceStart": "Start of Source's Next Turn",
+      "TargetEnd": "End of Target's Next Turn",
+      "TargetStart": "Start of Target's Next Turn",
+      "YourEnd": "End of Your Next Turn",
+      "YourStart": "Start of Your Next Turn"
+    }
+  },
+  "FIELDS": {
+    "statuses": {
+      "label": "Status Conditions",
+      "hint": "While affected by this Active Effect, the target will be treated as having these additional status conditions."
+    }
   },
   "Label": "Available Effects",
   "New": "New Effect",

--- a/module/applications/active-effect/active-effect-sheet.mjs
+++ b/module/applications/active-effect/active-effect-sheet.mjs
@@ -113,18 +113,9 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
    * @protected
    */
   async _prepareDurationContext(context, options) {
-    const general = _loc("DND5E.ACTIVEEFFECT.Expiry.GROUPS.General");
-    const specific = _loc("DND5E.ACTIVEEFFECT.Expiry.GROUPS.Specific");
-
-    for ( const [expiry, label] of Object.entries(context.expiryEvents) ) {
-      context.expiryEvents[expiry] = { group: general, label };
-    }
-    for ( const expiry of dnd5e.documents.ActiveEffect5e.PSEUDO_EXPIRIES ) {
-      context.expiryEvents[expiry] = {
-        group: specific,
-        label: _loc(`DND5E.ACTIVEEFFECT.Expiry.${expiry.capitalize()}`)
-      };
-    }
+    context.expiryEvents = Object.fromEntries(
+      ActiveEffect.implementation.expiryOptions.map(({ value, ...data }) => [value, data])
+    );
     return context;
   }
 

--- a/module/applications/active-effect/effect-change-config.mjs
+++ b/module/applications/active-effect/effect-change-config.mjs
@@ -110,7 +110,7 @@ export default class EffectChangeConfig extends DocumentSheet5e {
     context.defaultPriority = ActiveEffect.CHANGE_TYPES[context.source?.type]?.defaultPriority;
     context.fields = this.effect.system.schema.fields.changes.element.fields;
 
-    context.hintText = _loc("DND5E.ACTIVEEFFECT.AttributeKeyTooltip", {
+    context.hintText = _loc("DND5E.EFFECT.AttributeKeyTooltip", {
       url: this.effect.type === "enchantment"
         ? "https://github.com/foundryvtt/dnd5e/wiki/Enchantment"
         : "https://github.com/foundryvtt/dnd5e/wiki/Active-Effect-Guide"
@@ -119,7 +119,7 @@ export default class EffectChangeConfig extends DocumentSheet5e {
     context.typeOptions = Object.entries(ActiveEffect.CHANGE_TYPES)
       .map(([value, { group, label }]) => ({ value, label: _loc(label), group: _loc(
         CONFIG.ActiveEffect.changeTypes[value]?.group
-          ?? `DND5E.ACTIVEEFFECT.ChangeType.Group.${value in CONST.ACTIVE_EFFECT_CHANGE_TYPES ? "Standard" : "Custom"}`
+          ?? `DND5E.EFFECT.Change.Group.${value in CONST.ACTIVE_EFFECT_CHANGE_TYPES ? "Standard" : "Custom"}`
       ) }))
       .sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang));
 

--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -182,6 +182,7 @@ export default class ActivitySheet extends PseudoDocumentSheet {
         value, label, group: _loc("DND5E.RangeDistance")
       }))
     ];
+    context.expiryOptions = ActiveEffect.implementation.expiryOptions;
 
     // Consumption targets
     const canScale = this.activity.canConfigureScaling;

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -214,8 +214,7 @@ export default class EffectApplicationElement extends ChatTrayElement {
     }
 
     // Get any effect changes provided by the activity & add flags
-    const changes = this.chatMessage.getAssociatedActivity({ scaled: true })
-      ?.getAppliedEffectChanges(effect, { chatMessage: this.chatMessage, target: actor }) ?? {};
+    const changes = activity?.getAppliedEffectChanges(effect, { chatMessage: this.chatMessage, target: actor }) ?? {};
     foundry.utils.mergeObject(changes, {
       flags: {
         dnd5e: {

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -213,7 +213,10 @@ export default class EffectApplicationElement extends ChatTrayElement {
       throw new Error(_loc("DND5E.EFFECT.Application.Warning.Ownership"));
     }
 
-    const effectFlags = {
+    // Get any effect changes provided by the activity & add flags
+    const changes = this.chatMessage.getAssociatedActivity({ scaled: true })
+      ?.getAppliedEffectChanges(effect, { chatMessage: this.chatMessage, target: actor }) ?? {};
+    foundry.utils.mergeObject(changes, {
       flags: {
         dnd5e: {
           dependentOn: concentration?.uuid,
@@ -230,41 +233,31 @@ export default class EffectApplicationElement extends ChatTrayElement {
             ? activity.effects?.find(e => (e.uuid === effect.uuid) || (e._id === effect.id))?._id : undefined
         }
       }
-    };
-
-    // Inherit the activity's duration only when the applied effect has a duration expiry and  no explicit duration of
-    // its own.
-    let durationOverride = {};
-    if ( !Number.isFinite(effect.duration.value) && effect.expirySupportsDuration() ) {
-      const effectDuration = activity?.duration.getEffectData();
-      if ( !foundry.utils.isEmpty(effectDuration) ) durationOverride = { duration: effectDuration };
-    }
+    });
 
     // Enable an existing effect on the target if it originated from this effect
     const existingEffect = actor.effects.find(e => e._stats[sourceKey] === effect.uuid);
     if ( existingEffect ) {
       return { action: "update", data: foundry.utils.mergeObject({
-        ...durationOverride,
         _id: existingEffect.id,
         disabled: false,
         duration: {
           expired: false
         },
         start: effect.constructor.getEffectStart()
-      }, effectFlags) };
+      }, changes) };
     }
 
     // Otherwise, create a new effect on the target
     const effectData = foundry.utils.mergeObject({
       ...effect.toObject(),
-      ...durationOverride,
       disabled: false,
       transfer: false,
       _stats: {
         [sourceKey]: effect.uuid,
         [effect.inCompendium ? "duplicateSource" : "compendiumSource"]: null
       }
-    }, effectFlags);
+    }, changes);
 
     effectData.system.changes = await ActiveEffect.implementation.forApplication(
       effectData.system.changes,

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -4754,12 +4754,12 @@ DND5E.expiryEvents = Object.seal({
 /**
  * System-specific "expiry" choices which do not require registration or custom expiry events, and instead
  * are handled dynamically in `ActiveEffect#isExpiryEvent`.
- * @type {Record<string>}
+ * @type {Record<string, string>}
  */
 DND5E.pseudoExpiryEvents = Object.seal({
   sourceStart: "DND5E.EFFECT.Expiry.Type.SourceStart",
-  sourceEnd: "DND5E.EFFECT.Expiry.Type.SourceEnd",
   targetStart: "DND5E.EFFECT.Expiry.Type.TargetStart",
+  sourceEnd: "DND5E.EFFECT.Expiry.Type.SourceEnd",
   targetEnd: "DND5E.EFFECT.Expiry.Type.TargetEnd"
 });
 preLocalize("pseudoExpiryEvents");

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -3946,31 +3946,31 @@ DND5E.elevationScaling = true;
  */
 DND5E.activeEffectChangeTypes = Object.freeze({
   "dnd5e.advantage": {
-    label: "DND5E.ACTIVEEFFECT.ChangeType.Advantage.Label",
+    label: "DND5E.EFFECT.Change.Type.Advantage.Label",
     defaultPriority: 100,
     handler: ActiveEffect5e._applyChangeRule,
-    group: "DND5E.ACTIVEEFFECT.ChangeType.Group.Rules",
+    group: "DND5E.EFFECT.Change.Group.Rules",
     skipConditions: true
   },
   "dnd5e.bonus": {
-    label: "DND5E.ACTIVEEFFECT.ChangeType.Bonus.Label",
+    label: "DND5E.EFFECT.Change.Type.Bonus.Label",
     defaultPriority: 100,
     handler: ActiveEffect5e._applyChangeRule,
-    group: "DND5E.ACTIVEEFFECT.ChangeType.Group.Rules",
+    group: "DND5E.EFFECT.Change.Group.Rules",
     skipConditions: true
   },
   "dnd5e.maximum": {
-    label: "DND5E.ACTIVEEFFECT.ChangeType.Maximum.Label",
+    label: "DND5E.EFFECT.Change.Type.Maximum.Label",
     defaultPriority: 100,
     handler: ActiveEffect5e._applyChangeRule,
-    group: "DND5E.ACTIVEEFFECT.ChangeType.Group.Rules",
+    group: "DND5E.EFFECT.Change.Group.Rules",
     skipConditions: true
   },
   "dnd5e.minimum": {
-    label: "DND5E.ACTIVEEFFECT.ChangeType.Minimum.Label",
+    label: "DND5E.EFFECT.Change.Type.Minimum.Label",
     defaultPriority: 100,
     handler: ActiveEffect5e._applyChangeRule,
-    group: "DND5E.ACTIVEEFFECT.ChangeType.Group.Rules",
+    group: "DND5E.EFFECT.Change.Group.Rules",
     skipConditions: true
   }
 });
@@ -4745,9 +4745,24 @@ DND5E.calendarDeltasRecoveryMapping = new Map([
  * @enum {string}
  */
 DND5E.expiryEvents = Object.seal({
-  longRest: "DND5E.EFFECT.Expiry.LongRest",
-  shortRest: "DND5E.EFFECT.Expiry.ShortRest"
+  longRest: "DND5E.EFFECT.Expiry.Type.LongRest",
+  shortRest: "DND5E.EFFECT.Expiry.Type.ShortRest"
 });
+
+/* -------------------------------------------- */
+
+/**
+ * System-specific "expiry" choices which do not require registration or custom expiry events, and instead
+ * are handled dynamically in `ActiveEffect#isExpiryEvent`.
+ * @type {Record<string>}
+ */
+DND5E.pseudoExpiryEvents = Object.seal({
+  sourceStart: "DND5E.EFFECT.Expiry.Type.SourceStart",
+  sourceEnd: "DND5E.EFFECT.Expiry.Type.SourceEnd",
+  targetStart: "DND5E.EFFECT.Expiry.Type.TargetStart",
+  targetEnd: "DND5E.EFFECT.Expiry.Type.TargetEnd"
+});
+preLocalize("pseudoExpiryEvents");
 
 /* -------------------------------------------- */
 /*  Requests                                    */

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -642,6 +642,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
         return { value, label, group: "DND5E.DurationPermanent" };
       })
     ];
+    context.expiryOptions = ActiveEffect.implementation.expiryOptions;
 
     // Targets
     context.targetTypes = [

--- a/module/data/shared/_types.mjs
+++ b/module/data/shared/_types.mjs
@@ -69,6 +69,7 @@
  * @typedef DurationData
  * @property {string} value             Scalar value for the activity's duration.
  * @property {string} units             Units that are used for the duration.
+ * @property {string} expiry            Active effect expiry event.
  * @property {string} special           Description of any special duration details.
  */
 

--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -98,6 +98,6 @@ export default class DurationField extends SchemaField {
       case "year": units = "years"; break;
       default: return expiry ? { expiry, value: null } : {};
     }
-    return { expiry, value, units };
+    return { value, units, expiry: expiry ?? "turnStart" };
   }
 }

--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -93,7 +93,7 @@ export default class DurationField extends SchemaField {
       case "second": units = "seconds"; break;
       case "minute": units = "minutes"; break;
       case "hour": units = "hours"; break;
-      case "day": units = "days" ; break;
+      case "day": units = "days"; break;
       case "month": units = "months"; break;
       case "year": units = "years"; break;
       default: return expiry ? { expiry, value: null } : {};

--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -16,6 +16,7 @@ export default class DurationField extends SchemaField {
     fields = {
       value: new FormulaField({ deterministic: true }),
       units: new StringField({ required: true, blank: false, initial: "inst" }),
+      expiry: new StringField(),
       special: new StringField(),
       ...fields
     };
@@ -80,21 +81,23 @@ export default class DurationField extends SchemaField {
   /**
    * Create duration data usable for an active effect based on this duration.
    * @this {DurationData}
-   * @returns {EffectDurationData}
+   * @returns {Partial<EffectDurationData>}
    */
   static getEffectDuration() {
-    if ( !Number.isNumeric(this.value) ) return {};
-    const { value, units } = this;
+    let { expiry, value, units } = this;
+    if ( !Number.isNumeric(value) ) return expiry ? { expiry, value: null } : {};
+    if ( expiry && !ActiveEffect.implementation.expirySupportsDuration(expiry) ) return { expiry, value: null };
     switch ( units ) {
-      case "turn": return { value, units: "turns" };
-      case "round": return { value, units: "rounds" };
-      case "second": return { value, units: "seconds" };
-      case "minute": return { value, units: "minutes" };
-      case "hour": return { value, units: "hours" };
-      case "day": return { value, units: "days" };
-      case "month": return { value, units: "months" };
-      case "year": return { value, units: "years" };
-      default: return {};
+      case "turn": units = "turns"; break;
+      case "round": units = "rounds"; break;
+      case "second": units = "seconds"; break;
+      case "minute": units = "minutes"; break;
+      case "hour": units = "hours"; break;
+      case "day": units = "days" ; break;
+      case "month": units = "months"; break;
+      case "year": units = "years"; break;
+      default: return expiry ? { expiry, value: null } : {};
     }
+    return { expiry, value, units };
   }
 }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -149,7 +149,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     const general = _loc("DND5E.EFFECT.Expiry.Group.General");
     const specific = _loc("DND5E.EFFECT.Expiry.Group.Specific");
     return [
-      ...Object.entries(ActiveEffect5e.EXPIRY_EVENTS).map(([value, l]) => ({ value, label: _loc(l), group: general })),
+      ...Object.entries(this.EXPIRY_EVENTS).map(([value, l]) => ({ value, label: _loc(l), group: general })),
       ...Object.entries(CONFIG.DND5E.pseudoExpiryEvents).map(([value, label]) => ({ value, label, group: specific }))
     ];
   }
@@ -1305,7 +1305,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @returns {boolean}
    */
   expirySupportsDuration(expiry=this.duration.expiry) {
-    return ActiveEffect5e.expirySupportsDuration(expiry);
+    return this.constructor.expirySupportsDuration(expiry);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -114,7 +114,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /* -------------------------------------------- */
 
   /** @inheritdoc */
-  static LOCALIZATION_PREFIXES = [...super.LOCALIZATION_PREFIXES, "DND5E.ACTIVEEFFECT"];
+  static LOCALIZATION_PREFIXES = [...super.LOCALIZATION_PREFIXES, "DND5E.EFFECT"];
 
   /* -------------------------------------------- */
   /*  Properties                                  */
@@ -137,6 +137,21 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   get dependentOrigin() {
     if ( !(this.parent instanceof Item) ) return null;
     return this.item.effects.get(this.flags.dnd5e?.dependentOn) ?? null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Possible expiry options.
+   * @type {FormSelectOption[]}
+   */
+  static get expiryOptions() {
+    const general = _loc("DND5E.EFFECT.Expiry.Group.General");
+    const specific = _loc("DND5E.EFFECT.Expiry.Group.Specific");
+    return [
+      ...Object.entries(ActiveEffect5e.EXPIRY_EVENTS).map(([value, l]) => ({ value, label: _loc(l), group: general })),
+      ...Object.entries(CONFIG.DND5E.pseudoExpiryEvents).map(([value, label]) => ({ value, label, group: specific }))
+    ];
   }
 
   /* -------------------------------------------- */
@@ -255,7 +270,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( !expiry ) return null;
     return {
       icon: expiry.startsWith("target") ? "fa-bullseye" : "fa-user",
-      label: _loc(`DND5E.ACTIVEEFFECT.Expiry.Abbreviation.${expiry.endsWith("Start") ? "Start" : "End"}`)
+      label: _loc(`DND5E.EFFECT.Expiry.Abbreviation.${expiry.endsWith("Start") ? "Start" : "End"}`)
     };
   }
 
@@ -635,22 +650,23 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   _prepareDuration(duration, context) {
     duration = super._prepareDuration(duration, context);
-    if ( duration.expired && !Number.isFinite(duration.value) ) {
-      duration.label = _loc("DND5E.ACTIVEEFFECT.Expired");
-    }
+
+    // Expired effects say "Expired"
+    if ( duration.expired && !Number.isFinite(duration.value) ) duration.label = _loc("DND5E.EFFECT.Expired");
 
     // Pseudo expires adjust label based on relationship to actor
     else if ( this.constructor.PSEUDO_EXPIRIES.has(duration.expiry) ) {
       const useYour = (this.modifiesActor || this.isAppliedEnchantment)
         && (duration.expiry.startsWith("target") || (this.getSourceActor() === this.actor));
-      if ( useYour ) duration.label = _loc(`DND5E.ACTIVEEFFECT.Expiry.Your${duration.expiry.slice(6)}`);
-      else duration.label = _loc(`DND5E.ACTIVEEFFECT.Expiry.${duration.expiry.capitalize()}`);
+      if ( useYour ) duration.label = _loc(`DND5E.EFFECT.Expiry.Type.Your${duration.expiry.slice(6)}`);
+      else duration.label = CONFIG.DND5E.pseudoExpiryEvents[duration.expiry];
     }
 
-    // Durationless expiries just use expiry name
+    // Duration-less expiries use expiry name
     else if ( this.constructor.DURATIONLESS_EXPIRIES.has(duration.expiry) ) {
       duration.label = _loc(CONFIG.ActiveEffect.expiryEvents[duration.expiry]);
     }
+
     return duration;
   }
 
@@ -1274,11 +1290,22 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /**
    * Determine whether the provided expiry should be able to display duration fields.
+   * @param {string} [expiry]  Active effect expiry event to check.
+   * @returns {boolean}
+   */
+  static expirySupportsDuration(expiry) {
+    return !this.PSEUDO_EXPIRIES.has(expiry) && !this.DURATIONLESS_EXPIRIES.has(expiry);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Determine whether the provided expiry should be able to display duration fields.
    * @param {string} [expiry]  Active effect expiry event to check, defaults to this effect's current expiry.
    * @returns {boolean}
    */
   expirySupportsDuration(expiry=this.duration.expiry) {
-    return !this.constructor.PSEUDO_EXPIRIES.has(expiry) && !this.constructor.DURATIONLESS_EXPIRIES.has(expiry);
+    return ActiveEffect5e.expirySupportsDuration(expiry);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -164,7 +164,7 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
 
     const flags = { enchantmentProfile: profileId };
     if ( concentration ) flags.dependentOn = concentration.uuid;
-    const enchantmentData = effect.clone({
+    const enchantmentData = effect.clone(foundry.utils.mergeObject({
       "flags.dnd5e": flags,
       system: {
         origin: {
@@ -175,7 +175,7 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
       },
       disabled: false,
       transfer: true
-    }).toObject();
+    }, this.getAppliedEffectChanges(effect, { chatMessage, target: item }))).toObject();
     enchantmentData.system.changes =
       await ActiveEffect.implementation.forApplication(enchantmentData.system.changes, this, item);
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1201,9 +1201,13 @@ export default function ActivityMixin(Base) {
      */
     getAppliedEffectChanges(effect, { chatMessage, target }={}) {
       const changes = {};
-      if ( !Number.isFinite(effect.duration.value) && !effect.duration.expiry ) {
-        const duration = this.duration?.getEffectData();
-        if ( !foundry.utils.isEmpty(duration) ) changes.duration = duration;
+      if ( !effect.duration.expiry ) {
+        if ( !Number.isFinite(effect.duration.value) ) {
+          const duration = this.duration?.getEffectData();
+          if ( !foundry.utils.isEmpty(duration) ) changes.duration = duration;
+        } else {
+          changes.duration = { expiry: "turnStart" };
+        }
       }
       return changes;
     }

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1192,6 +1192,25 @@ export default function ActivityMixin(Base) {
     /* -------------------------------------------- */
 
     /**
+     * Retrieve any modifications to be made to an applied effect.
+     * @param {ActiveEffect5e} effect                The base effect that will be applied.
+     * @param {object} [options={}]
+     * @param {ChatMessage5e} [options.chatMessage]  Message associated with the application.
+     * @param {Actor5e|Item5e} [options.target]      Actor or item to which the effect will be applied.
+     * @returns {object}
+     */
+    getAppliedEffectChanges(effect, { chatMessage, target }={}) {
+      const changes = {};
+      if ( !Number.isFinite(effect.duration.value) && !effect.duration.expiry ) {
+        const duration = this.duration?.getEffectData();
+        if ( !foundry.utils.isEmpty(duration) ) changes.duration = duration;
+      }
+      return changes;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
      * Prepare activity favorite data.
      * @returns {Promise<FavoriteData5e>}
      */

--- a/templates/activity/parts/activity-time.hbs
+++ b/templates/activity/parts/activity-time.hbs
@@ -28,7 +28,7 @@
             </label>
         </legend>
         {{> "dnd5e.field-duration" duration=activity.duration fields=fields.duration.fields data=data.duration
-            durationUnits=durationUnits inputs=inputs }}
+            durationUnits=durationUnits expiryOptions=expiryOptions inputs=inputs }}
         {{ formField fields.duration.fields.concentration value=data.duration.concentration
            input=inputs.createCheckboxInput rootId=partId }}
     </fieldset>

--- a/templates/items/details/details-spell.hbs
+++ b/templates/items/details/details-spell.hbs
@@ -89,7 +89,7 @@
 
     {{!-- Duration --}}
     {{> "dnd5e.field-duration" duration=system.duration fields=fields.duration.fields data=source.duration
-        durationUnits=durationUnits inputs=inputs }}
+        durationUnits=durationUnits expiryOptions=expiryOptions inputs=inputs }}
 </fieldset>
 
 {{> "dnd5e.field-targets" target=system.target fields=fields.target.fields data=source.target inputs=inputs

--- a/templates/shared/fields/field-duration.hbs
+++ b/templates/shared/fields/field-duration.hbs
@@ -22,4 +22,4 @@
 </div>
 
 {{!-- Expiry Options --}}
-{{ formField fields.expiry value=data.expiry options=expiryOptions rootId=partId }}
+{{ formField fields.expiry value=data.expiry hint=false options=expiryOptions rootId=partId }}

--- a/templates/shared/fields/field-duration.hbs
+++ b/templates/shared/fields/field-duration.hbs
@@ -20,3 +20,6 @@
                  placeholder=(localize "DND5E.DURATION.FIELDS.duration.special.label") rootId=partId }}
     {{/if}}
 </div>
+
+{{!-- Expiry Options --}}
+{{ formField fields.expiry value=data.expiry options=expiryOptions rootId=partId }}


### PR DESCRIPTION
Adds `duration.expiry` to activity and spell data. Does not hide the duration field for duration-less expiry events because you may need to keep the duration data (for example, Shield has a duration of 1 Round and the expiry event of "Start of Source's Next Turn").

Changes how duration overrides are handled for applied effects by moving the logic into the activity itself, to give activities a chance to fully modify the effect being applied. In the process this also applies those same changes to applied enchantments.