### PR TITLE
Convert death save rolls into bespoke system sub-type.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2491,16 +2491,13 @@
 "DND5E.Day": "Day",
 "DND5E.DeathSave": "Death Saves",
 "DND5E.DeathSaveConfigure": "Configure Death Saves",
-"DND5E.DeathSaveCriticalSuccess": "{name} critically succeeded on a death saving throw and has regained 1 Hit Point!",
 "DND5E.DeathSaveHide": "Hide Death Saves",
 "DND5E.DeathSaveShow": "Show Death Saves",
-"DND5E.DeathSaveSuccess": "{name} has survived with 3 death save successes and is now stable!",
 "DND5E.DeathSaveSuccessLabel": "Death Save Success",
 "DND5E.DeathSaveSuccessLabelN.one": "1st death save success",
 "DND5E.DeathSaveSuccessLabelN.two": "2nd death save success",
 "DND5E.DeathSaveSuccessLabelN.few": "3rd death save success",
 "DND5E.DeathSaveSuccesses": "Successes",
-"DND5E.DeathSaveFailure": "{name} has died with 3 death save failures!",
 "DND5E.DeathSaveFailureLabel": "Death Save Failure",
 "DND5E.DeathSaveFailureLabelN.one": "1st death save failure",
 "DND5E.DeathSaveFailureLabelN.two": "2nd death save failure",
@@ -2522,6 +2519,11 @@
         }
       }
     }
+  },
+  "Outcome": {
+    "death": "{name} has died with 3 death save failures!",
+    "revive": "{name} critically succeeded on a death saving throw and has regained 1 Hit Point!",
+    "stable": "{name} has survived with 3 death save successes and is now stable!"
   }
 },
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -3,6 +3,7 @@ import Proficiency from "../../documents/actor/proficiency.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
 import { getRulesVersion } from "../../enrichers.mjs";
 import { defaultUnits, formatCR, formatLength, formatNumber, getPluralRules, splitSemicolons } from "../../utils.mjs";
+import { ActorDeltasField } from "../chat-message/fields/deltas-field.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 import CreatureTypeField from "../shared/creature-type-field.mjs";
 import MovementField from "../shared/movement-field.mjs";
@@ -580,12 +581,12 @@ export default class NPCData extends CreatureTemplate {
       const priorFailure = message.system.deltas?.actor
         ?.find(d => d.keyPath === "system.attributes.death.failure")?.delta ?? 0;
       const failure = this.attributes.death.failure - priorFailure;
-      const { deltas, outcome, updates } = AttributesFields.applyDeathSaveResult({
+      const { outcome, updates } = AttributesFields.applyDeathSaveResult({
         failure, success: this.attributes.death.success
       }, { isSuccess: true });
       updates["system.attributes.death.failure"] ??= failure;
       Object.assign(actorUpdate, updates);
-      messageUpdate["system.deltas"] = _replace(deltas);
+      messageUpdate["system.deltas"] = _replace(ActorDeltasField.getDeltas(this.parent, { actor: updates, item: [] }));
       messageUpdate["system.outcome"] = outcome;
     }
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -571,8 +571,28 @@ export default class NPCData extends CreatureTemplate {
     if ( this.resources.legres.value === 0 ) throw new Error("No legendary resistances remaining.");
     if ( message.type !== "save" ) throw new Error("Chat message must contain a save roll.");
     if ( message.system.resisted ) throw new Error("Save has already been resisted.");
-    await this.parent.update({ "system.resources.legres.spent": this.resources.legres.spent + 1 });
-    await message.update({ "system.resisted": true });
+    const actorUpdate = { "system.resources.legres.spent": this.resources.legres.spent + 1 };
+    const messageUpdate = { _id: message.id, "system.resisted": true };
+
+    // Legendary resistance turns the failed save into a success: revert this save's failure and credit a success
+    // (which may stabilize the creature at three).
+    if ( message.system.ability === "death" ) {
+      const priorFailure = message.system.deltas?.actor
+        ?.find(d => d.keyPath === "system.attributes.death.failure")?.delta ?? 0;
+      const failure = this.attributes.death.failure - priorFailure;
+      const { deltas, outcome, updates } = AttributesFields.applyDeathSaveResult({
+        failure, success: this.attributes.death.success
+      }, { isSuccess: true });
+      updates["system.attributes.death.failure"] ??= failure;
+      Object.assign(actorUpdate, updates);
+      messageUpdate["system.deltas"] = _replace(deltas);
+      messageUpdate["system.outcome"] = outcome;
+    }
+
+    await this.parent.performBulkUpdate({
+      actor: actorUpdate,
+      operations: [{ action: "update", documentName: "ChatMessage", updates: [messageUpdate] }]
+    });
   }
 
   /* -------------------------------------------- */

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -14,7 +14,6 @@ const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { ActorRollData, DeathSaveOutcome } from "../../../documents/_types.mjs";
- * @import { ActorDeltasData } from "../../chat-message/fields/_types.mjs";
  * @import { ArmorClassData, AttributesCommonData, AttributesCreatureData, HitPointsData } from "./_types.mjs";
  */
 
@@ -723,17 +722,16 @@ export default class AttributesFields {
   /* -------------------------------------------- */
 
   /**
-   * Determine the actor updates, card deltas, and terminal outcome resulting from a death saving throw.
+   * Determine the actor updates and terminal outcome resulting from a death saving throw.
    * @param {{ success: number, failure: number }} death  Current death save success/failure counts.
    * @param {object} result
    * @param {boolean} result.isSuccess                    Whether the save succeeded.
    * @param {boolean} [result.isCritical]                 Whether the save was a natural 20.
    * @param {boolean} [result.isFumble]                   Whether the save was a natural 1.
-   * @returns {{ deltas: ActorDeltasData, outcome: DeathSaveOutcome, updates: object }}
+   * @returns {{ outcome: DeathSaveOutcome, updates: object }}
    */
   static applyDeathSaveResult(death, { isSuccess, isCritical=false, isFumble=false }) {
     const updates = {};
-    const deltas = { actor: [] };
     let outcome = null;
     if ( isSuccess ) {
       const successes = (death.success || 0) + 1;
@@ -745,31 +743,27 @@ export default class AttributesFields {
           "system.attributes.death.failure": 0,
           "system.attributes.hp.value": 1
         });
-        deltas.actor.push({ delta: 1, keyPath: "system.attributes.hp.value" });
         outcome = "revive";
       }
 
       // Normal success - stabilize on the third.
-      else {
-        deltas.actor.push({ delta: 1, keyPath: "system.attributes.death.success" });
-        if ( successes >= 3 ) {
-          Object.assign(updates, {
-            "system.attributes.death.success": 0,
-            "system.attributes.death.failure": 0
-          });
-          outcome = "stable";
-        }
-        else updates["system.attributes.death.success"] = Math.clamp(successes, 0, 3);
+      else if ( successes >= 3 ) {
+        Object.assign(updates, {
+          "system.attributes.death.success": 0,
+          "system.attributes.death.failure": 0
+        });
+        outcome = "stable";
       }
+
+      else updates["system.attributes.death.success"] = Math.clamp(successes, 0, 3);
     }
 
     else {
       const failures = Math.clamp((death.failure || 0) + (isFumble ? 2 : 1), 0, 3);
       updates["system.attributes.death.failure"] = failures;
-      deltas.actor.push({ delta: failures - (death.failure || 0), keyPath: "system.attributes.death.failure" });
       if ( failures >= 3 ) outcome = "death";
     }
 
-    return { deltas, outcome, updates };
+    return { outcome, updates };
   }
 }

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -13,7 +13,8 @@ import ACFormulasField from "../fields/ac-formulas-field.mjs";
 const { NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
- * @import { ActorRollData } from "../../../documents/_types.mjs";
+ * @import { ActorRollData, DeathSaveOutcome } from "../../../documents/_types.mjs";
+ * @import { ActorDeltasData } from "../../chat-message/fields/_types.mjs";
  * @import { ArmorClassData, AttributesCommonData, AttributesCreatureData, HitPointsData } from "./_types.mjs";
  */
 
@@ -713,7 +714,62 @@ export default class AttributesFields {
     if ( changed.system?.attributes?.death?.failure !== 3 ) return;
 
     // If hp update is included, updateDowned will be called in onUpdateHP, so exit early
-    if ( !!changed.system.attributes.hp ) return;
+    if ( changed.system.attributes.hp ) return;
     if ( userId === game.userId ) await this.parent.updateDowned(options);
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Determine the actor updates, card deltas, and terminal outcome resulting from a death saving throw.
+   * @param {{ success: number, failure: number }} death  Current death save success/failure counts.
+   * @param {object} result
+   * @param {boolean} result.isSuccess                    Whether the save succeeded.
+   * @param {boolean} [result.isCritical]                 Whether the save was a natural 20.
+   * @param {boolean} [result.isFumble]                   Whether the save was a natural 1.
+   * @returns {{ deltas: ActorDeltasData, outcome: DeathSaveOutcome, updates: object }}
+   */
+  static applyDeathSaveResult(death, { isSuccess, isCritical=false, isFumble=false }) {
+    const updates = {};
+    const deltas = { actor: [] };
+    let outcome = null;
+    if ( isSuccess ) {
+      const successes = (death.success || 0) + 1;
+
+      // Critical success - revive with 1 hp.
+      if ( isCritical ) {
+        Object.assign(updates, {
+          "system.attributes.death.success": 0,
+          "system.attributes.death.failure": 0,
+          "system.attributes.hp.value": 1
+        });
+        deltas.actor.push({ delta: 1, keyPath: "system.attributes.hp.value" });
+        outcome = "revive";
+      }
+
+      // Normal success - stabilize on the third.
+      else {
+        deltas.actor.push({ delta: 1, keyPath: "system.attributes.death.success" });
+        if ( successes >= 3 ) {
+          Object.assign(updates, {
+            "system.attributes.death.success": 0,
+            "system.attributes.death.failure": 0
+          });
+          outcome = "stable";
+        }
+        else updates["system.attributes.death.success"] = Math.clamp(successes, 0, 3);
+      }
+    }
+
+    else {
+      const failures = Math.clamp((death.failure || 0) + (isFumble ? 2 : 1), 0, 3);
+      updates["system.attributes.death.failure"] = failures;
+      deltas.actor.push({ delta: failures - (death.failure || 0), keyPath: "system.attributes.death.failure" });
+      if ( failures >= 3 ) outcome = "death";
+    }
+
+    return { deltas, outcome, updates };
   }
 }

--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -1,5 +1,5 @@
 /**
- * @import { BastionTurnItem } from "../../documents/_types.mjs";
+ * @import { BastionTurnItem, DeathSaveOutcome } from "../../documents/_types.mjs";
  * @import { ActivationsData, ActorDeltasData } from "./fields/_types.mjs";
  */
 
@@ -89,8 +89,10 @@
 
 /**
  * @typedef SaveMessageSystemData
- * @property {string} ability    Ability used for the save.
- * @property {boolean} resisted  Whether the save was turned into a success by spending a legendary resistance.
+ * @property {string} ability            Ability used for the save, or "death" for a death saving throw.
+ * @property {ActorDeltasData} deltas    Actor changes recorded by this save (death saves only).
+ * @property {DeathSaveOutcome} outcome  Terminal death-save outcome shown on the card, if any.
+ * @property {boolean} resisted          Whether the save was turned into a success by spending a legendary resistance.
  */
 
 /* -------------------------------------------- */

--- a/module/data/chat-message/save-message-data.mjs
+++ b/module/data/chat-message/save-message-data.mjs
@@ -83,7 +83,7 @@ export default class SaveMessageData extends RollMessageData {
       context.deltas = ActorDeltasField.processDeltas.call(this.deltas, actor, this.parent.rolls);
       context.deltasHeading = "DND5E.DeathSave";
     }
-    if ( this.outcome ) context.outcome = game.i18n.format(`DND5E.DEATH.Outcome.${this.outcome}`, {
+    if ( this.outcome ) context.outcome = _loc(`DND5E.DEATH.Outcome.${this.outcome}`, {
       name: actor?.name ?? ""
     });
     return context;

--- a/module/data/chat-message/save-message-data.mjs
+++ b/module/data/chat-message/save-message-data.mjs
@@ -1,3 +1,4 @@
+import { ActorDeltasField } from "./fields/deltas-field.mjs";
 import RollMessageData from "./roll-message-data.mjs";
 
 const { BooleanField, StringField } = foundry.data.fields;
@@ -21,6 +22,10 @@ export default class SaveMessageData extends RollMessageData {
   static defineSchema() {
     return {
       ability: new StringField({ blank: false, required: true }),
+      deltas: new ActorDeltasField(),
+      outcome: new StringField({
+        blank: false, choices: ["death", "revive", "stable"], initial: null, nullable: true, required: false
+      }),
       resisted: new BooleanField()
     };
   }
@@ -52,6 +57,13 @@ export default class SaveMessageData extends RollMessageData {
   /* -------------------------------------------- */
 
   /** @override */
+  get canCrit() {
+    return this.ability === "death";
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
   get forceSuccess() {
     return this.resisted;
   }
@@ -64,7 +76,16 @@ export default class SaveMessageData extends RollMessageData {
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     const { canResist, resisted } = this;
+    const actor = this.parent.getAssociatedActor();
     Object.assign(context, { canResist, resisted });
+    context.death = this.ability === "death";
+    if ( actor ) {
+      context.deltas = ActorDeltasField.processDeltas.call(this.deltas, actor, this.parent.rolls);
+      context.deltasHeading = "DND5E.DeathSave";
+    }
+    if ( this.outcome ) context.outcome = game.i18n.format(`DND5E.DEATH.Outcome.${this.outcome}`, {
+      name: actor?.name ?? ""
+    });
     return context;
   }
 

--- a/module/data/chat-message/save-message-data.mjs
+++ b/module/data/chat-message/save-message-data.mjs
@@ -80,8 +80,11 @@ export default class SaveMessageData extends RollMessageData {
     Object.assign(context, { canResist, resisted });
     context.death = this.ability === "death";
     if ( actor ) {
-      context.deltas = ActorDeltasField.processDeltas.call(this.deltas, actor, this.parent.rolls);
-      context.deltasHeading = "DND5E.DeathSave";
+      // Filter out success & failure tallies since their real data changes might read as confusing.
+      const deltas = {
+        ...this.deltas, actor: this.deltas.actor.filter(d => !d.keyPath.startsWith("system.attributes.death."))
+      };
+      context.deltas = ActorDeltasField.processDeltas.call(deltas, actor, this.parent.rolls);
     }
     if ( this.outcome ) context.outcome = _loc(`DND5E.DEATH.Outcome.${this.outcome}`, {
       name: actor?.name ?? ""

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -92,6 +92,12 @@
  * @property {number} tempMax  Total amount of temp max HP across all damage types.
  */
 
+/**
+ * Terminal result of a death saving throw: "death" (three failures), "revive" (natural 20, back to 1 hp),
+ * "stable" (three successes), or `null` for a non-terminal save.
+ * @typedef {"death"|"revive"|"stable"|null} DeathSaveOutcome
+ */
+
 /* -------------------------------------------- */
 
 /**

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1668,7 +1668,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const returnValue = oldFormat ? roll : rolls;
     const card = roll.parent;
 
-    const { deltas, outcome, updates } = AttributesFields.applyDeathSaveResult(death, {
+    const { outcome, updates } = AttributesFields.applyDeathSaveResult(death, {
       isSuccess: roll.total >= (roll.options.target ?? 10),
       isCritical: roll.isCritical,
       isFumble: roll.isFumble
@@ -1691,6 +1691,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( Hooks.call("dnd5e.rollDeathSave", rolls, details) === false ) return returnValue;
     if ( Hooks.call("dnd5e.rollDeathSaveV2", rolls, details) === false ) return returnValue;
 
+    const deltas = ActorDeltasField.getDeltas(this, { actor: details.updates, item: [] });
     if ( !foundry.utils.isEmpty(details.updates) ) await this.update(details.updates);
     if ( card ) await card.update({ "system.deltas": deltas, "system.outcome": details.outcome ?? null });
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -3,9 +3,9 @@ import CreateDocumentDialog from "../../applications/create-document-dialog.mjs"
 import SkillToolRollConfigurationDialog from "../../applications/dice/skill-tool-configuration-dialog.mjs";
 import PropertyAttribution from "../../applications/property-attribution.mjs";
 import TravelField from "../../data/actor/fields/travel-field.mjs";
+import AttributesFields from "../../data/actor/templates/attributes.mjs";
 import ActivationsField from "../../data/chat-message/fields/activations-field.mjs";
 import { ActorDeltasField } from "../../data/chat-message/fields/deltas-field.mjs";
-import AdvantageModeField from "../../data/fields/advantage-mode-field.mjs";
 import D20RollModificationField from "../../data/shared/d20-roll-modification-field.mjs";
 import TransformationSetting from "../../data/settings/transformation-setting.mjs";
 import { createRollLabel } from "../../enrichers.mjs";
@@ -13,7 +13,6 @@ import {
   convertTime, defaultUnits, formatLength, formatNumber, formatTime, simplifyBonus, staticID
 } from "../../utils.mjs";
 import ActiveEffect5e from "../active-effect.mjs";
-import AppliedRules from "../applied-rules.mjs";
 import Item5e from "../item.mjs";
 import SystemDocumentMixin from "../mixins/document.mjs";
 import Proficiency from "./proficiency.mjs";
@@ -34,7 +33,7 @@ import ConditionData from "../../data/active-effect/condition.mjs";
  * } from "../../dice/_types.mjs";
  * @import {
  *   ActorRollData, ActorUpdatesDescription, DamageAffectCategory, DamageApplicationOptions,
- *   DamageDescription, DamageSummary, RestConfiguration, RestResult, RollDataOptions,
+ *   DamageDescription, DamageSummary, DeathSaveOutcome, RestConfiguration, RestResult, RollDataOptions,
  *   SpellcastingDescription
  * } from "../_types.mjs";
  */
@@ -1655,14 +1654,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     const messageConfig = foundry.utils.mergeObject({
       data: {
-        flags: {
-          dnd5e: {
-            roll: {
-              type: "death"
-            }
-          }
-        },
-        flavor: _loc("DND5E.DeathSavingThrow")
+        flavor: _loc("DND5E.DeathSavingThrow"),
+        system: { ability: "death" }
       }
     }, message);
 
@@ -1673,71 +1666,33 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const details = { subject: this };
     const roll = rolls[0];
     const returnValue = oldFormat ? roll : rolls;
+    const card = roll.parent;
 
-    // Save success
-    if ( roll.total >= (roll.options.target ?? 10) ) {
-      let successes = (death.success || 0) + 1;
-
-      // Critical Success = revive with 1hp
-      if ( roll.isCritical ) {
-        details.updates = {
-          "system.attributes.death.success": 0,
-          "system.attributes.death.failure": 0,
-          "system.attributes.hp.value": 1
-        };
-        details.chatString = "DND5E.DeathSaveCriticalSuccess";
-      }
-
-      // 3 Successes = survive and reset checks
-      else if ( successes === 3 ) {
-        details.updates = {
-          "system.attributes.death.success": 0,
-          "system.attributes.death.failure": 0
-        };
-        details.chatString = "DND5E.DeathSaveSuccess";
-      }
-
-      // Increment successes
-      else details.updates = {"system.attributes.death.success": Math.clamp(successes, 0, 3)};
-    }
-
-    // Save failure
-    else {
-      let failures = (death.failure || 0) + (roll.isFumble ? 2 : 1);
-      details.updates = {"system.attributes.death.failure": Math.clamp(failures, 0, 3)};
-      if ( failures >= 3 ) {  // 3 Failures = death
-        details.chatString = "DND5E.DeathSaveFailure";
-      }
-    }
+    const { deltas, outcome, updates } = AttributesFields.applyDeathSaveResult(death, {
+      isSuccess: roll.total >= (roll.options.target ?? 10),
+      isCritical: roll.isCritical,
+      isFumble: roll.isFumble
+    });
+    details.updates = updates;
+    details.outcome = outcome;
 
     /**
      * A hook event that fires after a death saving throw has been rolled for an Actor, but before
      * updates have been performed.
      * @function dnd5e.rollDeathSave
      * @memberof hookEvents
-     * @param {D20Roll[]} rolls         The resulting rolls.
+     * @param {D20Roll[]} rolls                The resulting rolls.
      * @param {object} data
-     * @param {string} data.chatString  Localizable string displayed in the create chat message. If not set, then
-     *                                  no chat message will be displayed.
-     * @param {object} data.updates     Updates that will be applied to the actor as a result of this save.
-     * @param {Actor5e} data.subject    Actor for which the death saving throw has been rolled.
-     * @returns {boolean}               Explicitly return `false` to prevent updates from being performed.
+     * @param {DeathSaveOutcome} data.outcome  Terminal outcome rendered on the save card, if any.
+     * @param {object} data.updates            Updates that will be applied to the actor as a result of this save.
+     * @param {Actor5e} data.subject           Actor for which the death saving throw has been rolled.
+     * @returns {boolean}                      Explicitly return `false` to prevent updates from being performed.
      */
     if ( Hooks.call("dnd5e.rollDeathSave", rolls, details) === false ) return returnValue;
     if ( Hooks.call("dnd5e.rollDeathSaveV2", rolls, details) === false ) return returnValue;
 
     if ( !foundry.utils.isEmpty(details.updates) ) await this.update(details.updates);
-
-    // Display success/failure chat message
-    let resultsMessage;
-    if ( details.chatString ) {
-      const chatData = {
-        content: _loc(details.chatString, { name: this.name }),
-        speaker: messageConfig.speaker ?? ChatMessage.getSpeaker({ actor: this })
-      };
-      ChatMessage.applyMode(chatData, messageConfig.rollMode ?? CONFIG.Dice.BasicRoll.getMessageMode());
-      resultsMessage = await ChatMessage.create(chatData);
-    }
+    if ( card ) await card.update({ "system.deltas": deltas, "system.outcome": details.outcome ?? null });
 
     /**
      * A hook event that fires after a death saving throw has been rolled and after changes have been applied.
@@ -1745,10 +1700,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
      * @memberof hookEvents
      * @param {D20Roll[]} rolls                  The resulting rolls.
      * @param {object} data
-     * @param {ChatMessage5e|void} data.message  The created results chat message.
+     * @param {ChatMessage5e|void} data.message  The save card chat message, if one was created.
      * @param {Actor5e} data.subject             Actor for which the death saving throw has been rolled.
      */
-    Hooks.callAll("dnd5e.postRollDeathSave", rolls, { message: resultsMessage, subject: this });
+    Hooks.callAll("dnd5e.postRollDeathSave", rolls, { message: card, subject: this });
 
     return returnValue;
   }

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -838,6 +838,13 @@ export function migrateMessageData(messageData) {
     updateData["flags.dnd5e.roll"] = _del;
   }
 
+  else if ( (rollType === "death") && (messageData.type === "base") ) {
+    updateData.type = "save";
+    updateData.system = _replace({ ability: "death" });
+    updateData["flags.dnd5e.messageType"] = _del;
+    updateData["flags.dnd5e.roll"] = _del;
+  }
+
   /* TODO: Re-instate these migrations when foundryvtt/foundryvtt#14229 is resolved.
   else if ( (flags?.dnd5e?.roll?.type === "generic") && (messageData.type === "base") ) {
     updateData.type = "generic";

--- a/templates/chat/parts/card-deltas.hbs
+++ b/templates/chat/parts/card-deltas.hbs
@@ -1,6 +1,6 @@
 <section class="deltas">
     <strong class="roboto-condensed-upper">
-        {{ localize (ifThen deltasHeading deltasHeading "DND5E.CHATMESSAGE.Deltas.Recovery") }}
+        {{ localize "DND5E.CHATMESSAGE.Deltas.Recovery" }}
     </strong>
     <ul class="unlist">
         {{#each deltas}}

--- a/templates/chat/parts/card-deltas.hbs
+++ b/templates/chat/parts/card-deltas.hbs
@@ -1,5 +1,7 @@
 <section class="deltas">
-    <strong class="roboto-condensed-upper">{{ localize "DND5E.CHATMESSAGE.Deltas.Recovery" }}</strong>
+    <strong class="roboto-condensed-upper">
+        {{ localize (ifThen deltasHeading deltasHeading "DND5E.CHATMESSAGE.Deltas.Recovery") }}
+    </strong>
     <ul class="unlist">
         {{#each deltas}}
         <li class="delta delta-{{ type }} operation-{{ operation }}">

--- a/templates/chat/save-card.hbs
+++ b/templates/chat/save-card.hbs
@@ -2,20 +2,28 @@
 {{{ this }}}
 {{/each}}
 
-{{#if resisted}}
-<div class="chat-card">
+{{#if (or outcome resisted canResist deltas.length)}}
+<div class="chat-card{{#if death}} death-save{{/if}}">
+    {{#if outcome}}
+    <p class="supplement">{{ outcome }}</p>
+    {{/if}}
+
+    {{#if resisted}}
     <p class="supplement">
         <strong>{{ localize "DND5E.ROLL.Status" }}</strong>
         {{ localize "DND5E.LegendaryResistance.Resisted" }}
     </p>
-</div>
-{{else if canResist}}
-<div class="chat-card">
+    {{else if canResist}}
     <div class="card-buttons">
         <button type="button" data-action="resistSave">
             <i class="fa-solid fa-dragon" inert></i>
             {{ localize "DND5E.LegendaryResistance.Action.Resist" }}
         </button>
     </div>
+    {{/if}}
+
+    {{#if deltas.length}}
+    {{> "dnd5e.card-deltas" }}
+    {{/if}}
 </div>
 {{/if}}


### PR DESCRIPTION
Since death saves alter the actor, I've used `deltas` here to record the changes (so they can be appropriately reversed when a legendary resistance is used). Also removed the split message cards reporting death save terminal outcomes. Those are included in the main card now, meaning the hook signature has also changed slightly.