### PR TITLE
Convert Hit Points, Hit Die, and Utility roll messages into bespoke system sub-types

### DIFF
--- a/module/data/chat-message/_module.mjs
+++ b/module/data/chat-message/_module.mjs
@@ -1,5 +1,6 @@
 import BastionAttackMessageData from "./bastion-attack-message-data.mjs";
 import BastionTurnMessageData from "./bastion-turn-message-data.mjs";
+import HitPointsMessageData from "./hit-points-message-data.mjs";
 import RequestMessageData from "./request-message-data.mjs";
 import RestMessageData from "./rest-message-data.mjs";
 import TimePassedMessageData from "./time-passed-message-data.mjs";
@@ -9,6 +10,7 @@ import UsageMessageData from "./usage-message-data.mjs";
 export {
   BastionAttackMessageData,
   BastionTurnMessageData,
+  HitPointsMessageData,
   RequestMessageData,
   RestMessageData,
   TimePassedMessageData,
@@ -20,6 +22,7 @@ export * as fields from "./fields/_module.mjs";
 export const config = {
   bastionAttack: BastionAttackMessageData,
   bastionTurn: BastionTurnMessageData,
+  hitPoints: HitPointsMessageData,
   request: RequestMessageData,
   rest: RestMessageData,
   timePassed: TimePassedMessageData,

--- a/module/data/chat-message/_module.mjs
+++ b/module/data/chat-message/_module.mjs
@@ -1,5 +1,6 @@
 import BastionAttackMessageData from "./bastion-attack-message-data.mjs";
 import BastionTurnMessageData from "./bastion-turn-message-data.mjs";
+import GenericMessageData from "./generic-message-data.mjs";
 import HitDieMessageData from "./hit-die-message-data.mjs";
 import HitPointsMessageData from "./hit-points-message-data.mjs";
 import RequestMessageData from "./request-message-data.mjs";
@@ -11,6 +12,7 @@ import UsageMessageData from "./usage-message-data.mjs";
 export {
   BastionAttackMessageData,
   BastionTurnMessageData,
+  GenericMessageData,
   HitDieMessageData,
   HitPointsMessageData,
   RequestMessageData,
@@ -24,6 +26,7 @@ export * as fields from "./fields/_module.mjs";
 export const config = {
   bastionAttack: BastionAttackMessageData,
   bastionTurn: BastionTurnMessageData,
+  generic: GenericMessageData,
   hitDie: HitDieMessageData,
   hitPoints: HitPointsMessageData,
   request: RequestMessageData,

--- a/module/data/chat-message/_module.mjs
+++ b/module/data/chat-message/_module.mjs
@@ -1,5 +1,6 @@
 import BastionAttackMessageData from "./bastion-attack-message-data.mjs";
 import BastionTurnMessageData from "./bastion-turn-message-data.mjs";
+import HitDieMessageData from "./hit-die-message-data.mjs";
 import HitPointsMessageData from "./hit-points-message-data.mjs";
 import RequestMessageData from "./request-message-data.mjs";
 import RestMessageData from "./rest-message-data.mjs";
@@ -10,6 +11,7 @@ import UsageMessageData from "./usage-message-data.mjs";
 export {
   BastionAttackMessageData,
   BastionTurnMessageData,
+  HitDieMessageData,
   HitPointsMessageData,
   RequestMessageData,
   RestMessageData,
@@ -22,6 +24,7 @@ export * as fields from "./fields/_module.mjs";
 export const config = {
   bastionAttack: BastionAttackMessageData,
   bastionTurn: BastionTurnMessageData,
+  hitDie: HitDieMessageData,
   hitPoints: HitPointsMessageData,
   request: RequestMessageData,
   rest: RestMessageData,

--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -31,6 +31,12 @@
 /* -------------------------------------------- */
 
 /**
+ * @typedef HitDieMessageSystemData
+ */
+
+/* -------------------------------------------- */
+
+/**
  * @typedef HitPointsMessageSystemData
  */
 

--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -31,6 +31,12 @@
 /* -------------------------------------------- */
 
 /**
+ * @typedef GenericMessageSystemData
+ */
+
+/* -------------------------------------------- */
+
+/**
  * @typedef HitDieMessageSystemData
  */
 

--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -31,6 +31,12 @@
 /* -------------------------------------------- */
 
 /**
+ * @typedef HitPointsMessageSystemData
+ */
+
+/* -------------------------------------------- */
+
+/**
  * @typedef RequestMessageSystemData
  * @property {object} button
  * @property {string} [button.icon]         Font awesome code or path to SVG icon for the request button.

--- a/module/data/chat-message/generic-message-data.mjs
+++ b/module/data/chat-message/generic-message-data.mjs
@@ -1,0 +1,41 @@
+import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
+
+/**
+ * @import { GenericMessageSystemData } from "./_types.mjs";
+ */
+
+/**
+ * Data stored in a generic roll chat message.
+ * @extends {ChatMessageDataModel<GenericMessageSystemData>}
+ * @mixes GenericMessageSystemData
+ */
+export default class GenericMessageData extends ChatMessageDataModel {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {};
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    template: "systems/dnd5e/templates/chat/generic-card.hbs"
+  }, { inplace: false }));
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext(options) {
+    const isPrivate = !this.parent.isContentVisible;
+    return {
+      rolls: await Promise.all(this.parent.rolls.map(roll => roll.render({ isPrivate, message: this.parent })))
+    };
+  }
+}

--- a/module/data/chat-message/hit-die-message-data.mjs
+++ b/module/data/chat-message/hit-die-message-data.mjs
@@ -1,0 +1,41 @@
+import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
+
+/**
+ * @import { HitDieMessageSystemData } from "./_types.mjs";
+ */
+
+/**
+ * Data stored in a hit die roll chat message.
+ * @extends {ChatMessageDataModel<HitDieMessageSystemData>}
+ * @mixes HitDieMessageSystemData
+ */
+export default class HitDieMessageData extends ChatMessageDataModel {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {};
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    template: "systems/dnd5e/templates/chat/hit-die-card.hbs"
+  }, { inplace: false }));
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext(options) {
+    const isPrivate = !this.parent.isContentVisible;
+    return {
+      rolls: await Promise.all(this.parent.rolls.map(roll => roll.render({ isPrivate, message: this.parent })))
+    };
+  }
+}

--- a/module/data/chat-message/hit-points-message-data.mjs
+++ b/module/data/chat-message/hit-points-message-data.mjs
@@ -1,0 +1,41 @@
+import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
+
+/**
+ * @import { HitPointsMessageSystemData } from "./_types.mjs";
+ */
+
+/**
+ * Data stored in a hit points roll chat message.
+ * @extends {ChatMessageDataModel<HitPointsMessageSystemData>}
+ * @mixes HitPointsMessageSystemData
+ */
+export default class HitPointsMessageData extends ChatMessageDataModel {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {};
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    template: "systems/dnd5e/templates/chat/hit-points-card.hbs"
+  }, { inplace: false }));
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext(options) {
+    const isPrivate = !this.parent.isContentVisible;
+    return {
+      rolls: await Promise.all(this.parent.rolls.map(roll => roll.render({ isPrivate, message: this.parent })))
+    };
+  }
+}

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -91,12 +91,9 @@ export default class UtilityActivity extends ActivityMixin(BaseUtilityActivityDa
       create: true,
       data: {
         flavor: `${this.item.name} - ${this.roll.label || _loc("DND5E.OtherFormula")}`,
+        type: "generic",
         flags: {
-          dnd5e: {
-            ...this.messageFlags,
-            messageType: "roll",
-            roll: { type: "generic" }
-          }
+          dnd5e: this.messageFlags
         }
       }
     }, message);

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2165,7 +2165,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       title: `${flavor}: ${this.name}`,
       flavor,
       speaker: ChatMessage.implementation.getSpeaker({ actor: this }),
-      "flags.dnd5e.roll": { type: "hitPoints" }
+      type: "hitPoints"
     };
 
     /**
@@ -2218,7 +2218,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       title: `${flavor}: ${this.name}`,
       flavor,
       speaker: ChatMessage.getSpeaker({ actor: this }),
-      "flags.dnd5e.roll": { type: "hitPoints" }
+      type: "hitPoints"
     };
 
     /**

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2090,7 +2090,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
         speaker: ChatMessage.implementation.getSpeaker({actor: this}),
         flavor,
         title: `${flavor}: ${this.name}`,
-        "flags.dnd5e.roll": {type: "hitDie"}
+        type: "hitDie"
       }
     }, message);
 

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -1,6 +1,14 @@
 import { formatIdentifier, log } from "./utils.mjs";
 
 /**
+ * Number of chat messages to update per batch during world migration.
+ * @type {number}
+ */
+const MESSAGE_MIGRATION_BATCH_SIZE = 64;
+
+/* -------------------------------------------- */
+
+/**
  * Perform a system migration for the entire World, applying migrations for Actors, Items, and Compendium packs.
  * @param {object} [options={}]
  * @param {boolean} [options.bypassVersionCheck=false]  Bypass certain migration restrictions gated behind system
@@ -106,19 +114,27 @@ export async function migrateWorld({ bypassVersionCheck=false }={}) {
     incrementProgress();
   }
 
-  // Migrate World Messages
+  // Migrate World Messages in batches
+  let messageBatch = [];
+  const flushMessageBatch = async () => {
+    if ( !messageBatch.length ) return;
+    await ChatMessage.implementation.updateDocuments(messageBatch, { enforceTypes: false, render: false });
+    messageBatch = [];
+  };
   for ( const m of game.messages ) {
     try {
-      const updateData = migrateMessageData(m.toObject(), migrationData);
+      const updateData = migrateMessageData(m.toObject());
       if ( !foundry.utils.isEmpty(updateData) ) {
         log(`Migrating Message document ${m.id}`);
-        await m.update(updateData, { enforceTypes: false, render: false });
+        messageBatch.push({ _id: m.id, ...updateData });
+        if ( messageBatch.length >= MESSAGE_MIGRATION_BATCH_SIZE ) await flushMessageBatch();
       }
     } catch(err) {
       err.message = `Failed dnd5e system migration for Message ${m.id}: ${err.message}`;
       console.error(err);
     }
   }
+  await flushMessageBatch();
 
   // Migrate World Roll Tables
   for ( const table of game.tables ) {
@@ -805,6 +821,12 @@ export function migrateMessageData(messageData) {
     updateData.type = "orders" in bastion ? "bastionTurn" : "bastionAttack";
     updateData.system = _replace(bastion);
     updateData["flags.dnd5e.bastion"] = _del;
+  }
+
+  else if ( (flags?.dnd5e?.roll?.type === "hitPoints") && (messageData.type === "base") ) {
+    updateData.type = "hitPoints";
+    updateData.system = _replace({});
+    updateData["flags.dnd5e.roll"] = _del;
   }
 
   return updateData;

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -823,6 +823,12 @@ export function migrateMessageData(messageData) {
     updateData["flags.dnd5e.bastion"] = _del;
   }
 
+  else if ( (flags?.dnd5e?.roll?.type === "generic") && (messageData.type === "base") ) {
+    updateData.type = "generic";
+    updateData.system = _replace({});
+    updateData["flags.dnd5e.roll"] = _del;
+  }
+
   else if ( (flags?.dnd5e?.roll?.type === "hitDie") && (messageData.type === "base") ) {
     updateData.type = "hitDie";
     updateData.system = _replace({});

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -823,6 +823,7 @@ export function migrateMessageData(messageData) {
     updateData["flags.dnd5e.bastion"] = _del;
   }
 
+  /* TODO: Re-instate these migrations when foundryvtt/foundryvtt#14229 is resolved.
   else if ( (flags?.dnd5e?.roll?.type === "generic") && (messageData.type === "base") ) {
     updateData.type = "generic";
     updateData.system = _replace({});
@@ -839,7 +840,7 @@ export function migrateMessageData(messageData) {
     updateData.type = "hitPoints";
     updateData.system = _replace({});
     updateData["flags.dnd5e.roll"] = _del;
-  }
+  }*/
 
   return updateData;
 }

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -823,6 +823,12 @@ export function migrateMessageData(messageData) {
     updateData["flags.dnd5e.bastion"] = _del;
   }
 
+  else if ( (flags?.dnd5e?.roll?.type === "hitDie") && (messageData.type === "base") ) {
+    updateData.type = "hitDie";
+    updateData.system = _replace({});
+    updateData["flags.dnd5e.roll"] = _del;
+  }
+
   else if ( (flags?.dnd5e?.roll?.type === "hitPoints") && (messageData.type === "base") ) {
     updateData.type = "hitPoints";
     updateData.system = _replace({});

--- a/system.json
+++ b/system.json
@@ -48,6 +48,7 @@
     "ChatMessage": {
       "bastionAttack": {},
       "bastionTurn": {},
+      "hitPoints": {},
       "request": {},
       "rest": {},
       "timePassed": {},

--- a/system.json
+++ b/system.json
@@ -48,6 +48,7 @@
     "ChatMessage": {
       "bastionAttack": {},
       "bastionTurn": {},
+      "generic": {},
       "hitDie": {},
       "hitPoints": {},
       "request": {},

--- a/system.json
+++ b/system.json
@@ -48,6 +48,7 @@
     "ChatMessage": {
       "bastionAttack": {},
       "bastionTurn": {},
+      "hitDie": {},
       "hitPoints": {},
       "request": {},
       "rest": {},

--- a/templates/chat/generic-card.hbs
+++ b/templates/chat/generic-card.hbs
@@ -1,0 +1,3 @@
+{{#each rolls}}
+{{{ this }}}
+{{/each}}

--- a/templates/chat/hit-die-card.hbs
+++ b/templates/chat/hit-die-card.hbs
@@ -1,0 +1,3 @@
+{{#each rolls}}
+{{{ this }}}
+{{/each}}

--- a/templates/chat/hit-points-card.hbs
+++ b/templates/chat/hit-points-card.hbs
@@ -1,0 +1,3 @@
+{{#each rolls}}
+{{{ this }}}
+{{/each}}


### PR DESCRIPTION
Starting the process of converting our chat cards into sub-types that render from data. I started with the easy ones first, the ones that only render their rolls (for now), and also adjusted our chat card migration to migrate in batches since on worlds with thousands of messages this could be a real bottleneck.