### PR TITLE
Convert roll requests into bespoke system sub-type.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -26,6 +26,7 @@
 },
 
 "TYPES.ChatMessage": {
+  "prompt": "Prompt Message",
   "request": "Request Message",
   "rest": "Rest Message",
   "timePassed": "Time Passed Message",

--- a/module/data/chat-message/_module.mjs
+++ b/module/data/chat-message/_module.mjs
@@ -4,6 +4,7 @@ import CheckMessageData from "./check-message-data.mjs";
 import GenericMessageData from "./generic-message-data.mjs";
 import HitDieMessageData from "./hit-die-message-data.mjs";
 import HitPointsMessageData from "./hit-points-message-data.mjs";
+import PromptMessageData from "./prompt-message-data.mjs";
 import RequestMessageData from "./request-message-data.mjs";
 import RestMessageData from "./rest-message-data.mjs";
 import RollMessageData from "./roll-message-data.mjs";
@@ -19,6 +20,7 @@ export {
   GenericMessageData,
   HitDieMessageData,
   HitPointsMessageData,
+  PromptMessageData,
   RequestMessageData,
   RestMessageData,
   RollMessageData,
@@ -36,6 +38,7 @@ export const config = {
   generic: GenericMessageData,
   hitDie: HitDieMessageData,
   hitPoints: HitPointsMessageData,
+  prompt: PromptMessageData,
   request: RequestMessageData,
   rest: RestMessageData,
   save: SaveMessageData,

--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -58,6 +58,31 @@
 /* -------------------------------------------- */
 
 /**
+ * @typedef PromptMessageSystemData
+ * @property {boolean} broadcast           Whether the prompt is broadcast to the whole table or applies only to the
+ *                                         speaker.
+ * @property {PromptButtonData[]} buttons  Buttons offering a roll or an action to the user.
+ */
+
+/**
+ * @typedef {"check"|"concentration"|"endConcentration"|"save"|"skill"|"tool"} PromptButtonType
+ */
+
+/**
+ * @typedef PromptButtonData
+ * @property {string} [ability]                 Ability used for the roll.
+ * @property {number} [dc]                      Target value for the roll.
+ * @property {"long"|"short"} [format]          Label format style.
+ * @property {string} [skill]                   Skill used for the roll.
+ * @property {string} [tool]                    Tool used for the roll.
+ * @property {PromptButtonType} type            Roll or action performed by this button.
+ * @property {string} [usingTool]               Tool used to make a skill check.
+ * @property {"all"|"creator"|"gm"} visibility  Which users can see this button.
+ */
+
+/* -------------------------------------------- */
+
+/**
  * @typedef RequestMessageSystemData
  * @property {object} button
  * @property {string} [button.icon]         Font awesome code or path to SVG icon for the request button.

--- a/module/data/chat-message/prompt-message-data.mjs
+++ b/module/data/chat-message/prompt-message-data.mjs
@@ -1,0 +1,156 @@
+import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
+import { createRollLabel, roll } from "../../enrichers.mjs";
+
+const { ArrayField, BooleanField, NumberField, StringField, TypedSchemaField } = foundry.data.fields;
+
+/**
+ * @import { PromptMessageSystemData } from "./_types.mjs";
+ */
+
+/**
+ * Data stored in a chat message prompting a player to roll or take an action.
+ * @extends {ChatMessageDataModel<PromptMessageSystemData>}
+ * @mixes PromptMessageSystemData
+ */
+export default class PromptMessageData extends ChatMessageDataModel {
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {
+      broadcast: new BooleanField({ initial: true }),
+      buttons: new ArrayField(new TypedSchemaField({
+        check: PromptMessageData.#d20TestFields(),
+        concentration: PromptMessageData.#d20TestFields(),
+        endConcentration: PromptMessageData.#sharedFields(),
+        save: PromptMessageData.#d20TestFields(),
+        skill: {
+          ...PromptMessageData.#d20TestFields(),
+          skill: new StringField({ blank: false, required: false }),
+          usingTool: new StringField({ blank: false, required: false })
+        },
+        tool: {
+          ...PromptMessageData.#d20TestFields(),
+          tool: new StringField({ blank: false, required: false })
+        }
+      }))
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Fields shared by the button types that trigger a d20 test.
+   * @returns {Record<string, DataField>}
+   */
+  static #d20TestFields() {
+    return {
+      ...PromptMessageData.#sharedFields(),
+      ability: new StringField({ blank: false, required: false }),
+      dc: new NumberField({ integer: true, nullable: true, required: false }),
+      format: new StringField({ choices: ["long", "short"], initial: "short", required: true })
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Fields shared by every button type.
+   * @returns {Record<string, DataField>}
+   */
+  static #sharedFields() {
+    return {
+      visibility: new StringField({ choices: ["all", "creator", "gm"], initial: "all", required: true })
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    actions: {
+      endConcentration: PromptMessageData.#endConcentration,
+      roll: PromptMessageData.#roll
+    },
+    template: "systems/dnd5e/templates/chat/prompt-card.hbs"
+  }, { inplace: false }));
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext(options) {
+    const isCreator = game.user.isGM || this.parent.getAssociatedActor()?.isOwner || this.parent.isAuthor;
+    return {
+      buttons: this.buttons.map((button, index) => ({
+        index,
+        action: button.type === "endConcentration" ? "endConcentration" : "roll",
+        hidden: ((button.visibility === "gm") && !game.user.isGM)
+          || ((button.visibility === "creator") && !isCreator),
+        hiddenLabel: createRollLabel({ ...button, hideDC: true, icon: true }),
+        label: createRollLabel({ ...button, icon: true })
+      }))
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onRender(element) {
+    super._onRender(element);
+    if ( this.parent.shouldDisplayChallenge ) element.dataset.displayChallenge = "";
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners & Handlers                  */
+  /* -------------------------------------------- */
+
+  /**
+   * End concentration for the actor associated with this message.
+   * @this {PromptMessageData}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static async #endConcentration(event, target) {
+    target.disabled = true;
+    try {
+      await this.parent.getAssociatedActor()?.endConcentration();
+    } finally {
+      target.disabled = false;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Perform the roll described by the clicked button.
+   * @this {PromptMessageData}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   */
+  static async #roll(event, target) {
+    const button = this.#getButton(target);
+    if ( !button ) return;
+    target.disabled = true;
+    try {
+      await roll({ ...button, actor: this.broadcast ? null : this.parent.getAssociatedActor() }, event);
+    } finally {
+      target.disabled = false;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Retrieve the configuration for the button that was clicked.
+   * @param {HTMLElement} target  Button that was clicked.
+   * @returns {object|void}
+   */
+  #getButton(target) {
+    return this.buttons[Number(target.dataset.index)];
+  }
+}

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -8,7 +8,6 @@ import ActivationsField from "../../data/chat-message/fields/activations-field.m
 import { ActorDeltasField } from "../../data/chat-message/fields/deltas-field.mjs";
 import D20RollModificationField from "../../data/shared/d20-roll-modification-field.mjs";
 import TransformationSetting from "../../data/settings/transformation-setting.mjs";
-import { createRollLabel } from "../../enrichers.mjs";
 import {
   convertTime, defaultUnits, formatLength, formatNumber, formatTime, simplifyBonus, staticID
 } from "../../utils.mjs";
@@ -1128,31 +1127,14 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const isConcentrating = this.concentration.effects.size > 0;
     if ( !isConcentrating ) return null;
 
-    const dataset = {
-      action: "concentration",
-      dc: dc
-    };
-    if ( ability in CONFIG.DND5E.abilities ) dataset.ability = ability;
-
-    const config = {
-      type: "concentration",
-      format: "short",
-      icon: true
-    };
+    const button = { dc, format: "short", type: "concentration" };
+    if ( ability in CONFIG.DND5E.abilities ) button.ability = ability;
 
     return ChatMessage.implementation.create({
-      content: await foundry.applications.handlebars.renderTemplate(
-        "systems/dnd5e/templates/chat/roll-request-card.hbs",
-        {
-          buttons: [{
-            dataset: { ...dataset, type: "concentration", visibility: "all" },
-            buttonLabel: createRollLabel({ ...dataset, ...config }),
-            hiddenLabel: createRollLabel({ ...dataset, ...config, hideDC: true })
-          }]
-        }
-      ),
-      whisper: game.users.filter(user => this.testUserPermission(user, "OWNER")),
-      speaker: ChatMessage.implementation.getSpeaker({ actor: this })
+      speaker: ChatMessage.implementation.getSpeaker({ actor: this }),
+      system: { broadcast: false, buttons: [button] },
+      type: "prompt",
+      whisper: game.users.filter(user => this.testUserPermission(user, "OWNER"))
     });
   }
 
@@ -1166,23 +1148,11 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const isConcentrating = this.concentration.effects.size > 0;
     if ( !isConcentrating ) return null;
 
-    const label = `<i class="fa-solid fa-ban" inert></i>${
-      _loc("DND5E.CONCENTRATION.Action.Break")
-    }`;
-
     return ChatMessage.implementation.create({
-      content: await foundry.applications.handlebars.renderTemplate(
-        "systems/dnd5e/templates/chat/roll-request-card.hbs",
-        {
-          buttons: [{
-            dataset: { action: "endConcentration", actorUuid: this.uuid, visibility: "all" },
-            buttonLabel: label,
-            hiddenLabel: label
-          }]
-        }
-      ),
-      whisper: game.users.filter(user => this.testUserPermission(user, "OWNER")),
-      speaker: ChatMessage.implementation.getSpeaker({ actor: this })
+      speaker: ChatMessage.implementation.getSpeaker({ actor: this }),
+      system: { broadcast: false, buttons: [{ type: "endConcentration" }] },
+      type: "prompt",
+      whisper: game.users.filter(user => this.testUserPermission(user, "OWNER"))
     });
   }
 

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -663,20 +663,22 @@ function createCheckRequestButtons(dataset) {
   const skills = foundry.utils.getType(dataset.skill) === "string" ? dataset.skill.split("|") : dataset.skill ?? [];
   const tools = foundry.utils.getType(dataset.tool) === "string" ? dataset.tool.split("|") : dataset.tool ?? [];
   if ( ((skills.length + tools.length) <= 1) && !dataset.usingTool ) {
-    if ( !dataset.ability ) {
-      if ( skills.length === 1 ) dataset.ability = CONFIG.DND5E.skills[skills[0]]?.ability;
-      else if ( tools.length === 1 ) dataset.ability = CONFIG.DND5E.tools[tools[0]]?.ability;
-    }
-    return [createRequestButton(dataset)];
+    const [skill] = skills;
+    const [tool] = tools;
+    return [createPromptButton({
+      ...dataset, skill, tool,
+      ability: dataset.ability || (skill ? CONFIG.DND5E.skills[skill]?.ability : CONFIG.DND5E.tools[tool]?.ability),
+      type: skill ? "skill" : tool ? "tool" : "check"
+    })];
   }
   const baseDataset = { ...dataset };
   delete baseDataset.skill;
   delete baseDataset.tool;
   return [
-    ...skills.map(skill => createRequestButton({
+    ...skills.map(skill => createPromptButton({
       ability: CONFIG.DND5E.skills[skill].ability, ...baseDataset, format: "short", skill, type: "skill"
     })),
-    ...dataset.usingTool ? [] : tools.map(tool => createRequestButton({
+    ...dataset.usingTool ? [] : tools.map(tool => createPromptButton({
       ability: CONFIG.DND5E.tools[tool]?.ability, ...baseDataset, format: "short", tool, type: "tool"
     }))
   ];
@@ -843,7 +845,7 @@ async function handleSaveCommand(config) {
 function createSaveRequestButtons(dataset) {
   const abilities = foundry.utils.getType(dataset.ability) === "string" ? dataset.ability.split("|")
     : dataset.ability ?? [];
-  return abilities.map(ability => createRequestButton({ ...dataset, format: "long", ability }));
+  return abilities.map(ability => createPromptButton({ ...dataset, format: "long", ability }));
 }
 
 /* -------------------------------------------- */
@@ -882,7 +884,7 @@ async function rollCheckSave(config, event) {
   if ( ability in CONFIG.DND5E.abilities ) options.ability = ability;
   if ( dc ) options.target = Number(dc);
 
-  const actors = getSceneTargets().map(t => t.actor);
+  const actors = config.actor ? [config.actor] : getSceneTargets().map(t => t.actor);
   if ( !actors.length && game.user.character ) actors.push(game.user.character);
   if ( !actors.length ) {
     ui.notifications.warn("EDITOR.DND5E.Inline.Warning.NoActor");
@@ -1626,6 +1628,9 @@ export function createRollLabel(config) {
       if ( showDC ) label = _loc("EDITOR.DND5E.Inline.DC", { dc: config.dc, check: label });
       label = _loc(`EDITOR.DND5E.Inline.Save${longSuffix}`, { save: label });
       break;
+    case "endConcentration":
+      label = _loc("DND5E.CONCENTRATION.Action.Break");
+      break;
     default:
       return "";
   }
@@ -1642,6 +1647,9 @@ export function createRollLabel(config) {
       case "concentration":
       case "save":
         label = `<i class="fas fa-shield-heart"></i>${label}`;
+        break;
+      case "endConcentration":
+        label = `<i class="fa-solid fa-ban" inert></i>${label}`;
         break;
     }
   }
@@ -1810,39 +1818,56 @@ async function handlePostRequest(dataset, target) {
   let buttons;
   if ( dataset.type === "check" ) buttons = createCheckRequestButtons(dataset);
   else if ( dataset.type === "save" ) buttons = createSaveRequestButtons(dataset);
-  else buttons = [createRequestButton({ ...dataset, format: "short" })];
+  else buttons = [createPromptButton({ ...dataset, format: "short" })];
 
   const MessageClass = getDocumentClass("ChatMessage");
-  const chatData = {
-    user: game.user.id,
-    content: await foundry.applications.handlebars.renderTemplate(
-      "systems/dnd5e/templates/chat/roll-request-card.hbs", { buttons }
-    ),
+  MessageClass.create({
     flavor: _loc("EDITOR.DND5E.Inline.RollRequest"),
-    speaker: MessageClass.getSpeaker({ user: game.user })
-  };
-  MessageClass.create(chatData);
+    speaker: MessageClass.getSpeaker({ user: game.user }),
+    system: { broadcast: true, buttons },
+    type: "prompt",
+    user: game.user.id
+  });
 }
 
 /* -------------------------------------------- */
 
 /**
- * Create a button for a chat request.
- * @param {object} dataset
+ * Create a button descriptor for a prompt message.
+ * @param {object} config
  * @returns {object}
  */
-function createRequestButton(dataset) {
-  return {
-    buttonLabel: createRollLabel({ ...dataset, icon: true }),
-    hiddenLabel: createRollLabel({ ...dataset, icon: true, hideDC: true }),
-    dataset: { ...dataset, action: "rollRequest", visibility: "all" }
-  };
+function createPromptButton(config) {
+  const { ability, dc, format, skill, tool, type, usingTool, visibility } = config;
+  const button = { ability, format, type, visibility };
+  if ( dc ) button.dc = Number(dc);
+  if ( skill ) button.skill = skill;
+  if ( tool ) button.tool = tool;
+  if ( usingTool ) button.usingTool = usingTool;
+  return button;
 }
 
 /* -------------------------------------------- */
 
 /**
- * Handle performing a roll.
+ * Perform the roll described by the provided configuration.
+ * @param {object} config  Roll configuration.
+ * @param {Event} [event]  Triggering click event.
+ * @returns {Promise}
+ */
+export async function roll(config, event) {
+  switch ( config.type ) {
+    case "attack": return rollAttack(config, event);
+    case "damage": return rollDamage(config, event);
+    case "item": return useItem(config, event);
+    default: return rollCheckSave(config, event);
+  }
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Handle performing a roll from a link or button in rendered content.
  * @param {Event} event         Triggering click event.
  * @param {HTMLElement} target  Button that was clicked.
  * @returns {Promise}
@@ -1853,12 +1878,7 @@ async function handleRoll(event, target) {
   link.disabled = true;
   window.getSelection().empty();
   try {
-    switch ( dataset.type ) {
-      case "attack": return await rollAttack(dataset, event);
-      case "damage": return await rollDamage(dataset, event);
-      case "item": return await useItem(dataset, event);
-      default: return await rollCheckSave(dataset, event);
-    }
+    return await roll(dataset, event);
   } finally {
     link.disabled = false;
   }

--- a/system.json
+++ b/system.json
@@ -52,6 +52,7 @@
       "generic": {},
       "hitDie": {},
       "hitPoints": {},
+      "prompt": {},
       "request": {},
       "rest": {},
       "save": {},

--- a/templates/chat/prompt-card.hbs
+++ b/templates/chat/prompt-card.hbs
@@ -1,8 +1,8 @@
 <div class="chat-card request-card">
     <div class="card-buttons">
         {{#each buttons}}
-        <button {{ dnd5e-dataset dataset }}>
-            <span class="visible-dc">{{{ buttonLabel }}}</span>
+        <button type="button" data-action="{{ action }}" data-index="{{ index }}" {{#if hidden}}hidden{{/if}}>
+            <span class="visible-dc">{{{ label }}}</span>
             <span class="hidden-dc">{{{ hiddenLabel }}}</span>
         </button>
         {{/each}}


### PR DESCRIPTION
No migration for this one. Roll requests didn't write a `roll.type` flag and I didn't want a heuristic check, so I think these cards will just remain unmigrated and eventually their click handlers will stop being applied but I don't foresee that being a problem for these types of cards.

I also opted for `prompt` over `rollRequest` partly because I am biased against camelCase property names in general, and partly because we had co-opted this message type for the end concentration prompt, which is not a request for a roll. I figured it might be more generally useful to have a card that will accept extensible data for prompting for various game actions.

I also considered whether this should be unified with the `request` card in some way, since they can both request rolls, but the `request` card has specific targets rather being broadcast for anyone to optionally roll, and it is also stateful, unlike this card.