### PR TITLE
Refactor card data pipeline

### DIFF
--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -1,3 +1,4 @@
+import PropertyField from "../../data/shared/property-field.mjs";
 import UsesField from "../../data/shared/uses-field.mjs";
 import * as Trait from "../../documents/actor/trait.mjs";
 import { filteredKeys } from "../../utils.mjs";
@@ -220,11 +221,14 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
     if ( this.item.type !== "spell" ) {
       context.properties.options.sort((a, b) => a.label.localeCompare(b.label, game.i18n.lang));
     }
-    if ( game.user.isGM || context.isIdentified ) context.properties.active.push(
-      ...this.item.system.cardProperties ?? [],
-      ...Object.values(this.item.labels.activations?.[0] ?? {}),
-      ...this.item.system.equippableItemCardProperties ?? []
-    );
+    if ( game.user.isGM || context.isIdentified ) {
+      const usage = this.item.system.getUsageData?.() ?? {};
+      context.properties.active.push(...PropertyField.getLabels([
+        ...this.item.system.cardProperties ?? [],
+        ...PropertyField.getUsageProperties(usage),
+        ...this.item.system.equippableItemCardProperties ?? []
+      ], { ...usage, properties: this.item.system.properties }));
+    }
 
     await this.item.system.getSheetData?.(context);
 

--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -1,4 +1,5 @@
 import * as Trait from "../../documents/actor/trait.mjs";
+import PropertyField from "../shared/property-field.mjs";
 import SystemDataModel from "./system-data-model.mjs";
 
 const TextEditor = foundry.applications.ux.TextEditor.implementation;
@@ -140,16 +141,6 @@ export default class ItemDataModel extends SystemDataModel {
   }
 
   /* -------------------------------------------- */
-
-  /**
-   * Parts making up the subtitle on the item's tooltip.
-   * @type {string[]}
-   */
-  get tooltipSubtitle() {
-    return [this.type?.label ?? _loc(CONFIG.Item.typeLabels[this.parent.type])];
-  }
-
-  /* -------------------------------------------- */
   /*  Data Preparation                            */
   /* -------------------------------------------- */
 
@@ -188,7 +179,7 @@ export default class ItemDataModel extends SystemDataModel {
   async richTooltip(enrichmentOptions={}) {
     return {
       content: await foundry.applications.handlebars.renderTemplate(
-        this.constructor.ITEM_TOOLTIP_TEMPLATE, await this.getCardData(enrichmentOptions)
+        this.constructor.ITEM_TOOLTIP_TEMPLATE, await this.getTooltipData(enrichmentOptions)
       ),
       classes: ["dnd5e2", "dnd5e-tooltip", "item-tooltip", "themed", "theme-light"]
     };
@@ -197,57 +188,92 @@ export default class ItemDataModel extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
-   * Prepare item card template data.
-   * @param {EnrichmentOptions} [enrichmentOptions={}]  Options for text enrichment.
-   * @param {Activity} [enrichmentOptions.activity]     Specific activity on item to use for customizing the data.
-   * @param {string} [enrichmentOptions.extras]         Extra HTML displayed with the tooltip.
+   * Capture the item data displayed on a chat card.
+   * @param {EnrichmentOptions} [options={}]        Options for text enrichment.
+   * @param {Activity} [options.activity]           Specific activity on item to use for customizing the data.
+   * @param {boolean|null} [options.identified]     Treat the item as having this identified state, rather than its
+   *                                                own, when deciding what to include.
    * @returns {Promise<object>}
    */
-  async getCardData({ activity, extras, ...enrichmentOptions }={}) {
+  async getCardData({ activity, identified, ...enrichmentOptions }={}) {
+    const { description: desc, unidentified } = this;
+    const { _stats, id, img, name, type, uuid } = this.parent;
+    identified ??= this.identified ?? null;
+
+    enrichmentOptions.rollData ??= (activity ?? this.parent).getRollData();
+    enrichmentOptions.relativeTo ??= this.parent;
+
+    const source = (await activity?.getCardData()) ?? {};
+    const usage = this.getUsageData({ activity });
+
+    let description = source.description ?? "";
+    description ||= (identified === false) ? unidentified?.description : (desc.chat || desc.value);
+
+    return {
+      identified, ...usage,
+      activity: source.activity ?? {},
+      concealed: game.user.isGM && dnd5e.settings.concealItemDescriptions && !desc.chat,
+      description: await TextEditor.enrichHTML(description || "", enrichmentOptions),
+      item: {
+        id, img, name, type, uuid, compendiumSource: _stats.compendiumSource, properties: this.properties ?? new Set()
+      },
+      level: enrichmentOptions.rollData.item?.level ?? null,
+      properties: (identified === false) ? [] : [
+        ...this.cardProperties ?? [],
+        ...PropertyField.getUsageProperties(usage),
+        ...this.equippableItemCardProperties ?? []
+      ],
+      subtitle: [this.type?.label ?? _loc(CONFIG.Item.typeLabels[type])]
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Resolve the data describing how this item is used, taken from the activity being used, otherwise the first
+   * activity that has an activation. Item types with intrinsic usage data supply their own.
+   * @param {object} [options]
+   * @param {Activity} [options.activity]  Specific activity being used.
+   * @returns {UsageData}
+   */
+  getUsageData({ activity }={}) {
+    const source = activity ?? this.activities?.find(a => ("activation" in a) && !a.isHidden);
+    return { activation: null, duration: null, range: null, target: null, ...source?.getUsageData() };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare item tooltip template data.
+   * @param {EnrichmentOptions} [options={}]  Options for text enrichment.
+   * @param {Activity} [options.activity]     Specific activity on item to use for customizing the data.
+   * @param {string} [options.extras]         Extra HTML displayed with the tooltip.
+   * @returns {Promise<object>}
+   */
+  async getTooltipData({ activity, extras, ...enrichmentOptions }={}) {
+    enrichmentOptions.rollData ??= (activity ?? this.parent).getRollData();
+    enrichmentOptions.relativeTo ??= this.parent;
+    const options = { activity, ...enrichmentOptions };
+    if ( game.user.isGM ) options.identified = true;
+    const context = await this.getCardData(options);
+
     const { name, type, img } = this.parent;
-    let {
-      price, weight, uses, identified, unidentified, description, school, materials
-    } = this;
-    const rollData = (activity ?? this.parent).getRollData();
-    const isIdentified = identified !== false;
+    const { description: desc, unidentified } = this;
+    const description = (context.identified === false) ? unidentified?.description : desc.value;
+    let { identified, price, uses } = this;
     uses = this.hasLimitedUses && (game.user.isGM || identified) ? uses : null;
     price = game.user.isGM || identified ? price : null;
 
-    enrichmentOptions = { rollData, relativeTo: this.parent, ...enrichmentOptions };
-    const context = {
-      name, type, img, price, weight, uses, school, materials, extras,
+    Object.assign(context, {
+      name, type, img, price, uses, extras,
       config: CONFIG.DND5E,
-      controlHints: game.settings.get("dnd5e", "controlHints"),
+      controlHints: dnd5e.settings.controlHints,
+      description: await TextEditor.enrichHTML(description || "", enrichmentOptions),
       labels: foundry.utils.deepClone((activity ?? this.parent).labels),
-      tags: this.parent.labels?.components?.tags,
-      subtitle: this.tooltipSubtitle.filterJoin(" • "),
-      description: {
-        value: await TextEditor.enrichHTML(
-          (game.user.isGM || isIdentified ? description.value : unidentified?.description) ?? "",
-          enrichmentOptions
-        ),
-        chat: await TextEditor.enrichHTML(
-          activity?.description?.value
-            || (isIdentified ? description.chat || description.value : unidentified?.description)
-            || "",
-          enrichmentOptions
-        ),
-        concealed: game.user.isGM && game.settings.get("dnd5e", "concealItemDescriptions") && !description.chat
-      }
-    };
-
-    context.properties = [];
-
-    if ( game.user.isGM || isIdentified ) {
-      context.properties.push(
-        ...this.cardProperties ?? [],
-        ...Object.values((activity ? activity?.activationLabels : this.parent.labels.activations?.[0]) ?? {}),
-        ...this.equippableItemCardProperties ?? []
-      );
-    }
-
-    context.properties = context.properties.filter(_ => _);
-    context.hasProperties = context.tags?.length || context.properties.length;
+      properties: PropertyField.getLabels(context.properties, { ...context, properties: context.item.properties }),
+      subtitle: context.subtitle.filterJoin(" • "),
+      weight: this.weight
+    });
     return context;
   }
 

--- a/module/data/activity/attack-data.mjs
+++ b/module/data/activity/attack-data.mjs
@@ -82,6 +82,15 @@ export default class BaseAttackActivityData extends BaseActivityData {
 
   /* -------------------------------------------- */
 
+  /** @inheritDoc */
+  getUsageData() {
+    const usage = super.getUsageData();
+    if ( (this.item.type === "weapon") && !this.range.override ) usage.range = this.item.system.range;
+    return usage;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * Abilities that could potentially be used with this attack. Unless a specific ability is specified then
    * whichever ability has the highest modifier will be selected when making an attack.

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -752,6 +752,31 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   /* -------------------------------------------- */
 
   /**
+   * Capture the activity data for a chat card.
+   * @returns {Promise<object>}
+   */
+  async getCardData() {
+    const { description, id, img, name, type, uuid } = this;
+    return {
+      description: description.value,
+      activity: { id, img, name, type, uuid, chatFlavor: description.chatFlavor }
+    };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Capture the data describing how this activity is used.
+   * @returns {UsageData}
+   */
+  getUsageData() {
+    const { activation, duration, range, target } = this;
+    return { activation, duration, range, target };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Effects that can be applied from this activity.
    * @returns {Promise<ActiveEffect5e[]>|null}
    */

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -121,10 +121,10 @@ export default class ConsumableData extends ItemDataModel.mixin(
    */
   get chatProperties() {
     return [
-      this.type.label,
-      this.hasLimitedUses ? `${this.uses.value}/${this.uses.max} ${_loc("DND5E.Charges")}` : null,
-      this.priceLabel
-    ];
+      { type: "text", text: this.type.label },
+      this.hasLimitedUses ? { type: "charges", max: this.uses.max, value: this.uses.value } : null,
+      { type: "price", denomination: this.price.denomination, value: this.price.value }
+    ].filter(_ => _);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -120,11 +120,7 @@ export default class EquipmentData extends ItemDataModel.mixin(
    * @type {string[]}
    */
   get chatProperties() {
-    return [
-      this.type.label,
-      (this.isArmor || this.isMountable) ? (this.parent.labels?.armor ?? null) : null,
-      this.properties.has("stealthDisadvantage") ? _loc("DND5E.ITEM.Property.StealthDisadvantage") : null
-    ];
+    return [{ type: "text", text: this.type.label }, ...this.cardProperties];
   }
 
   /* -------------------------------------------- */
@@ -135,9 +131,9 @@ export default class EquipmentData extends ItemDataModel.mixin(
    */
   get cardProperties() {
     return [
-      (this.isArmor || this.isMountable) ? (this.parent.labels?.armor ?? null) : null,
-      this.properties.has("stealthDisadvantage") ? _loc("DND5E.ITEM.Property.StealthDisadvantage") : null
-    ];
+      ((this.isArmor || this.isMountable) && this.armor.value) ? { type: "ac", value: this.armor.value } : null,
+      this.properties.has("stealthDisadvantage") ? { type: "property", property: "stealthDisadvantage" } : null
+    ].filter(_ => _);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -155,7 +155,7 @@ export default class FeatData extends ItemDataModel.mixin(
    * @type {string[]}
    */
   get chatProperties() {
-    return [this.requirements];
+    return this.cardProperties;
   }
 
   /* -------------------------------------------- */
@@ -165,7 +165,7 @@ export default class FeatData extends ItemDataModel.mixin(
    * @type {string[]}
    */
   get cardProperties() {
-    return [this.requirements];
+    return this.requirements ? [{ type: "text", text: this.requirements }] : [];
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -98,10 +98,10 @@ export default class LootData extends ItemDataModel.mixin(
    */
   get chatProperties() {
     return [
-      this.type.label,
-      this.weight ? `${this.weight.value} ${_loc("DND5E.AbbreviationLbs")}` : null,
-      this.priceLabel
-    ];
+      { type: "text", text: this.type.label },
+      this.weight ? { type: "weight", value: this.weight.value } : null,
+      { type: "price", denomination: this.price.denomination, value: this.price.value }
+    ].filter(_ => _);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -99,7 +99,7 @@ export default class LootData extends ItemDataModel.mixin(
   get chatProperties() {
     return [
       { type: "text", text: this.type.label },
-      this.weight ? { type: "weight", value: this.weight.value } : null,
+      this.weight ? { ...this.weight, type: "weight" } : null,
       { type: "price", denomination: this.price.denomination, value: this.price.value }
     ].filter(_ => _);
   }

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -197,11 +197,32 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
    */
   get chatProperties() {
     return [
-      this.parent.labels.level,
-      this.parent.labels.components.vsm + (this.parent.labels.materials ? ` (${this.parent.labels.materials})` : ""),
-      ...this.parent.labels.components.tags,
-      this.parent.labels.duration
+      { type: "level", level: this.level },
+      { type: "components", materials: this.properties.has("material") ? this.materials.value : "" },
+      ...this.tagProperties,
+      { type: "duration" }
     ];
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  get cardProperties() {
+    return [...this.tagProperties, { type: "components" }];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Descriptors for the spell's tag properties, such as ritual or concentration.
+   * @type {object[]}
+   */
+  get tagProperties() {
+    return Array.from(this.properties).reduce((arr, property) => {
+      const config = this.validProperties.has(property) ? CONFIG.DND5E.itemProperties[property] : null;
+      if ( config?.isTag && config.label ) arr.push({ property, type: "property" });
+      return arr;
+    }, []);
   }
 
   /* -------------------------------------------- */
@@ -275,11 +296,6 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   }
 
   /* -------------------------------------------- */
-
-  /** @override */
-  get tooltipSubtitle() {
-    return [this.parent.labels.level, CONFIG.DND5E.spellSchools[this.school]?.label];
-  }
 
   /* -------------------------------------------- */
   /*  Data Migration                              */
@@ -459,10 +475,33 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   /** @inheritDoc */
   async getCardData(options) {
     const context = await super.getCardData(options);
+    context.materials = this.properties.has("material") ? this.materials.value : "";
+    context.school = this.school;
+    context.subtitle = [
+      CONFIG.DND5E.spellLevels[context.level], CONFIG.DND5E.spellSchools[this.school]?.label
+    ].filter(_ => _);
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  getUsageData(options) {
+    const usage = super.getUsageData(options);
+    usage.activation ??= this.activation;
+    usage.duration ??= this.duration;
+    usage.range ??= this.range;
+    usage.target ??= this.target;
+    return usage;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async getTooltipData(options) {
+    const context = await super.getTooltipData(options);
     context.isSpell = true;
-    const { activation, components, duration, range, target } = this.parent.labels;
-    context.properties = [components?.vsm, activation, duration, range, target].filter(_ => _);
-    if ( !this.properties.has("material") ) delete context.materials;
+    context.properties = [];
     return context;
   }
 

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -65,17 +65,6 @@ export default class SubclassData extends ItemDataModel.mixin(AdvancementTemplat
   }
 
   /* -------------------------------------------- */
-  /*  Properties                                  */
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  get tooltipSubtitle() {
-    const cls = dnd5e.registry.classes.get(this.classIdentifier)?.name;
-    if ( cls ) return [_loc("DND5E.SubclassOf", { class: cls })];
-    return super.tooltipSubtitle;
-  }
-
-  /* -------------------------------------------- */
   /*  Data Migration                              */
   /* -------------------------------------------- */
 
@@ -109,6 +98,16 @@ export default class SubclassData extends ItemDataModel.mixin(AdvancementTemplat
   /** @inheritDoc */
   prepareFinalData() {
     SpellcastingField.prepareData.call(this, this.parent.getRollData({ deterministic: true }));
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async getCardData(options) {
+    const context = await super.getCardData(options);
+    const cls = dnd5e.registry.classes.get(this.classIdentifier)?.name;
+    if ( cls ) context.subtitle = [_loc("DND5E.SubclassOf", { class: cls })];
+    return context;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -61,11 +61,11 @@ export default class EquippableItemTemplate extends SystemDataModel {
    */
   get equippableItemCardProperties() {
     return [
-      this.attuned ? _loc("DND5E.AttunementAttuned")
-        : CONFIG.DND5E.attunementTypes[this.attunement] ?? null,
-      _loc(this.equipped ? "DND5E.Equipped" : "DND5E.Unequipped"),
-      ("proficient" in this) ? CONFIG.DND5E.proficiencyLevels[this.prof?.multiplier || 0] : null
-    ];
+      (this.attuned || CONFIG.DND5E.attunementTypes[this.attunement])
+        ? { type: "attunement", attuned: this.attuned, attunement: this.attunement } : null,
+      { type: "label", label: this.equipped ? "DND5E.Equipped" : "DND5E.Unequipped" },
+      ("proficient" in this) ? { type: "proficiency", proficiency: this.prof?.multiplier || 0 } : null
+    ].filter(_ => _);
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -123,7 +123,7 @@ export default class ToolData extends ItemDataModel.mixin(
    * @type {string[]}
    */
   get chatProperties() {
-    return [CONFIG.DND5E.abilities[this.ability]?.label];
+    return this.cardProperties;
   }
 
   /* -------------------------------------------- */
@@ -133,7 +133,7 @@ export default class ToolData extends ItemDataModel.mixin(
    * @type {string[]}
    */
   get cardProperties() {
-    return [CONFIG.DND5E.abilities[this.ability]?.label];
+    return this.ability ? [{ type: "ability", ability: this.ability }] : [];
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -242,9 +242,7 @@ export default class WeaponData extends ItemDataModel.mixin(
    */
   get chatProperties() {
     return [
-      this.type.label,
-      CONFIG.DND5E.weaponMasteries[this.mastery]?.label,
-      this.isMountable ? (this.parent.labels?.armor ?? null) : null
+      { type: "text", text: this.type.label }, { type: "mastery", mastery: this.mastery }, ...this.cardProperties
     ];
   }
 
@@ -255,9 +253,7 @@ export default class WeaponData extends ItemDataModel.mixin(
    * @type {string[]}
    */
   get cardProperties() {
-    return [
-      this.isMountable ? (this.parent.labels?.armor ?? null) : null
-    ];
+    return (this.isMountable && this.armor.value) ? [{ type: "ac", value: this.armor.value }] : [];
   }
 
   /* -------------------------------------------- */
@@ -376,13 +372,6 @@ export default class WeaponData extends ItemDataModel.mixin(
     const improvised = (this.type.value === "improv") && !!actor.getFlag("dnd5e", "tavernBrawlerFeat");
     const isProficient = natural || improvised || actorProfs.has(itemProf) || actorProfs.has(this.type.baseItem);
     return Number(isProficient);
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  get tooltipSubtitle() {
-    return [...super.tooltipSubtitle, CONFIG.DND5E.weaponMasteries[this.mastery]?.label];
   }
 
   /* -------------------------------------------- */
@@ -514,6 +503,26 @@ export default class WeaponData extends ItemDataModel.mixin(
     if ( this.hasRange ) labels.range = !long || (long === value) ? formatLength(value, units)
       : `${formatNumber(value)}/${formatLength(long, units)}`;
     if ( reach ) labels.reach = _loc("DND5E.RANGE.Formatted.Reach", { reach: formatLength(reach, units) });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async getCardData(options) {
+    const context = await super.getCardData(options);
+    context.mastery = this.mastery;
+    const masteryLabel = CONFIG.DND5E.weaponMasteries[this.mastery]?.label;
+    if ( masteryLabel ) context.subtitle.push(masteryLabel);
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  getUsageData(options) {
+    const usage = super.getUsageData(options);
+    usage.range ??= this.range;
+    return usage;
   }
 
   /* -------------------------------------------- */

--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -41,7 +41,7 @@ export default class DurationField extends SchemaField {
     } else {
       labels.simple = CONFIG.DND5E.timePeriods[duration.units] ?? "";
     }
-    labels.concentration = duration.concentration || properties?.has("concentration")
+    labels.concentration = duration.concentration || properties?.has?.("concentration")
       ? _loc("DND5E.CONCENTRATION.Duration", { duration: labels.simple }) : labels.simple;
     return labels;
   }

--- a/module/data/shared/property-field.mjs
+++ b/module/data/shared/property-field.mjs
@@ -1,4 +1,4 @@
-import { formatLength, formatNumber } from "../../utils.mjs";
+import { defaultUnits, formatLength, formatNumber, formatWeight } from "../../utils.mjs";
 import ActivationField from "./activation-field.mjs";
 import DurationField from "./duration-field.mjs";
 import RangeField from "./range-field.mjs";
@@ -33,7 +33,10 @@ export default class PropertyField extends TypedSchemaField {
       reach: {},
       target: {},
       text: { text: new StringField() },
-      weight: { value: new NumberField() }
+      weight: {
+        units: new StringField({ blank: false, initial: () => defaultUnits("weight"), required: true }),
+        value: new NumberField()
+      }
     }, options, context);
   }
 
@@ -85,7 +88,7 @@ export default class PropertyField extends TypedSchemaField {
           return labels.template.statblock || labels.affects.sheet;
         }
         case "text": return p.text;
-        case "weight": return `${p.value} ${_loc("DND5E.AbbreviationLbs")}`;
+        case "weight": return formatWeight(p.value, p.units);
         default: return null;
       }
     }).filter(_ => _);

--- a/module/data/shared/property-field.mjs
+++ b/module/data/shared/property-field.mjs
@@ -1,0 +1,111 @@
+import { formatLength, formatNumber } from "../../utils.mjs";
+import ActivationField from "./activation-field.mjs";
+import DurationField from "./duration-field.mjs";
+import RangeField from "./range-field.mjs";
+import TargetField from "./target-field.mjs";
+
+const { BooleanField, NumberField, StringField, TypedSchemaField } = foundry.data.fields;
+
+/**
+ * @import { UsageData } from "./_types.mjs";
+ */
+
+/**
+ * Field for storing some salient property of an item.
+ */
+export default class PropertyField extends TypedSchemaField {
+  constructor(options={}, context={}) {
+    super({
+      ability: { ability: new StringField() },
+      ac: { value: new NumberField({ integer: true }) },
+      activation: {},
+      attunement: { attuned: new BooleanField(), attunement: new StringField() },
+      charges: { max: new NumberField(), value: new NumberField() },
+      components: { materials: new StringField() },
+      duration: {},
+      label: { label: new StringField() },
+      level: { level: new NumberField({ integer: true }) },
+      mastery: { mastery: new StringField() },
+      price: { denomination: new StringField(), value: new NumberField() },
+      proficiency: { proficiency: new NumberField({ integer: true }) },
+      property: { property: new StringField() },
+      range: {},
+      reach: {},
+      target: {},
+      text: { text: new StringField() },
+      weight: { value: new NumberField() }
+    }, options, context);
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /**
+   * Build the display labels for a list of property descriptors.
+   * @param {object[]} props     Descriptors to render.
+   * @param {UsageData} [usage]  Usage data the empty descriptors read.
+   * @returns {string[]}
+   */
+  static getLabels(props, { activation, duration, properties, range, target }={}) {
+    return props.map(p => {
+      switch ( p.type ) {
+        case "ability": return CONFIG.DND5E.abilities[p.ability]?.label;
+        case "ac": return `${p.value} ${_loc("DND5E.AC")}`;
+        case "activation": return ActivationField.getLabels({ activation, properties }).simple;
+        case "attunement": return p.attuned
+          ? _loc("DND5E.AttunementAttuned")
+          : CONFIG.DND5E.attunementTypes[p.attunement];
+        case "charges": return `${p.value}/${p.max} ${_loc("DND5E.Charges")}`;
+        case "components": {
+          const components = game.i18n.getListFormatter({ style: "narrow" }).format(
+            Array.from(properties ?? []).reduce((arr, p) => {
+              const { abbreviation, isTag } = CONFIG.DND5E.itemProperties[p] ?? {};
+              if ( abbreviation && !isTag ) arr.push(abbreviation);
+              return arr;
+            }, [])
+          );
+          return p.materials ? `${components} (${p.materials})` : components;
+        }
+        case "duration": return DurationField.getLabels({ duration, properties }).simple;
+        case "label": return _loc(p.label);
+        case "level": return CONFIG.DND5E.spellLevels[p.level];
+        case "mastery": return CONFIG.DND5E.weaponMasteries[p.mastery]?.label;
+        case "price": return (p.value && (p.denomination in CONFIG.DND5E.currencies))
+          ? `${p.value} ${CONFIG.DND5E.currencies[p.denomination].label}`
+          : null;
+        case "proficiency": return CONFIG.DND5E.proficiencyLevels[p.proficiency];
+        case "property": return CONFIG.DND5E.itemProperties[p.property]?.label;
+        case "range": return (range.long && (range.long !== range.value))
+          ? `${formatNumber(range.value)}/${formatLength(range.long, range.units)}`
+          : RangeField.getLabels({ range }).simple;
+        case "reach": return _loc("DND5E.RANGE.Formatted.Reach", { reach: formatLength(range.reach, range.units) });
+        case "target": {
+          const labels = TargetField.getLabels({ target });
+          return labels.template.statblock || labels.affects.sheet;
+        }
+        case "text": return p.text;
+        case "weight": return `${p.value} ${_loc("DND5E.AbbreviationLbs")}`;
+        default: return null;
+      }
+    }).filter(_ => _);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Build the descriptors for the properties that describe how an item or activity is used.
+   * @param {UsageData} [usage]  Usage data to describe.
+   * @returns {object[]}
+   */
+  static getUsageProperties({ activation, duration, range, target }={}) {
+    const properties = [];
+    if ( !activation?.type ) return properties;
+    properties.push({ type: "activation" });
+    if ( duration?.units ) properties.push({ type: "duration" });
+    if ( range?.units ) properties.push({ type: "range" });
+    if ( range?.reach ) properties.push({ type: "reach" });
+    if ( target?.template.type || target?.affects.type ) properties.push({ type: "target" });
+    return properties;
+  }
+}

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -3,6 +3,7 @@ import ActivityUsageDialog from "../../applications/activity/activity-usage-dial
 import TemplatePlacement from "../../canvas/template-placement.mjs";
 import { ConsumptionError } from "../../data/activity/fields/consumption-targets-field.mjs";
 import { ActorDeltasField } from "../../data/chat-message/fields/deltas-field.mjs";
+import PropertyField from "../../data/shared/property-field.mjs";
 import { formatNumber, getSceneTargets, getTargetDescriptors, localizeSchema } from "../../utils.mjs";
 import AppliedRules from "../applied-rules.mjs";
 import DependentDocumentMixin from "../mixins/dependent.mjs";
@@ -683,22 +684,15 @@ export default function ActivityMixin(Base) {
      */
     async _usageChatContext(message) {
       const data = await this.item.system.getCardData({ activity: this });
-      const properties = [...(data.tags ?? []), ...(data.properties ?? [])];
+      const properties = PropertyField.getLabels(data.properties, { ...data, properties: data.item.properties });
       const supplements = [];
       if ( this.activation.condition ) {
         supplements.push(`<strong>${_loc("DND5E.Trigger")}</strong> ${this.activation.condition}`);
       }
-      if ( data.materials?.value ) {
-        supplements.push(`<strong>${_loc("DND5E.Materials")}</strong> ${data.materials.value}`);
+      if ( data.materials ) {
+        supplements.push(`<strong>${_loc("DND5E.Materials")}</strong> ${data.materials}`);
       }
       const buttons = this._usageChatButtons(message);
-
-      // Include spell level in the subtitle.
-      if ( this.item.type === "spell" ) {
-        const spellLevel = foundry.utils.getProperty(message, "data.system.spellLevel");
-        const { spellLevels, spellSchools } = CONFIG.DND5E;
-        data.subtitle = [spellLevels[spellLevel], spellSchools[this.item.system.school]?.label].filterJoin(" &bull; ");
-      }
 
       return {
         activity: this,
@@ -706,9 +700,10 @@ export default function ActivityMixin(Base) {
         item: this.item,
         token: this.item.actor?.token,
         buttons: buttons.length ? buttons : null,
+        concealed: data.concealed,
         description: data.description,
         properties: properties.length ? properties : null,
-        subtitle: this.description.chatFlavor || data.subtitle,
+        subtitle: this.description.chatFlavor || data.subtitle.filterJoin(" • "),
         supplements
       };
     }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -10,6 +10,7 @@ import EquipmentData from "../data/item/equipment.mjs";
 import SpellData from "../data/item/spell.mjs";
 import ActivitiesTemplate from "../data/item/templates/activities.mjs";
 import PhysicalItemTemplate from "../data/item/templates/physical-item.mjs";
+import PropertyField from "../data/shared/property-field.mjs";
 import { formatIdentifier, staticID } from "../utils.mjs";
 import Scaling from "./scaling.mjs";
 import Proficiency from "./actor/proficiency.mjs";
@@ -763,12 +764,15 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    * @returns {Promise<ChatMessage5e|object|void>}
    */
   async displayCard(message={}) {
+    const data = await this.system.getCardData();
+    data.subtitle = data.subtitle.filterJoin(" • ");
+    data.properties = PropertyField.getLabels(data.properties, { ...data, properties: data.item.properties });
     const context = {
+      data,
       actor: this.actor,
       config: CONFIG.DND5E,
       tokenId: this.actor.token?.uuid || null,
       item: this,
-      data: await this.system.getCardData(),
       isSpell: this.type === "spell"
     };
 
@@ -843,11 +847,12 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     });
 
     // Type specific properties
-    context.properties = [
+    const usage = this.system.getUsageData?.() ?? {};
+    context.properties = PropertyField.getLabels([
       ...this.system.chatProperties ?? [],
       ...this.system.equippableItemCardProperties ?? [],
-      ...Object.values(this.labels.activations?.[0] ?? {})
-    ].filter(p => p);
+      ...PropertyField.getUsageProperties(usage)
+    ], { ...usage, properties: this.system.properties });
 
     return context;
   }

--- a/templates/chat/activity-card.hbs
+++ b/templates/chat/activity-card.hbs
@@ -1,6 +1,6 @@
 <div class="chat-card activation-card">
-    <section class="card-header description {{~#if description.chat}} collapsible{{/if}}"
-             {{~#if description.concealed}} data-concealed{{/if}}>
+    <section class="card-header description {{~#if description}} collapsible{{/if}}"
+             {{~#if concealed}} data-concealed{{/if}}>
         <header class="summary">
             <img class="gold-icon" src="{{ item.img }}" alt="{{ item.name }}">
             <div class="name-stacked border">
@@ -9,11 +9,11 @@
                 <span class="subtitle">{{{ subtitle }}}</span>
                 {{/if}}
             </div>
-            {{#if description.chat}}<i class="fa-solid fa-chevron-down fa-fw" inert></i>{{/if}}
+            {{#if description}}<i class="fa-solid fa-chevron-down fa-fw" inert></i>{{/if}}
         </header>
-        {{#if description.chat}}
+        {{#if description}}
         <section class="details collapsible-content card-content">
-            <div class="wrapper">{{{ description.chat }}}</div>
+            <div class="wrapper">{{{ description }}}</div>
         </section>
         {{/if}}
     </section>

--- a/templates/chat/item-card.hbs
+++ b/templates/chat/item-card.hbs
@@ -2,7 +2,7 @@
      {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}} {{#if isSpell}}data-spell-level="{{ item.system.level }}"{{/if}}>
 
     {{!-- Collapsible Item Details --}}
-    <section class="card-header description collapsible" {{#if data.description.concealed}}data-concealed{{/if}}>
+    <section class="card-header description collapsible" {{#if data.concealed}}data-concealed{{/if}}>
 
         {{!-- Summary --}}
         <header class="summary">
@@ -21,24 +21,19 @@
         {{!-- Details --}}
         <section class="details collapsible-content card-content">
             <div class="wrapper">
-                {{{ data.description.chat }}}
+                {{{ data.description }}}
             </div>
         </section>
     </section>
 
     {{!-- Materials --}}
-    {{#if data.materials.value}}
-    <p class="supplement"><strong>{{ localize "DND5E.Materials" }}</strong>{{ data.materials.value }}</p>
+    {{#if data.materials}}
+    <p class="supplement"><strong>{{ localize "DND5E.Materials" }}</strong>{{ data.materials }}</p>
     {{/if}}
 
     {{!-- Item Properties --}}
-    {{#if data.hasProperties}}
+    {{#if data.properties.length}}
     <ul class="card-footer pills unlist">
-        {{#each data.tags}}
-        <li class="pill transparent">
-            <span class="label">{{ this }}</span>
-        </li>
-        {{/each}}
         {{#each data.properties}}
         <li class="pill transparent">
             <span class="label">{{ this }}</span>

--- a/templates/items/parts/item-tooltip.hbs
+++ b/templates/items/parts/item-tooltip.hbs
@@ -40,7 +40,7 @@
     </section>
     {{#if extras}}<p class="extras">{{{ extras }}}</p>{{/if}}
     {{#if isSpell}}{{> "dnd5e.spell-block" }}{{/if}}
-    <section class="description">{{{ description.value }}}</section>
+    <section class="description">{{{ description }}}</section>
     <ul class="pills">
         {{#each properties}}
         <li class="pill transparent">


### PR DESCRIPTION
This is a larger body of work that I am trying to split up so it's easier to review. So bear in mind that some of this code is temporary wiring to keep things somewhat testable in isolation.

The motivation here is to have `getCardData` return structured data that directly becomes the `usage` message's `system` data. To do that I spun off `getTooltipData` that produces actual tooltip render context from the structured card data, taking into account some differences around displaying identified/unidentified information to GMs (I preserved status quo behaviour here).

As part of this work, I also refactored the pills/property generation to produce structured data. I think these properties (maybe 'tags' is a better word?) are fairly important, and there may be more emphasis on them in future, so I wanted to move away from us shuttling around opaque strings.

This means the various `*Properties` getters are updated to also return structured data, which I think is an improvement. All the various areas in the UI that generate pills have been consolidated to generate them in the same way now.

Summary from the commit is repeated here:
 
 - `getCardData` now returns structured data only, suitable for storing in a schema
 - `getTooltipData` converts `getCardData` into tooltip context suitable for tooltip display
 - Added `getUsageData` on Items & Activities to produce activation usage structured data
 - Adjusted various `*Properties` getters to also produce structured data
 - Added `PropertyField` as a `TypedSchemaField` subclass that wraps an individual pill/property element
 - Added `PropertyField.getLabels` which converts structured data to a human-readable label for pill display
 - Consolidated all sites that generate Item pills to go via `PropertyField.getLabels` and transact structured data
 - Removed `tooltipSubtitle` getter and rolled it into `getTooltipData`

With the return values changing and removal of some getters I've marked this PR as breaking. I suspect that downstream is not really using these methods at all, but if they are, I think we can provide a deprecation path, but that will involve creating new methods/getter names rather than repurposing these ones.