### PR TITLE
Very early proof of concept for adding typed damage multipliers to `system.traits.dm`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2480,7 +2480,8 @@
 "DND5E.DamageModification": {
   "Label": "Damage Modification",
   "Hint": "Formulas for amounts that will be added to typed damage applied to this actor. Negative values will reduce the damage taken.",
-  "BypassHint": "These weapon properties will bypass damage modification for physical damage."
+  "BypassHint": "These weapon properties will bypass damage modification for physical damage.",
+  "MultiplyHint": "Multipliers that will be applied to typed damage applied to this actor. Negative values will result in restoring health, rather than decreasing it."
 },
 "DND5E.DamageRoll": "Damage Roll",
 "DND5E.DamageThreshold": "Damage Threshold",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2510,7 +2510,8 @@
   "Label": "Damage Modification",
   "Hint": "Formulas for amounts that will be added to typed damage applied to this actor. Negative values will reduce the damage taken.",
   "BypassHint": "These weapon properties will bypass damage modification for physical damage.",
-  "Formatter": "{name} Damage Modification"
+  "Formatter": "{name} Damage Modification",
+  "MultiplyHint": "Multipliers that will be applied to typed damage applied to this actor. Negative values will result in restoring health, rather than decreasing it."
 },
 "DND5E.DamageRoll": "Damage Roll",
 "DND5E.DamageThreshold": "Damage Threshold",

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -695,7 +695,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     const dm = this.actor.system.traits?.dm;
     if ( dm ) {
       const rollData = this.actor.getRollData({ deterministic: true });
-      const values = Object.entries(dm.amount).map(([k, v]) => {
+      const amountValues = Object.entries(dm.amount).map(([k, v]) => {
         const total = simplifyBonus(v, rollData);
         if ( !total ) return null;
         const value = {
@@ -709,6 +709,20 @@ export default class BaseActorSheet extends PrimarySheetMixin(
         }));
         return value;
       }).filter(f => f);
+      const multiplyValues = Object.entries(dm.multiply).map(([k, v]) => {
+        if ( !v || v === 1) return null;
+        const value = {
+          label: `${CONFIG.DND5E.damageTypes[k]?.label ?? k} × ${formatNumber(v)}`,
+          color: v > 1 ? "maroon" : "green"
+        };
+        const icons = value.icons = [];
+        if ( dm.bypasses.size && CONFIG.DND5E.damageTypes[k]?.isPhysical ) icons.push(...dm.bypasses.map(p => {
+          const type = CONFIG.DND5E.itemProperties[p]?.label;
+          return { icon: p, label: _loc("DND5E.DAMAGE.PhysicalBypass.DescriptionShort", { type }) };
+        }));
+        return value;
+      }).filter(f => f);
+      const values = [...amountValues, ...multiplyValues];
       if ( values.length ) traits.dm = values;
     }
 

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -699,7 +699,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     const dm = this.actor.system.traits?.dm;
     if ( dm ) {
       const rollData = this.actor.getRollData({ deterministic: true });
-      const values = Object.entries(dm.amount).map(([k, v]) => {
+      const amountValues = Object.entries(dm.amount).map(([k, v]) => {
         const total = simplifyBonus(v, rollData);
         if ( !total ) return null;
         const value = {
@@ -713,6 +713,20 @@ export default class BaseActorSheet extends PrimarySheetMixin(
         }));
         return value;
       }).filter(f => f);
+      const multiplyValues = Object.entries(dm.multiply).map(([k, v]) => {
+        if ( !v || v === 1) return null;
+        const value = {
+          label: `${CONFIG.DND5E.damageTypes[k]?.label ?? k} × ${formatNumber(v)}`,
+          color: v > 1 ? "maroon" : "green"
+        };
+        const icons = value.icons = [];
+        if ( dm.bypasses.size && CONFIG.DND5E.damageTypes[k]?.isPhysical ) icons.push(...dm.bypasses.map(p => {
+          const type = CONFIG.DND5E.itemProperties[p]?.label;
+          return { icon: p, label: _loc("DND5E.DAMAGE.PhysicalBypass.DescriptionShort", { type }) };
+        }));
+        return value;
+      }).filter(f => f);
+      const values = [...amountValues, ...multiplyValues];
       if ( values.length ) traits.dm = values;
     }
 

--- a/module/applications/actor/config/damages-config.mjs
+++ b/module/applications/actor/config/damages-config.mjs
@@ -47,11 +47,22 @@ export default class DamagesConfig extends TraitsConfig {
     }, {}));
     context.value = {};
     if ( this.options.trait === "dm" ) {
-      context.choices.forEach((key, data) => data.chosen = context.data.amount[key] ?? "");
+      context.choices = new SelectChoices({
+        amount: context.choices.OTHER,
+        multiply: {
+          label: context.choices.OTHER.label,
+          // TODO: Should this different hint & field be moved elsewhere? Probably
+          hint: "DND5E.DamageModification.MultiplyHint",
+          field: new foundry.data.fields.NumberField(),
+          // TODO: Technically this won't be immediately accurate, but there's relevance for `chosen` here anyway
+          children: context.choices.OTHER.children.clone()
+        }
+      });
+      context.choices.amount.children.forEach((key, data) => data.chosen = context.data.amount[key] ?? "");
+      context.choices.multiply.children.forEach((key, data) => data.chosen = context.data.multiply[key] ?? "");
       context.bypassHint = "DND5E.DamageModification.BypassHint";
       context.hint = "DND5E.DamageModification.Hint";
       context.value.field = new FormulaField({ determinstic: true });
-      context.value.key = "amount";
     } else {
       context.bypassHint = "DND5E.DAMAGE.PhysicalBypass.Hint";
       context.value.field = context.checkbox;
@@ -78,10 +89,12 @@ export default class DamagesConfig extends TraitsConfig {
   _processFormData(event, form, formData) {
     const submitData = super._processFormData(event, form, formData);
     if ( this.options.trait === "dm" ) {
-      for ( const [type, formula] of Object.entries(submitData.system?.traits?.dm?.amount ?? {}) ) {
-        if ( !formula ) {
-          delete submitData.system.traits.dm.amount[type];
-          submitData.system.traits.dm.amount[type] = _del;
+      for ( const subKey of ["amount", "multiply"] ) {
+        for ( const [type, modification] of Object.entries(submitData.system?.traits?.dm?.[subKey] ?? {}) ) {
+          if ( !modification ) {
+            delete submitData.system.traits.dm[subKey][type];
+            submitData.system.traits.dm[subKey][type] = _del;
+          }
         }
       }
     }

--- a/module/data/actor/templates/_types.mjs
+++ b/module/data/actor/templates/_types.mjs
@@ -158,8 +158,9 @@
 
 /**
  * @typedef DamageModificationData
- * @property {Record<string, string>} amount  Damage boost or reduction by damage type.
- * @property {Set<string>} bypasses           Keys for physical properties that cause modification to be bypassed.
+ * @property {Record<string, string>} amount    Damage boost or reduction by damage type.
+ * @property {Set<string>} bypasses             Keys for physical properties that cause modification to be bypassed.
+ * @property {Record<string, number>} multiply  Damage multiplier by damage type.
  */
 
 /**

--- a/module/data/actor/templates/_types.mjs
+++ b/module/data/actor/templates/_types.mjs
@@ -154,8 +154,9 @@
 
 /**
  * @typedef DamageModificationData
- * @property {Record<string, string>} amount  Damage boost or reduction by damage type.
- * @property {Set<string>} bypasses           Keys for physical properties that cause modification to be bypassed.
+ * @property {Record<string, string>} amount    Damage boost or reduction by damage type.
+ * @property {Set<string>} bypasses             Keys for physical properties that cause modification to be bypassed.
+ * @property {Record<string, number>} multiply  Damage multiplier by damage type.
  */
 
 /**

--- a/module/data/actor/templates/traits.mjs
+++ b/module/data/actor/templates/traits.mjs
@@ -31,6 +31,9 @@ export default class TraitsField {
         }),
         bypasses: new SetField(new StringField(), {
           label: "DND5E.DAMAGE.PhysicalBypass.Label", hint: "DND5E.DAMAGE.PhysicalBypass.Hint"
+        }),
+        multiply: new MappingField(new NumberField({nullable: false, initial: 1}), {
+          label: "DND5E.DamMult", labels: { value: "DND5E.DamMult" }
         })
       }),
       ci: new SimpleTraitField({}, { label: "DND5E.ConImm" })

--- a/module/data/actor/templates/traits.mjs
+++ b/module/data/actor/templates/traits.mjs
@@ -35,6 +35,9 @@ export default class TraitsField {
         ),
         bypasses: new SetField(new StringField(), {
           label: "DND5E.DAMAGE.PhysicalBypass.Label", hint: "DND5E.DAMAGE.PhysicalBypass.Hint"
+        }),
+        multiply: new MappingField(new NumberField({nullable: false, initial: 1}), {
+          label: "DND5E.DamMult", labels: { value: "DND5E.DamMult" }
         })
       }),
       ci: new SimpleTraitField({}, { label: "DND5E.TRAIT.Condition.Immunity.title" })

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -826,18 +826,27 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     const dm = this.system.traits?.dm ?? {};
     const rollData = this.getRollData({ deterministic: true });
-    const modifications = Object.entries(dm.amount ?? {}).reduce((obj, [type, formula]) => {
+    const amountModifications = Object.entries(dm.amount ?? {}).reduce((obj, [type, formula]) => {
       obj[type] = simplifyBonus(formula, rollData);
       return obj;
     }, {});
-    const applyModification = (d, type=d.type) => {
-      if ( !modifications[type] || this.#changeIsIgnored("modification", type, { options }) ) return;
+    const applyAmountModification = (d, type) => {
+      if ( !amountModifications[type] || this.#changeIsIgnored("modification", type, { options }) ) return;
       const originalValue = d.value;
-      if ( Math.sign(d.value) !== Math.sign(d.value + modifications[type]) ) d.value = 0;
-      else d.value += modifications[type];
+      if ( Math.sign(d.value) !== Math.sign(d.value + amountModifications[type]) ) d.value = 0;
+      else d.value += amountModifications[type];
       (d.active[type === "ALL" ? "all" : "type"] ??= {}).modification = true;
-      modifications[type] += originalValue - d.value;
+      amountModifications[type] += originalValue - d.value;
     };
+    const applyMultiplyModification = (d, type) => {
+      if ( !dm.multiply?.[type] || this.#changeIsIgnored("modification", type, { options }) ) return;
+      d.value *= dm.multiply[type];
+      (d.active[type === "ALL" ? "all" : "type"] ??= {}).modification = true;
+    }
+    const applyModification = (d, type=d.type) => {
+      applyAmountModification(d, type);
+      applyMultiplyModification(d, type);
+    }
 
     damages.forEach(d => {
       d.active ??= {};

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -881,18 +881,27 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     const dm = this.system.traits?.dm ?? {};
     const rollData = this.getRollData({ deterministic: true });
-    const modifications = Object.entries(dm.amount ?? {}).reduce((obj, [type, formula]) => {
+    const amountModifications = Object.entries(dm.amount ?? {}).reduce((obj, [type, formula]) => {
       obj[type] = simplifyBonus(formula, rollData);
       return obj;
     }, {});
-    const applyModification = (d, type=d.type) => {
-      if ( !modifications[type] || this.#changeIsIgnored("modification", type, { options }) ) return;
+    const applyAmountModification = (d, type) => {
+      if ( !amountModifications[type] || this.#changeIsIgnored("modification", type, { options }) ) return;
       const originalValue = d.value;
-      if ( Math.sign(d.value) !== Math.sign(d.value + modifications[type]) ) d.value = 0;
-      else d.value += modifications[type];
+      if ( Math.sign(d.value) !== Math.sign(d.value + amountModifications[type]) ) d.value = 0;
+      else d.value += amountModifications[type];
       (d.active[type === "ALL" ? "all" : "type"] ??= {}).modification = true;
-      modifications[type] += originalValue - d.value;
+      amountModifications[type] += originalValue - d.value;
     };
+    const applyMultiplyModification = (d, type) => {
+      if ( !dm.multiply?.[type] || this.#changeIsIgnored("modification", type, { options }) ) return;
+      d.value *= dm.multiply[type];
+      (d.active[type === "ALL" ? "all" : "type"] ??= {}).modification = true;
+    }
+    const applyModification = (d, type=d.type) => {
+      applyAmountModification(d, type);
+      applyMultiplyModification(d, type);
+    }
 
     damages.forEach(d => {
       d.active ??= {};

--- a/templates/actors/config/damages-config.hbs
+++ b/templates/actors/config/damages-config.hbs
@@ -2,9 +2,13 @@
     {{#each choices}}
     <fieldset class="traits card">
         <legend>{{ label }}</legend>
-        {{#if @root.hint}}<p class="hint">{{ localize @root.hint }}</p>{{/if}}
-        {{> "dnd5e.traits-list" choices=children keyPath=(concat @root.keyPath "." @root.value.key ".") topLevel=true
-            field=@root.value.field input=@root.value.input }}
+        {{#if hint}}
+        <p class="hint">{{localize hint}}</p>
+        {{else if @root.hint}}
+        <p class="hint">{{ localize @root.hint }}</p>
+        {{/if}}
+        {{> "dnd5e.traits-list" choices=children keyPath=(concat @root.keyPath "." (ifThen @root.value.key @root.value.key @key) ".") topLevel=true
+            field=(ifThen field field @root.value.field) input=@root.value.input }}
     </fieldset>
     {{/each}}
     <fieldset class="traits bypasses card">


### PR DESCRIPTION
Closes #4917, if we go this direction.
Very basic implementation of "what if we just add `multiply` under `traits.dm`?"
Besides just generally lacking some polish (there's a few areas for code deduplication, if nothing else), the main two pieces I'd call out as potentially troublesome are:
- The existing trait infrastructure doesn't _really_ support this use case. Illustrated in the `DamagesConfig` TODOs: I added a not-currently-typed `hint` and `field` to the `SelectChoices` being created so that they can be different for `dm.multiply` vs `dm.amount`. A better solution would also be a more _involved_ solution, either registering them as different traits (maybe we should) or introducing logic in `SelectChoices` and in `trait.mjs` for scenarios like this one. Of which I think there are probably 0, not including this one.
- When would this multiplication happen, ideally? Right now I have it being applied directly after `dm.amount` modification. I think any decision here will be a bit of a guess, since there isn't really a concept of arbitrary damage multiplication. Best we could do probably is determine how something like absorption would be intended to work in a scenario where a creature has resistance to all damage types, but also absorption of, say, fire damage. Should they absorb the non-resisted amount, or the post-resist amount, etc etc.

Also entirely possible that this method of implementation is not one that you guys wanna go with. The "hard" part of this PR was just making it play nice with the sheet UI, so nothing much would be lost if so.

Edit: unmarking as draft since in theory this is fully functional as-is; I just knew it'd need some cleanup which made me want to mark it draft, but there's nothing more I feel inclined to do on it without feedback on direction.