### PR TITLE
Convert activity use to new chat system data. Adjust activity chat handlers to transact button descriptors rather than DOM nodes.

### DIFF
--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -232,9 +232,15 @@
  */
 
 /**
- * @typedef UsageMessageSystemData
+ * @typedef {ItemMessageSystemData} UsageMessageSystemData
+ * @property {UsageMessageActivityData} activity  Activity that was used.
  * @property {ActivityUsageChatButton[]} buttons  Buttons offered by the activity that created this message.
  * @property {string} [cause]                     Relative ID of the activity that caused this one on the same actor.
  * @property {ActorDeltasData} deltas             Actor/item consumption from this turn change.
  * @property {string[]} effects                   Relative or absolute UUIDs of effects that can be applied.
+ */
+
+/**
+ * @typedef {ItemMessageSourceData} UsageMessageActivityData
+ * @property {string} chatFlavor  Flavor text displayed in place of the card's subtitle.
  */

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -1,26 +1,32 @@
-import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
+import ItemMessageData from "./item-message-data.mjs";
 import { ActorDeltasField } from "./fields/deltas-field.mjs";
 
 const { ArrayField, DocumentIdField, NumberField, ObjectField, SchemaField, StringField } = foundry.data.fields;
 
 /**
+ * @import { ActivityUsageChatButton } from "../../documents/activity/_types.mjs";
  * @import { UsageMessageSystemData } from "./_types.mjs";
  */
 
 /**
  * Data stored in a usage chat message.
- * @extends {ChatMessageDataModel<UsageMessageSystemData>}
+ * @extends {ItemMessageData<UsageMessageSystemData>}
  * @mixes UsageMessageSystemData
  */
-export default class UsageMessageData extends ChatMessageDataModel {
+export default class UsageMessageData extends ItemMessageData {
 
   /* -------------------------------------------- */
   /*  Model Configuration                         */
   /* -------------------------------------------- */
 
-  /** @override */
+  /** @inheritDoc */
   static defineSchema() {
     return {
+      ...super.defineSchema(),
+      activity: new SchemaField({
+        ...this._sourceFields(),
+        chatFlavor: new StringField()
+      }),
       buttons: new ArrayField(new SchemaField({
         action: new StringField({ blank: false, required: true }),
         dataset: new ObjectField(),
@@ -61,16 +67,44 @@ export default class UsageMessageData extends ChatMessageDataModel {
   /*  Rendering                                   */
   /* -------------------------------------------- */
 
-  /** @override */
-  async _prepareContext() {
-    const item = this.parent.getAssociatedItem();
-    return {
+  /** @inheritDoc */
+  async _prepareContext(options) {
+    let context;
+    if ( this.parent.content ) context = {
       content: await foundry.applications.ux.TextEditor.implementation.enrichHTML(
         this.parent.content, { rollData: this.parent.getRollData() }
-      ),
-      effects: (await Promise.all(this.effects.map(uuid => fromUuid(uuid, { relative: item }))))
-        .filter(e => e && (game.user.isGM || (e.transfer & (this.parent.author?.id === game.user.id))))
+      )
     };
+    else {
+      context = await super._prepareContext(options);
+      context.buttons = this._prepareButtons();
+      if ( this.activity.chatFlavor ) context.subtitle = this.activity.chatFlavor;
+    }
+
+    const item = this.parent.getAssociatedItem();
+    context.effects = (await Promise.all(this.effects.map(uuid => fromUuid(uuid, { relative: item }))))
+      .filter(e => e && (game.user.isGM || (e.transfer & (this.parent.author?.id === game.user.id))));
+    return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Render context for the buttons offered by the activity, with their visibility resolved for the viewing user.
+   * @returns {object[]}
+   * @protected
+   */
+  _prepareButtons() {
+    const activity = this.parent.getAssociatedActivity();
+    const isCreator = game.user.isGM || this.actor?.isOwner || this.parent.isAuthor;
+    return this.buttons.map((button, index) => ({
+      ...button, index,
+      hidden: button.visibility === "all"
+        ? false
+        : ((button.visibility === "gm") && !game.user.isGM)
+          || !isCreator
+          || !!activity?.shouldHideChatButton(button, this.parent)
+    }));
   }
 
   /* -------------------------------------------- */
@@ -78,33 +112,30 @@ export default class UsageMessageData extends ChatMessageDataModel {
   /** @inheritDoc */
   _onRender(element) {
     super._onRender(element);
-    const activity = this.parent.getAssociatedActivity();
-    activity?.onRenderChatCard(this.parent, element);
-    this._displayChatActionButtons(element);
-    if ( game.settings.get("dnd5e", "autoCollapseItemCards") ) {
-      element.querySelectorAll(".description.collapsible").forEach(el => el.classList.add("collapsed"));
-    }
-    activity?.activateChatListeners(this.parent, element);
+    if ( this.parent.shouldDisplayChallenge ) element.dataset.displayChallenge = "";
+    this.parent.getAssociatedActivity()?.onRenderChatCard(this.parent, element);
   }
 
   /* -------------------------------------------- */
+  /*  Event Listeners & Handlers                  */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onClickAction(event, target) {
+    if ( event.button !== 0 ) return;
+    this.parent.getAssociatedActivity()?.onChatAction(event, target, this.parent);
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
 
   /**
-   * Control visibility of chat card action buttons based on viewing user.
-   * @param {HTMLElement} element  Rendered contents of the message.
-   * @protected
+   * Retrieve the descriptor for the button that was clicked.
+   * @param {HTMLElement} target  Button that was clicked.
+   * @returns {ActivityUsageChatButton|void}
    */
-  _displayChatActionButtons(element) {
-    if ( this.parent.shouldDisplayChallenge ) element.dataset.displayChallenge = "";
-
-    const activity = this.parent.getAssociatedActivity();
-    const isCreator = game.user.isGM || this.actor?.isOwner || this.parent.isAuthor;
-    for ( const button of element.querySelectorAll(".card-buttons button") ) {
-      if ( button.dataset.visibility === "all" ) continue;
-
-      // GM buttons should only be visible to GMs, otherwise button should only be visible to message's creator
-      if ( ((button.dataset.visibility === "gm") && !game.user.isGM) || !isCreator
-        || activity?.shouldHideChatButton(button, this.parent) ) button.hidden = true;
-    }
+  getButton(target) {
+    return this.buttons[Number(target.dataset.index)];
   }
 }

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -26,7 +26,7 @@ export default class UsageMessageData extends ItemMessageData {
       activity: new SchemaField({
         ...this._sourceFields(),
         chatFlavor: new StringField(),
-        uuid: new StringField({ blank: false, nullable: false, required: true })
+        uuid: new StringField({ blank: false, nullable: true, required: true })
       }),
       buttons: new ArrayField(new SchemaField({
         action: new StringField({ blank: false, required: true }),

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -25,7 +25,8 @@ export default class UsageMessageData extends ItemMessageData {
       ...super.defineSchema(),
       activity: new SchemaField({
         ...this._sourceFields(),
-        chatFlavor: new StringField()
+        chatFlavor: new StringField(),
+        uuid: new StringField({ blank: false, nullable: false, required: true })
       }),
       buttons: new ArrayField(new SchemaField({
         action: new StringField({ blank: false, required: true }),

--- a/module/documents/activity/_types.mjs
+++ b/module/documents/activity/_types.mjs
@@ -74,7 +74,7 @@
 /**
  * @typedef ActivityUsageChatButton
  * @property {string} action                      Action performed when the button is clicked.
- * @property {object} [dataset]                   Additional data attributes attached to the button.
+ * @property {object} [dataset]                   Parameters passed to the action that handles the button.
  * @property {string} [hiddenLabel]               Label displayed in place of label when challenge details are
  *                                                concealed from the viewer.
  * @property {string} icon                        FontAwesome classes or a path to an icon image.

--- a/module/documents/activity/check.mjs
+++ b/module/documents/activity/check.mjs
@@ -94,8 +94,7 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
     const targets = getSceneTargets();
     if ( !targets.length && game.user.character ) targets.push(game.user.character);
     if ( !targets.length ) ui.notifications.warn("DND5E.ActionWarningNoToken");
-    let { ability, dc, skill, tool } = target.dataset;
-    dc = parseInt(dc);
+    const { ability, dc, skill, tool } = message.system.getButton(target)?.dataset ?? {};
     const rollData = { event, target: Number.isFinite(dc) ? dc : this.check.dc.value };
     const bonusData = CONFIG.Dice.BasicRoll.constructParts({ activityBonus: this.check.bonus }, this.getRollData());
     if ( ability in CONFIG.DND5E.abilities ) rollData.ability = ability;

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -42,7 +42,7 @@ export default function ActivityMixin(Base) {
       usage: {
         actions: {},
         applyEffectsInChat: true,
-        chatCard: "systems/dnd5e/templates/chat/activity-card.hbs",
+        chatCard: null,
         dialog: ActivityUsageDialog,
         messageType: "usage"
       }
@@ -215,7 +215,7 @@ export default function ActivityMixin(Base) {
         create: true,
         data: {
           flags: {
-            dnd5e: this.messageFlags
+            dnd5e: { targets: getTargetDescriptors() }
           }
         },
         hasConsumption: usageConfig.hasConsumption
@@ -759,12 +759,12 @@ export default function ActivityMixin(Base) {
 
     /**
      * Determine whether the provided button in a chat message should be visible.
-     * @param {HTMLButtonElement} button  The button to check.
-     * @param {ChatMessage5e} message     Chat message containing the button.
+     * @param {ActivityUsageChatButton} button  Descriptor for the button to check.
+     * @param {ChatMessage5e} message           Chat message containing the button.
      * @returns {boolean}
      */
     shouldHideChatButton(button, message) {
-      switch ( button.dataset.action ) {
+      switch ( button.action ) {
         case "consumeResource": return !!message.system.deltas;
         case "refundResource": return !message.system.deltas;
         case "placeTemplate": return !game.user.can("REGION_CREATE") || !game.canvas.scene;
@@ -787,6 +787,7 @@ export default function ActivityMixin(Base) {
           core: { canPopout: true }
         },
         speaker: ChatMessage.implementation.getSpeaker({ actor: this.item.actor }),
+        system: await this.item.system.getCardData({ activity: this }),
         title: `${this.item.name} - ${this.name}`,
         type: messageType
       };
@@ -963,20 +964,6 @@ export default function ActivityMixin(Base) {
     /* -------------------------------------------- */
 
     /**
-     * Activate listeners on a chat message.
-     * @param {ChatMessage} message  Associated chat message.
-     * @param {HTMLElement} html     Element in the chat log.
-     */
-    activateChatListeners(message, html) {
-      html.addEventListener("click", event => {
-        const target = event.target.closest("[data-action]");
-        if ( target ) this.#onChatAction(event, target, message);
-      });
-    }
-
-    /* -------------------------------------------- */
-
-    /**
      * Construct context menu options for this Activity.
      * @returns {ContextMenuEntry[]}
      */
@@ -1036,7 +1023,7 @@ export default function ActivityMixin(Base) {
      * @param {HTMLElement} target     The capturing HTML element which defined a [data-action].
      * @param {ChatMessage5e} message  Message associated with the activation.
      */
-    async #onChatAction(event, target, message) {
+    async onChatAction(event, target, message) {
       const consumed = this.createConsumedFlag(message.getAssociatedActor(), message.system.deltas);
       const scaling = message.system.scaling ?? 0;
       const item = (consumed || scaling) ? this.item.clone({

--- a/module/documents/activity/order.mjs
+++ b/module/documents/activity/order.mjs
@@ -20,7 +20,6 @@ export default class OrderActivity extends ActivityMixin(BaseOrderActivityData) 
     img: "systems/dnd5e/icons/svg/activity/order.svg",
     title: "DND5E.FACILITY.Order.Issue",
     usage: {
-      chatCard: null,
       dialog: OrderUsageDialog,
       messageType: "bastionOrder"
     }

--- a/module/documents/activity/save.mjs
+++ b/module/documents/activity/save.mjs
@@ -105,14 +105,14 @@ export default class SaveActivity extends ActivityMixin(BaseSaveActivityData) {
     const targets = getSceneTargets();
     if ( !targets.length && game.user.character ) targets.push(game.user.character);
     if ( !targets.length ) ui.notifications.warn("DND5E.ActionWarningNoToken");
-    const dc = parseInt(target.dataset.dc);
+    const { ability, dc } = message.system.getButton(target)?.dataset ?? {};
     const bonusData = CONFIG.Dice.BasicRoll.constructParts({ activityBonus: this.save.bonus }, this.getRollData());
     for ( const token of targets ) {
       const actor = token instanceof Actor ? token : token.actor;
       const speaker = ChatMessage.getSpeaker({ actor, scene: canvas.scene, token: token.document });
       const rollData = {
         event,
-        ability: target.dataset.ability ?? this.save.ability.first(),
+        ability: ability ?? this.save.ability.first(),
         target: Number.isFinite(dc) ? dc : this.save.dc.value
       };
       if ( bonusData.parts.length ) rollData.rolls = [bonusData];

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -90,7 +90,7 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
 
   /** @inheritDoc */
   shouldHideChatButton(button, message) {
-    if ( button.dataset.action === "placeSummons" ) return !this.canSummon;
+    if ( button.action === "placeSummons" ) return !this.canSummon;
     return super.shouldHideChatButton(button, message);
   }
 

--- a/module/documents/activity/transform.mjs
+++ b/module/documents/activity/transform.mjs
@@ -101,7 +101,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
 
   /** @inheritDoc */
   shouldHideChatButton(button, message) {
-    if ( button.dataset.action === "transformActor" ) return !this.canTransform;
+    if ( button.action === "transformActor" ) return !this.canTransform;
     return super.shouldHideChatButton(button, message);
   }
 

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -102,10 +102,6 @@ export default class ChatMessage5e extends ChatMessage {
   /** @inheritDoc */
   prepareData() {
     super.prepareData();
-    if ( !this.flags.dnd5e?.item?.data && this.flags.dnd5e?.item?.id ) {
-      const itemData = this.system.deltas?.deleted?.find(i => i._id === this.flags.dnd5e.item.id);
-      if ( itemData ) Object.defineProperty(this.flags.dnd5e.item, "data", { value: itemData });
-    }
     dnd5e.registry.messages.track(this);
   }
 
@@ -186,8 +182,7 @@ export default class ChatMessage5e extends ChatMessage {
         if ( button.dataset.visibility === "all" ) continue;
 
         // GM buttons should only be visible to GMs, otherwise button should only be visible to message's creator
-        if ( ((button.dataset.visibility === "gm") && !game.user.isGM) || !isCreator
-          || this.getAssociatedActivity()?.shouldHideChatButton(button, this) ) button.hidden = true;
+        if ( ((button.dataset.visibility === "gm") && !game.user.isGM) || !isCreator ) button.hidden = true;
       }
     }
   }
@@ -574,12 +569,14 @@ export default class ChatMessage5e extends ChatMessage {
    * @returns {Activity|void}
    */
   getAssociatedActivity({ scaled=false }={}) {
-    const activity = fromUuidSync(this.getFlag("dnd5e", "activity.uuid"), { strict: false });
+    const uuid = this.system.activity?.uuid ?? this.getFlag("dnd5e", "activity.uuid");
+    const activity = fromUuidSync(uuid, { strict: false });
     if ( activity ) {
       const scaling = scaled ? this.system.scaling : null;
       return scaling ? activity.item.scaledClone(scaling).system.activities.get(activity.id) : activity;
     }
-    return this.getAssociatedItem({ scaled })?.system.activities?.get(this.getFlag("dnd5e", "activity.id"));
+    const id = this.system.activity?.id ?? this.getFlag("dnd5e", "activity.id");
+    return this.getAssociatedItem({ scaled })?.system.activities?.get(id);
   }
 
   /* -------------------------------------------- */
@@ -612,8 +609,19 @@ export default class ChatMessage5e extends ChatMessage {
     if ( item ) return scaling ? item.scaledClone(scaling) : item;
     const actor = this.getAssociatedActor();
     if ( !actor ) return;
-    const storedData = this.getFlag("dnd5e", "item.data") ?? this.getOriginatingMessage().getFlag("dnd5e", "item.data");
+    const storedData = this.#getStoredItemData() ?? this.getOriginatingMessage().#getStoredItemData();
     if ( storedData ) return new Item.implementation(storedData, { parent: actor }).scaledClone(scaling);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Retrieve the snapshot taken of this card's item if it has since been deleted.
+   * @returns {object|void}
+   */
+  #getStoredItemData() {
+    const id = this.system.item?.id ?? this.getFlag("dnd5e", "item.id");
+    return this.system.deltas?.deleted?.find(i => i._id === id) ?? this.getFlag("dnd5e", "item.data");
   }
 
   /* -------------------------------------------- */

--- a/system.json
+++ b/system.json
@@ -68,7 +68,13 @@
       "save": {},
       "timePassed": {},
       "turn": {},
-      "usage": {}
+      "usage": {
+        "filePathFields": {
+          "activity.img": ["IMAGE"],
+          "item.img": ["IMAGE"]
+        },
+        "htmlFields": ["description"]
+      }
     },
     "Item": {
       "weapon": {

--- a/templates/chat/parts/card-face.hbs
+++ b/templates/chat/parts/card-face.hbs
@@ -20,6 +20,23 @@
         {{/if}}
     </section>
 
+    {{!-- Buttons --}}
+    {{#if buttons.length}}
+    <div class="card-buttons">
+        {{#each buttons}}
+        <button type="button" data-action="{{ action }}" data-index="{{ index }}"{{#if hidden}} hidden{{/if}}>
+            {{ dnd5e-icon icon }}
+            {{#if hiddenLabel}}
+            <span class="visible-dc">{{ localize label }}</span>
+            <span class="hidden-dc">{{ localize hiddenLabel }}</span>
+            {{else}}
+            <span>{{ localize label }}</span>
+            {{/if}}
+        </button>
+        {{/each}}
+    </div>
+    {{/if}}
+
     {{!-- Supplements --}}
     {{#each supplements}}
     <p class="supplement"><strong>{{ localize label }}</strong> {{ detail }}</p>

--- a/templates/chat/usage-card.hbs
+++ b/templates/chat/usage-card.hbs
@@ -1,11 +1,13 @@
-<div>
-    {{{ content }}}
+{{#if content}}
+{{{ content }}}
+{{else}}
+{{> "dnd5e.card-face" }}
+{{/if}}
 
-    {{#if effects.length}}
-    <effect-application class="dnd5e2">
-        {{#each effects}}
-        <option value="{{ uuid }}"></option>
-        {{/each}}
-    </effect-application>
-    {{/if}}
-</div>
+{{#if effects.length}}
+<effect-application class="dnd5e2">
+    {{#each effects}}
+    <option value="{{ uuid }}"></option>
+    {{/each}}
+</effect-application>
+{{/if}}


### PR DESCRIPTION
`UsageMessageData` now inherits from `ItemMessageData`. It gets an `activity` source field that replaces `flags.dnd5e.activity` or `flags.dnd5e.use.activity`. `shouldHideChatButton` now gets the stored button descriptor rather than raw strings from the DOM node's `dataset`, which I think is an improvement. Again this will be breaking though if downstream are implementing this method, and again there is potentially a deprecation path available if we want to consider it.