### PR TITLE
[#6626] Move active effect origin into system data, split by type

### DIFF
--- a/module/applications/activity/activity-sheet.mjs
+++ b/module/applications/activity/activity-sheet.mjs
@@ -583,7 +583,11 @@ export default class ActivitySheet extends PseudoDocumentSheet {
     return {
       name: name || this.item.name,
       img: img || this.item.img,
-      origin: this.item.uuid,
+      system: {
+        origin: {
+          item: this.item.uuid
+        }
+      },
       transfer: false
     };
   }

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -315,7 +315,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     const concentration = originActor?.effects.get(this.chatMessage.system.concentration);
     const item = this.chatMessage.getAssociatedItem();
     const activity = this.chatMessage.getAssociatedActivity({ scaled: true });
-    const origin = concentration ?? (effect.inCompendium && item ? item : effect);
+    const sourceKey = effect.inCompendium ? "compendiumSource" : "duplicateSource";
     if ( !game.user.isGM && !actor.isOwner ) {
       throw new Error(_loc("DND5E.EFFECT.Application.Warning.Ownership"));
     }
@@ -345,9 +345,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     }
 
     // Enable an existing effect on the target if it originated from this effect
-    const existingEffect = effect.inCompendium
-      ? actor.effects.find(e => e._stats.compendiumSource === effect.uuid)
-      : actor.effects.find(e => e.origin === origin.uuid);
+    const existingEffect = actor.effects.find(e => e._stats[sourceKey] === effect.uuid);
     if ( existingEffect ) {
       return { action: "update", data: foundry.utils.mergeObject({
         ...durationOverride,
@@ -364,7 +362,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       disabled: false,
       transfer: false,
       _stats: {
-        [effect.inCompendium ? "compendiumSource" : "duplicateSource"]: effect.uuid,
+        [sourceKey]: effect.uuid,
         [effect.inCompendium ? "duplicateSource" : "compendiumSource"]: null
       }
     }, effectFlags);

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -289,7 +289,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
   /**
    * Handle applying an Active Effect to a Token.
    * @param {ActiveEffect5e} effect      The effect to apply.
-   * @param {Actor5e} actor              The actor.
+   * @param {Actor5e} actor              The actor to which the effect should be applied.
    * @returns {Promise<ActiveEffect5e>}  The created effect.
    * @throws {Error}                     If the effect could not be applied.
    * @protected
@@ -327,6 +327,12 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
           scaling: this.chatMessage.system.scaling,
           spellLevel: this.chatMessage.system.level
         }
+      },
+      system: {
+        origin: {
+          [activity ? "activity" : "item"]: activity ? activity.uuid : item?.uuid,
+          effect: concentration?.uuid
+        }
       }
     };
 
@@ -357,7 +363,6 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       ...durationOverride,
       disabled: false,
       transfer: false,
-      origin: origin.uuid,
       _stats: {
         [effect.inCompendium ? "compendiumSource" : "duplicateSource"]: effect.uuid,
         [effect.inCompendium ? "duplicateSource" : "compendiumSource"]: null

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -297,11 +297,9 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
 
     const dataset = target.closest("[data-effect-id]")?.dataset;
     const effect = this.getEffect(dataset);
-    if ( (action !== "create") && !effect ) return;
+    if ( !effect ) return;
 
     switch ( action ) {
-      case "create":
-        return this._onCreate(target);
       case "delete":
         await effect.deleteDialog({ sheet: this.#app }, { render: false });
         return this.#app.render();
@@ -391,6 +389,10 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
    * @returns {Promise<ActiveEffect5e>}
    */
   async _onCreate(target) {
+    foundry.utils.logCompatibilityWarning(
+      "`EffectsElement#_onCreate` method is not longer supported.",
+      { since: "DnD5e 6.0", until: "DnD5e 6.2" }
+    );
     const li = target.closest("li");
     const isActor = this.document instanceof Actor;
     const isEnchantment = li.dataset.effectType.startsWith("enchantment");

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -390,7 +390,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
    */
   async _onCreate(target) {
     foundry.utils.logCompatibilityWarning(
-      "`EffectsElement#_onCreate` method is not longer supported.",
+      "`EffectsElement#_onCreate` method is no longer supported.",
       { since: "DnD5e 6.0", until: "DnD5e 6.2" }
     );
     const li = target.closest("li");

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -967,12 +967,13 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
     const effect = await ActiveEffect.implementation.fromDropData(data);
     if ( !this.item.isOwner || !effect
       || (this.item.uuid === effect.parent?.uuid)
-      || (this.item.uuid === effect.origin) ) return false;
+      || (this.item.uuid === effect.origin)
+      || (this.item.uuid === effect.system.origin?.uuid) ) return false;
     const effectData = effect.toObject();
     const options = { parent: this.item, keepOrigin: false };
 
     if ( effect.type === "enchantment" ) {
-      effectData.origin ??= effect.parent?.uuid;
+      effectData.system.origin.item ??= effect.parent?.uuid;
       options.keepOrigin = true;
       options.dnd5e = {
         enchantmentProfile: effect.id,

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -703,9 +703,11 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
       return ActiveEffect.implementation.createDialog({
         name: this.document.name,
         img: this.document.img,
-        origin: this.document.uuid,
         system: {
-          magical: this.document.system.properties?.has("mgc")
+          magical: this.document.system.properties?.has("mgc"),
+          origin: {
+            item: this.document.uuid
+          }
         }
       }, { parent: this.document, renderSheet: true }, { sheet: this });
     }

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -967,8 +967,7 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
     const effect = await ActiveEffect.implementation.fromDropData(data);
     if ( !this.item.isOwner || !effect
       || (this.item.uuid === effect.parent?.uuid)
-      || (this.item.uuid === effect.origin)
-      || (this.item.uuid === effect.system.origin?.uuid) ) return false;
+      || effect.matchesOrigin(this.item.uuid) ) return false;
     const effectData = effect.toObject();
     const options = { parent: this.item, keepOrigin: false };
 

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -19,6 +19,7 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
       origin: new SchemaField({
         activity: new StringField({ required: false }),
         actor: new DocumentUUIDField({ relative: true, required: false, type: "Actor" }),
+        behavior: new DocumentUUIDField({ required: false, type: "RegionBehavior" }),
         effect: new DocumentUUIDField({ relative: true, required: false, type: "ActiveEffect" }),
         item: new DocumentUUIDField({ relative: true, required: false, type: "Item" })
       })

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -1,7 +1,7 @@
 import { getHumanReadableAttributeLabel } from "../../utils.mjs";
 import FiltersField from "../fields/filters-field.mjs";
 
-const { DocumentIdField, StringField } = foundry.data.fields;
+const { DocumentIdField, DocumentUUIDField, SchemaField, StringField } = foundry.data.fields;
 
 /**
  * Abstract base class to add some shared functionality to all of the system's custom active effect types.
@@ -14,7 +14,15 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
 
   /** @inheritDoc */
   static defineSchema() {
-    const schema = super.defineSchema();
+    const schema = {
+      ...super.defineSchema(),
+      origin: new SchemaField({
+        activity: new StringField({ required: false }),
+        actor: new DocumentUUIDField({ relative: true, required: false, type: "Actor" }),
+        effect: new DocumentUUIDField({ relative: true, required: false, type: "ActiveEffect" }),
+        item: new DocumentUUIDField({ relative: true, required: false, type: "Item" })
+      })
+    };
     schema.changes.element.extendFields({
       _id: new DocumentIdField({ initial: () => foundry.utils.randomID() }),
       conditions: new FiltersField(),

--- a/module/data/active-effect/base.mjs
+++ b/module/data/active-effect/base.mjs
@@ -61,7 +61,7 @@ export default class BaseEffectData extends ActiveEffectDataModel {
    */
   get isOnActivity() {
     return this.item
-      && (this.item.system.activities?.contents ?? []).some(a => a.effects.some(e => e._id === this.parent._id));
+      && (this.item.system.activities?.contents ?? []).some(a => a.effects?.some(e => e._id === this.parent._id));
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -323,15 +323,14 @@ export default class PhysicalItemTemplate extends SystemDataModel {
     if ( enchantment ) {
       if ( !flags.preserveEffect ) enchantment = await fromUuid(enchantment._stats.compendiumSource) ?? enchantment;
       clone.updateSource({
-        effects: [{
-          ...enchantment.toObject(),
+        effects: [foundry.utils.mergeObject(enchantment.toObject(), {
           disabled: false,
           system: {
             origin: {
               item: enchantment.parent.uuid
             }
           }
-        }]
+        })]
       });
       // TODO: Add rider activities & effects once https://github.com/foundryvtt/dnd5e/issues/6357 is merged
     }

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -323,7 +323,15 @@ export default class PhysicalItemTemplate extends SystemDataModel {
     if ( enchantment ) {
       if ( !flags.preserveEffect ) enchantment = await fromUuid(enchantment._stats.compendiumSource) ?? enchantment;
       clone.updateSource({
-        effects: [{ ...enchantment.toObject(), disabled: false, origin: enchantment.parent.uuid }]
+        effects: [{
+          ...enchantment.toObject(),
+          disabled: false,
+          system: {
+            origin: {
+              item: enchantment.parent.uuid
+            }
+          }
+        }]
       });
       // TODO: Add rider activities & effects once https://github.com/foundryvtt/dnd5e/issues/6357 is merged
     }

--- a/module/data/region-behavior/apply-active-effect.mjs
+++ b/module/data/region-behavior/apply-active-effect.mjs
@@ -161,7 +161,15 @@ export default class ApplyActiveEffect5eRegionBehaviorType extends foundry.data.
         data._stats.compendiumSource = null;
       }
       data._stats.exportSource = null;
-      data.origin = this.behavior.uuid;
+      if ( data.system.origin ) {
+        delete data.origin;
+        data.system.origin = {
+          activity: this.region.flags.dnd5e?.activity,
+          behavior: this.behavior.uuid,
+          item: this.region.flags.dnd5e?.item
+        };
+      }
+      else data.origin = this.behavior.uuid;
       data.system.changes = await ActiveEffect.implementation.forApplication(data.system.changes, origin, actor);
       toCreate.push(data);
     }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -211,7 +211,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /**
    * Retrieve the source Actor or Item, or null if it could not be determined.
-   * @returns {Promise<Activity|ActiveEffect|Actor5e|Item5e|null>}
+   * @returns {Promise<Activity|ActiveEffect|Actor5e|Item5e|RegionBehavior|null>}
    */
   async getSource() {
     if ( (this.target instanceof dnd5e.documents.Actor5e) && (this.parent instanceof dnd5e.documents.Item5e) ) {
@@ -227,7 +227,8 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @returns {Actor5e|null}
    */
   getSourceActor() {
-    const origin = fromUuidSync(this.system.origin?.actor ?? this.origin, { strict: false });
+    const o = this.system.origin ?? {};
+    const origin = fromUuidSync(o.actor ?? o.item ?? o.activity ?? this.origin, { strict: false });
     return (origin instanceof dnd5e.documents.Actor5e) ? origin : (origin?.actor || null);
   }
 
@@ -313,8 +314,8 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /** @inheritDoc */
   prepareBaseData() {
-    this.origin = this.system.origin?.effect ?? this.system.origin?.activity
-      ?? this.system.origin?.item ?? this.system.origin?.actor
+    this.origin = this.system.origin?.effect ?? this.system.origin?.behavior
+      ?? this.system.origin?.activity ?? this.system.origin?.item ?? this.system.origin?.actor
       ?? this.getFlag("core", "originText") ?? this.origin;
     super.prepareBaseData();
   }
@@ -744,7 +745,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       if ( effectData ) {
         delete effectData._id;
         delete effectData.flags?.dnd5e?.rider;
-        foundry.utils.setPoperty(effectData, "system.origin", this.system.origin);
+        foundry.utils.setProperty(effectData, "system.origin", this.system.origin);
       }
       return effectData;
     }));
@@ -794,6 +795,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   async _preCreate(data, options, user) {
     if ( await super._preCreate(data, options, user) === false ) return false;
     if ( options.keepOrigin === false ) this.updateSource({
+      origin: null,
       system: {
         origin: {
           activity: _del,
@@ -1306,7 +1308,8 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   async getSheetContext() {
     this.updateDuration();
     const { id, name, img, disabled, duration } = this;
-    const source = await this.getSource();
+    let source = await this.getSource();
+    if ( source instanceof RegionBehavior ) source = this.getSourceActor() ?? source;
     const special = this.getSpecialDurationParts();
     return {
       id, name, img, disabled, duration, source,
@@ -1334,6 +1337,18 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     };
     context.name ||= change.key;
     return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Determine if any of the origin values match a certain UUID.
+   * @param {string} uuid
+   * @returns {boolean}
+   */
+  matchesOrigin(uuid) {
+    return (this._source.origin === uuid)
+      || foundry.utils.iterateValues(this.system.origin ?? {}).some(o => o === uuid);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -69,9 +69,11 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /**
    * Active effect fields that should be redirected to another field, optionally with a compatibility warning.
    * Optional warning object contains options passed to `foundry.utils.logCompatibilityWarning`.
-   * @type {Record<string, { key: string, [type]: string, [value]: Function, [warning]: object }>}
+   * @type {Record<string, { key: string, [type]: string, [value]: any, [warning]: object }>}
    */
   static SHIM_FIELDS = {
+    "activities[attack].attack.ability": { key: "activities[attack].attack.abilities" },
+    "flags.dnd5e.initiativeAdv": { key: "system.attributes.init.roll.mode", type: "add", value: 1 },
     "system.attributes.concentration.bonuses.save": { key: "system.attributes.concentration.roll.bonus" },
     "system.attributes.death.bonuses.save": { key: "system.attributes.death.roll.bonus" },
     "system.attributes.init.bonus": { key: "system.attributes.init.roll.bonus" },
@@ -96,8 +98,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     "system.bonuses.rsak.damage": { key: "system.rolls.damage.rsak.bonus" },
     "system.bonuses.abilities.check": { key: "system.rolls.ability.check.bonus" },
     "system.bonuses.abilities.save": { key: "system.rolls.ability.save.bonus" },
-    "system.bonuses.abilities.skill": { key: "system.rolls.ability.skill.bonus" },
-    "activities[attack].attack.ability": { key: "activities[attack].attack.abilities" }
+    "system.bonuses.abilities.skill": { key: "system.rolls.ability.skill.bonus" }
   };
 
   /* -------------------------------------------- */
@@ -210,7 +211,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /**
    * Retrieve the source Actor or Item, or null if it could not be determined.
-   * @returns {Promise<Actor5e|Item5e|null>}
+   * @returns {Promise<Activity|ActiveEffect|Actor5e|Item5e|null>}
    */
   async getSource() {
     if ( (this.target instanceof dnd5e.documents.Actor5e) && (this.parent instanceof dnd5e.documents.Item5e) ) {
@@ -226,7 +227,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
    * @returns {Actor5e|null}
    */
   getSourceActor() {
-    const origin = fromUuidSync(this.origin);
+    const origin = fromUuidSync(this.system.origin?.actor ?? this.origin, { strict: false });
     return (origin instanceof dnd5e.documents.Actor5e) ? origin : (origin?.actor || null);
   }
 
@@ -298,20 +299,24 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   static migrateData(source) {
     source = super.migrateData(source);
 
-    for ( const change of source.changes ?? [] ) {
-      if ( change.key === "flags.dnd5e.initiativeAdv" ) {
-        change.key = "system.attributes.init.roll.mode";
-        change.type = "add";
-        change.value = 1;
-      }
-    }
-
     if ( source.flags?.dnd5e?.riders?.statuses && !source.system?.rider?.statuses ) {
       foundry.utils.setProperty(source, "system.rider.statuses", source.flags.dnd5e.riders.statuses);
       delete source.flags.dnd5e.riders.statuses;
     }
 
     return source;
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareBaseData() {
+    this.origin = this.system.origin?.effect ?? this.system.origin?.activity
+      ?? this.system.origin?.item ?? this.system.origin?.actor
+      ?? this.getFlag("core", "originText") ?? this.origin;
+    super.prepareBaseData();
   }
 
   /* -------------------------------------------- */
@@ -499,7 +504,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       `The active effect key "${change.key}" has been deprecated and should be changed to "${shim.key}".`,
       shim.warning
     );
-    return { ...change, key: shim.key, type: shim.type ?? change.type };
+    return { ...change, key: shim.key, type: shim.type ?? change.type, value: shim.value ?? change.value };
   }
 
   /* -------------------------------------------- */
@@ -611,14 +616,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /* -------------------------------------------- */
   /*  Lifecycle                                   */
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  prepareBaseData() {
-    this.origin = this.getFlag("core", "originText") ?? this.origin;
-    super.prepareBaseData();
-  }
-
   /* -------------------------------------------- */
 
   /** @inheritDoc */
@@ -796,7 +793,16 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   async _preCreate(data, options, user) {
     if ( await super._preCreate(data, options, user) === false ) return false;
-    if ( options.keepOrigin === false ) this.updateSource({ origin: this.parent.uuid });
+    if ( options.keepOrigin === false ) this.updateSource({
+      system: {
+        origin: {
+          activity: _del,
+          effect: _del,
+          [this.parent instanceof Actor ? "actor" : "item"]: this.parent.uuid,
+          [this.parent instanceof Actor ? "item" : "actor"]: _del
+        }
+      }
+    });
 
     // Special expiries are evaluated live in isExpiryEvent so we set duration to `null` to so it's always triggered
     const { units, expiry } = this.duration;

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -744,7 +744,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       if ( effectData ) {
         delete effectData._id;
         delete effectData.flags?.dnd5e?.rider;
-        effectData.origin = this.origin;
+        foundry.utils.setPoperty(effectData, "system.origin", this.system.origin);
       }
       return effectData;
     }));

--- a/module/documents/activity/cast.mjs
+++ b/module/documents/activity/cast.mjs
@@ -126,8 +126,12 @@ export default class CastActivity extends ActivityMixin(BaseCastActivityData) {
           type: "enchantment",
           name: _loc("DND5E.CAST.Enchantment.Name"),
           img: "systems/dnd5e/icons/svg/activity/cast.svg",
-          origin: this.uuid,
-          changes: this.getSpellChanges()
+          system: {
+            changes: this.getSpellChanges(),
+            origin: {
+              activity: this.uuid
+            }
+          }
         }
       ],
       flags: {

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -57,7 +57,7 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
    */
   get existingEnchantment() {
     return this.enchant.self
-      ? this.item.effects.find(e => e.isAppliedEnchantment && (e.origin === this.uuid)) : undefined;
+      ? this.item.effects.find(e => e.isAppliedEnchantment && e.matchesOrigin(this.uuid)) : undefined;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -165,7 +165,15 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
 
     const flags = { enchantmentProfile: profileId };
     if ( concentration ) flags.dependentOn = concentration.uuid;
-    const enchantmentData = effect.clone({ origin: this.uuid, "flags.dnd5e": flags }).toObject();
+    const enchantmentData = effect.clone({
+      "flags.dnd5e": flags,
+      system: {
+        origin: {
+          activity: this.uuid,
+          effect: concentration?.uuid
+        }
+      }
+    }).toObject();
     enchantmentData.system.changes = await ActiveEffect5e.forApplication(enchantmentData.system.changes, this, item);
 
     /**

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -459,11 +459,13 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
       if ( changes.length ) {
         const effect = (new ActiveEffect({
           _id: staticID("dnd5eItemChanges"),
-          changes,
           disabled: false,
           icon: "icons/skills/melee/strike-slashes-orange.webp",
           name: _loc("DND5E.SUMMON.ItemChanges.Label"),
-          origin: this.uuid,
+          system: {
+            changes,
+            origin: { activity: this.uuid }
+          },
           type: "enchantment"
         })).toObject();
         actorUpdates.items.push({ _id: item.id, effects: [effect, ...item.effects.map(e => e.toObject())] });

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -2734,7 +2734,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const attributions = [];
     for ( const e of this.allApplicableEffects() ) {
       let source = e.sourceName;
-      if ( !e.origin || (e.origin === this.uuid) ) source = e.name;
+      if ( !e.origin || e.matchesOrigin(this.uuid) ) source = e.name;
       if ( !source || e.disabled || e.isSuppressed ) continue;
       const value = e.changes.reduce((n, change) => {
         if ( (ActiveEffect5e.SHIM_FIELDS[change.key]?.key ?? change.key) !== target ) return n;
@@ -2987,7 +2987,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       // Remove active effects
       const oEffects = foundry.utils.deepClone(d.effects);
       const originEffectIds = new Set(oEffects.filter(effect => {
-        return !effect.origin || effect.origin === this.uuid;
+        return !effect.origin || effect.matchesOrigin(this.uuid);
       }).map(e => e._id));
       d.effects = d.effects.filter(e => {
         if ( settings.effects.has("all") ) return true;

--- a/module/documents/advancement/modify-item.mjs
+++ b/module/documents/advancement/modify-item.mjs
@@ -57,7 +57,11 @@ export default class ModifyItemAdvancement extends Advancement {
               sourceId: effect.uuid
             }
           },
-          origin: this.item.uuid
+          system: {
+            origin: {
+              item: this.item.uuid
+            }
+          }
         }, { keepId: true }).toObject();
         item.updateSource({ effects: [clone] });
         modified.push({ change: change._id, effect: clone._id, item: item._id });

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -756,6 +756,7 @@ export function migrateEffectData(effect, migrationData, { bypassVersionCheck, p
   _migrateDocumentIcon(effect, updateData, { ...migrationData, field: "img" });
   _migrateEffectChanges(effect, updateData, { setIds: migrate600 });
   if ( migrate600 ) _migrateEffectMagical(effect, parent, updateData);
+  _migrateEffectOrigin(effect, parent, updateData);
   if ( bypassVersionCheck || foundry.utils.isNewerVersion("3.1.0", version) ) {
     _migrateEffectTransfer(effect, parent, updateData);
   }
@@ -1164,6 +1165,33 @@ function _migrateEffectChanges(effect, updateData, { setIds }={}) {
  */
 function _migrateEffectMagical(effect, parent, updateData) {
   if ( isSpellOrScroll(parent) || parent.system?.properties?.includes("mgc") ) updateData["system.magical"] = true;
+  return updateData;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Migrates effect origin data from core field into system data.
+ * @param {object} effect      Effect data to migrate.
+ * @param {object} parent      The parent of this effect.
+ * @param {object} updateData  Existing update to expand upon.
+ * @returns {object}           The updateData to apply.
+ */
+function _migrateEffectOrigin(effect, parent, updateData) {
+  const origin = effect.flags?.core?.originText ?? effect.origin;
+  const systemDataModel = CONFIG.ActiveEffect.dataModels[effect.type];
+  if ( !origin || !systemDataModel?.schema.fields.origin ) return updateData;
+
+  const field = origin.includes("Activity") ? "activity"
+    : origin.includes("ActiveEffect") ? "effect"
+    : origin.includes("Item") ? "item"
+    : origin.includes("Actor") ? "actor" : undefined;
+  if ( field ) {
+    updateData["flags.core.originText"] = _del;
+    updateData.origin = null;
+    updateData[`system.origin.${field}`] = origin;
+  }
+
   return updateData;
 }
 

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -1180,12 +1180,13 @@ function _migrateEffectMagical(effect, parent, updateData) {
 function _migrateEffectOrigin(effect, parent, updateData) {
   const origin = effect.flags?.core?.originText ?? effect.origin;
   const systemDataModel = CONFIG.ActiveEffect.dataModels[effect.type];
-  if ( !origin || !systemDataModel?.schema.fields.origin ) return updateData;
+  if ( !origin || foundry.utils.objectValues(effect.system?.origin ?? {}).some(k => k)
+    || !systemDataModel?.schema.fields.origin ) return updateData;
 
   const field = origin.includes("Activity") ? "activity"
     : origin.includes("ActiveEffect") ? "effect"
-    : origin.includes("Item") ? "item"
-    : origin.includes("Actor") ? "actor" : undefined;
+      : origin.includes("Item") ? "item"
+        : origin.includes("Actor") ? "actor" : undefined;
   if ( field ) {
     updateData["flags.core.originText"] = _del;
     updateData.origin = null;

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -1186,7 +1186,9 @@ function _migrateEffectOrigin(effect, parent, updateData) {
   const field = origin.includes("Activity") ? "activity"
     : origin.includes("ActiveEffect") ? "effect"
       : origin.includes("Item") ? "item"
-        : origin.includes("Actor") ? "actor" : undefined;
+        : origin.includes("Actor") ? "actor"
+          : origin.includes("RegionBehavior") ? "behavior"
+            : undefined;
   if ( field ) {
     updateData["flags.core.originText"] = _del;
     updateData.origin = null;


### PR DESCRIPTION
Adds a new `system.origin` object that contains UUIDs for activity, actor, effect, and item origins. This allows storing more detailed information on origins and avoids relying on the `originText` flag when activities are the origin.

Closes #6626