### PR TITLE
[#4091] Add effects tab to group actor sheet, suppress transfer effects from items on group actors

### DIFF
--- a/less/v2/group.less
+++ b/less/v2/group.less
@@ -452,6 +452,17 @@
 
   &.tab-inventory.vehicle-inventory .window-content > .create-child { display: none; }
 
+  /* ---------------------------------- */
+  /*  Effects                           */
+  /* ---------------------------------- */
+
+  [data-application-part=effects] > .effects-element {
+    padding: 6px 4px calc(1.5rem + 30px) 12px;
+    margin-right: 4px;
+    overflow-y: auto;
+    scrollbar-gutter: stable;
+  }
+
   /* -------------------------------------------- */
   /*  Locked                                      */
   /* -------------------------------------------- */

--- a/less/v2/group.less
+++ b/less/v2/group.less
@@ -456,12 +456,7 @@
   /*  Effects                           */
   /* ---------------------------------- */
 
-  [data-application-part=effects] > .effects-element {
-    padding: 6px 4px calc(1.5rem + 30px) 12px;
-    margin-right: 4px;
-    overflow-y: auto;
-    scrollbar-gutter: stable;
-  }
+  [data-application-part=effects] > .effects-element { padding: 6px 4px calc(1.5rem + 30px) 12px; }
 
   /* -------------------------------------------- */
   /*  Locked                                      */

--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -48,6 +48,11 @@ export default class GroupActorSheet extends MultiActorSheet {
       ],
       scrollable: [".sidebar", ".body"]
     },
+    effects: {
+      container: { classes: ["tab-body"], id: "tabs" },
+      template: "systems/dnd5e/templates/actors/tabs/actor-effects.hbs",
+      scrollable: [""]
+    },
     biography: {
       container: { classes: ["tab-body"], id: "tabs" },
       template: "systems/dnd5e/templates/actors/group/biography.hbs",
@@ -61,6 +66,7 @@ export default class GroupActorSheet extends MultiActorSheet {
   static TABS = [
     { tab: "members", label: "DND5E.Group.Member.other" },
     { tab: "inventory", label: "DND5E.Inventory" },
+    { tab: "effects", label: "DND5E.EFFECT.Tab" },
     { tab: "biography", label: "DND5E.Biography" }
   ];
 
@@ -175,6 +181,7 @@ export default class GroupActorSheet extends MultiActorSheet {
     context = await super._preparePartContext(partId, context, options);
     switch ( partId ) {
       case "biography": return this._prepareDescriptionContext(context, options);
+      case "effects": return this._prepareEffectsContext(context, options);
       case "header": return this._prepareHeaderContext(context, options);
       case "inventory": return this._prepareInventoryContext(context, options);
       case "members": return this._prepareMembersContext(context, options);

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -500,6 +500,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const requireEquipped = (this.type !== "consumable")
       || ["rod", "trinket", "wand"].includes(this.system.type.value);
     if ( requireEquipped && (this.system.equipped === false) ) return true;
+    if ( this.parent?.system.isGroup ) return true;
     return !this.system.attuned && (this.system.attunement === "required");
   }
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -500,7 +500,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const requireEquipped = (this.type !== "consumable")
       || ["rod", "trinket", "wand"].includes(this.system.type.value);
     if ( requireEquipped && (this.system.equipped === false) ) return true;
-    if ( this.parent?.system.isGroup ) return true;
+    if ( this.parent?.system?.isGroup ) return true;
     return !this.system.attuned && (this.system.attunement === "required");
   }
 


### PR DESCRIPTION
Closes #4091 in a different way than the issue was framed.
- Group sheet gets an effects tab. Main purpose at this point would be to delete effects accidentally applied to them, but can also be used to have effects modify group actor data.
<img width="691" height="485" alt="image" src="https://github.com/user-attachments/assets/bc7d8927-6ffa-4916-8151-a49add94d00a" />

- Modified `Item5e#areEffectsSuppressed` so that transfer effects will be suppressed on group/encounter actors, as they should be (since those actors can only have physical items, and physical items must be equipped to transfer their effects. With the exception of certain consumables. So now those consumables won't transfer their effects to group/encounter actors).

Open questions:
- Should encounter actors get an effects tab? If not, should effect creation on them be explicitly disallowed?
- Should suppressed transfer effects also be given `isConcealed` so they don't show up on this new effects tab? I guess actually probably not, since then they wouldn't show up on the item itself, would they.