### PR TITLE
Preserve item proficiency when proficiency bonus is zero

### DIFF
--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -65,6 +65,26 @@ export default class ItemDataModel extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
+   * Modes that can be used when making an attack with this item.
+   * @type {FormSelectOption[]}
+   */
+  get attackModes() {
+    return [];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Set of abilities that can automatically be associated with this item.
+   * @type {Set<string>|null}
+   */
+  get availableAbilities() {
+    return null;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Whether this item's activities can have scaling configured for their consumption.
    * @type {boolean}
    */
@@ -94,29 +114,19 @@ export default class ItemDataModel extends SystemDataModel {
 
   /* -------------------------------------------- */
 
-  /**
-   * Modes that can be used when making an attack with this item.
-   * @type {FormSelectOption[]}
-   */
-  get attackModes() {
-    return [];
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Set of abilities that can automatically be associated with this item.
-   * @type {Set<string>|null}
-   */
-  get availableAbilities() {
-    return null;
-  }
-
-  /* -------------------------------------------- */
-
   /** @override */
   get embeddedDescriptionKeyPath() {
     return game.user.isGM || (this.identified !== false) ? "description.value" : "unidentified.description";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Whether a creature can be considered proficient in this type of item.
+   * @type {boolean}
+   */
+  get hasProficiency() {
+    return false;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -138,6 +138,13 @@ export default class ConsumableData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /** @override */
+  get hasProficiency() {
+    return true;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
   static get itemCategories() {
     return CONFIG.DND5E.consumableTypes;
   }

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -142,6 +142,13 @@ export default class EquipmentData extends ItemDataModel.mixin(
 
   /* -------------------------------------------- */
 
+  /** @override */
+  get hasProficiency() {
+    return true;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * Is this Item any of the armor subtypes?
    * @type {boolean}

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -182,6 +182,13 @@ export default class FeatData extends ItemDataModel.mixin(
 
   /* -------------------------------------------- */
 
+  /** @override */
+  get hasProficiency() {
+    return true;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * The proficiency multiplier for this item.
    * @returns {number}

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -134,6 +134,17 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
 
   /* -------------------------------------------- */
 
+  /** @override */
+  get availableAbilities() {
+    if ( this.ability ) return new Set([this.ability]);
+
+    const spellcasting = this.parent?.actor?.spellcastingClasses[this.classIdentifier]?.spellcasting.ability
+      ?? this.parent?.actor?.system.attributes?.spellcasting;
+    return new Set(spellcasting ? [spellcasting] : []);
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * The identifier of the spellcasting class associated with this spell, resolved through subclass parentage where
    * necessary. Returns an empty string if the spell was not granted by a class or subclass item.
@@ -145,17 +156,6 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
     if ( sourceItem?.type === "class" ) return sourceItem.identifier;
     if ( sourceItem?.type === "subclass" ) return sourceItem.system.classIdentifier ?? "";
     return "";
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  get availableAbilities() {
-    if ( this.ability ) return new Set([this.ability]);
-
-    const spellcasting = this.parent?.actor?.spellcastingClasses[this.classIdentifier]?.spellcasting.ability
-      ?? this.parent?.actor?.system.attributes?.spellcasting;
-    return new Set(spellcasting ? [spellcasting] : []);
   }
 
   /* -------------------------------------------- */
@@ -228,6 +228,13 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   /** @override */
   get criticalThreshold() {
     return this.parent?.actor?.flags.dnd5e?.spellCriticalThreshold ?? Infinity;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  get hasProficiency() {
+    return true;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -109,6 +109,16 @@ export default class ToolData extends ItemDataModel.mixin(
   /* -------------------------------------------- */
 
   /**
+   * Which ability score modifier is used by this item?
+   * @type {string|null}
+   */
+  get abilityMod() {
+    return this.ability || "int";
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Properties displayed in chat.
    * @type {string[]}
    */
@@ -128,12 +138,9 @@ export default class ToolData extends ItemDataModel.mixin(
 
   /* -------------------------------------------- */
 
-  /**
-   * Which ability score modifier is used by this item?
-   * @type {string|null}
-   */
-  get abilityMod() {
-    return this.ability || "int";
+  /** @override */
+  get hasProficiency() {
+    return true;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -268,9 +268,9 @@ export default class WeaponData extends ItemDataModel.mixin(
     if ( !availableAbilities ) return null;
     if ( availableAbilities.size === 1 ) return availableAbilities.first();
     const abilities = this.parent?.actor?.system.abilities ?? {};
-    return availableAbilities.reduce((largest, ability) =>
-      (abilities[ability]?.mod ?? -Infinity) > (abilities[largest]?.mod ?? -Infinity) ? ability : largest
-    , availableAbilities.first());
+    return availableAbilities.reduce((largest, ability) => {
+      return (abilities[ability]?.mod ?? -Infinity) > (abilities[largest]?.mod ?? -Infinity) ? ability : largest;
+    }, availableAbilities.first());
   }
 
   /* -------------------------------------------- */
@@ -278,6 +278,13 @@ export default class WeaponData extends ItemDataModel.mixin(
   /** @override */
   get criticalThreshold() {
     return this.parent?.actor?.flags.dnd5e?.weaponCriticalThreshold ?? Infinity;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  get hasProficiency() {
+    return true;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -654,13 +654,9 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @protected
    */
   _prepareProficiency() {
-    if ( !["spell", "weapon", "equipment", "tool", "feat", "consumable"].includes(this.type) ) return;
-    if ( !Number.isFinite(this.actor?.system.attributes?.prof) ) {
-      this.system.prof = new Proficiency(0, 0);
-      return;
-    }
-
-    this.system.prof = new Proficiency(this.actor.system.attributes.prof, this.system.proficiencyMultiplier ?? 0);
+    if ( !this.system.hasProficiency ) return;
+    const prof = this.actor?.system.attributes?.prof;
+    this.system.prof = new Proficiency(Number.isFinite(prof) ? prof : 0, this.system.proficiencyMultiplier ?? 0);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -655,7 +655,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   _prepareProficiency() {
     if ( !["spell", "weapon", "equipment", "tool", "feat", "consumable"].includes(this.type) ) return;
-    if ( !this.actor?.system.attributes?.prof ) {
+    if ( !Number.isFinite(this.actor?.system.attributes?.prof) ) {
       this.system.prof = new Proficiency(0, 0);
       return;
     }


### PR DESCRIPTION
Items retain their normal proficiency multiplier when an effect sets an actor's proficiency bonus to 0.