### PR TITLE
Refactor getTargetDescriptors to provide the token UUID. Migrate targets to system data.

### DIFF
--- a/module/_types.mjs
+++ b/module/_types.mjs
@@ -629,10 +629,11 @@
  * Important information on a targeted token.
  *
  * @typedef TargetDescriptor5e
- * @property {string} uuid  The UUID of the target.
- * @property {string} img   The target's image.
- * @property {string} name  The target's name.
- * @property {number} ac    The target's armor class, if applicable.
+ * @property {string} actor  The UUID of the target actor.
+ * @property {number} ac     The target's armor class, if applicable.
+ * @property {string} img    The target token's image.
+ * @property {string} name   The target token's name.
+ * @property {string} token  The UUID of the target token.
  */
 
 /* -------------------------------------------- */

--- a/module/applications/components/targeted-application-mixin.mjs
+++ b/module/applications/components/targeted-application-mixin.mjs
@@ -1,3 +1,5 @@
+import { resolveTargetDescriptor } from "../../utils.mjs";
+
 /**
  * Adds functionality to a custom HTML element for displaying a target selector and displaying targets.
  * @param {typeof HTMLElement} Base  The base class being mixed.
@@ -118,7 +120,10 @@ export default function TargetedApplicationMixin(Base) {
       const targetedTokens = new Map();
       switch ( this.targetingMode ) {
         case "targeted":
-          this.chatMessage?.getFlag("dnd5e", "targets")?.forEach(t => targetedTokens.set(t.uuid, t.name));
+          for ( const descriptor of this.chatMessage?.getFlag("dnd5e", "targets") ?? [] ) {
+            const { actor, token } = resolveTargetDescriptor(descriptor);
+            if ( actor ) targetedTokens.set(actor.uuid, token?.name ?? descriptor.name);
+          }
           break;
         case "selected":
           canvas.tokens?.controlled?.forEach(t => {

--- a/module/applications/components/targeted-application-mixin.mjs
+++ b/module/applications/components/targeted-application-mixin.mjs
@@ -1,4 +1,4 @@
-import { resolveTargetDescriptor } from "../../utils.mjs";
+import TargetsField from "../../data/chat-message/fields/targets-field.mjs";
 
 /**
  * Adds functionality to a custom HTML element for displaying a target selector and displaying targets.
@@ -102,7 +102,7 @@ export default function TargetedApplicationMixin(Base) {
       this.targetSourceControl.querySelectorAll("button").forEach(b =>
         b.addEventListener("click", this._onChangeTargetMode.bind(this))
       );
-      if ( !this.chatMessage?.getFlag("dnd5e", "targets")?.length ) this.targetSourceControl.hidden = true;
+      if ( !this.chatMessage?.system?.targets?.length ) this.targetSourceControl.hidden = true;
 
       this.targetList = document.createElement("ul");
       this.targetList.classList.add("targets", "unlist");
@@ -120,8 +120,8 @@ export default function TargetedApplicationMixin(Base) {
       const targetedTokens = new Map();
       switch ( this.targetingMode ) {
         case "targeted":
-          for ( const descriptor of this.chatMessage?.getFlag("dnd5e", "targets") ?? [] ) {
-            const { actor, token } = resolveTargetDescriptor(descriptor);
+          for ( const descriptor of this.chatMessage?.system?.targets ?? [] ) {
+            const { actor, token } = TargetsField.resolve(descriptor);
             if ( actor ) targetedTokens.set(actor.uuid, token?.name ?? descriptor.name);
           }
           break;

--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -1,4 +1,5 @@
 /**
+ * @import { TargetDescriptor5e } from "../../_types.mjs";
  * @import { ActivityUsageChatButton } from "../../documents/activity/_types.mjs";
  * @import { BastionTurnItem, SaveOutcome } from "../../documents/_types.mjs";
  * @import { ActivationData, DurationData, RangeData, TargetData } from "../shared/_types.mjs";
@@ -6,7 +7,14 @@
  */
 
 /**
- * @typedef AttackMessageSystemData
+ * @typedef RollMessageSystemData
+ * @property {TargetDescriptor5e[]} targets  Tokens this message was rolled against.
+ */
+
+/* -------------------------------------------- */
+
+/**
+ * @typedef {RollMessageSystemData} AttackMessageSystemData
  * @property {string|null} ability      Ability used for the attack.
  * @property {string|null} ammunition   ID of the ammunition used for the attack.
  * @property {ActorDeltasData} deltas   Snapshots Items consumed & destroyed by the attack.
@@ -63,7 +71,7 @@
 /* -------------------------------------------- */
 
 /**
- * @typedef CheckMessageSystemData
+ * @typedef {RollMessageSystemData} CheckMessageSystemData
  * @property {string} ability      Ability used for the check.
  * @property {string|null} skill   Skill used for the check, if any.
  * @property {string|null} tool    Tool used for the check, if any.
@@ -72,14 +80,14 @@
 /* -------------------------------------------- */
 
 /**
- * @typedef DamageMessageSystemData
+ * @typedef {RollMessageSystemData} DamageMessageSystemData
  * @property {string|null} onSave  How this damage is affected by a successful save, if it followed one.
  */
 
 /* -------------------------------------------- */
 
 /**
- * @typedef GenericMessageSystemData
+ * @typedef {RollMessageSystemData} GenericMessageSystemData
  */
 
 /* -------------------------------------------- */
@@ -91,13 +99,13 @@
 /* -------------------------------------------- */
 
 /**
- * @typedef HitDieMessageSystemData
+ * @typedef {RollMessageSystemData} HitDieMessageSystemData
  */
 
 /* -------------------------------------------- */
 
 /**
- * @typedef HitPointsMessageSystemData
+ * @typedef {RollMessageSystemData} HitPointsMessageSystemData
  */
 
 /* -------------------------------------------- */
@@ -118,6 +126,7 @@
  * @property {string} school                     Spell school.
  * @property {string[]} subtitle                 Localized parts of the card's subtitle.
  * @property {TargetData|null} target            What the item's use targets.
+ * @property {TargetDescriptor5e[]} targets      Tokens this message was rolled against.
  */
 
 /**
@@ -198,7 +207,7 @@
 /* -------------------------------------------- */
 
 /**
- * @typedef SaveMessageSystemData
+ * @typedef {RollMessageSystemData} SaveMessageSystemData
  * @property {string} ability            Ability used for the save. Required unless this is a death save.
  * @property {ActorDeltasData} deltas    Actor changes recorded by this save (death saves only).
  * @property {SaveOutcome} outcome       Terminal outcome shown on the card.

--- a/module/data/chat-message/attack-message-data.mjs
+++ b/module/data/chat-message/attack-message-data.mjs
@@ -116,8 +116,8 @@ export default class AttackMessageData extends RollMessageData {
     // TODO: Move this into model when effect targets are converted.
     const targets = this.parent.getFlag("dnd5e", "targets") ?? [];
     return targets
-      .map(({ ac, name, uuid }) => ({
-        ac, name, showAC, uuid,
+      .map(({ ac, actor, name, token }) => ({
+        ac, actor, name, showAC, token,
         hasAC: ac !== null,
         isMiss: (ac === null) || (!roll.isCritical && ((roll.total < ac) || roll.isFumble))
       }))

--- a/module/data/chat-message/attack-message-data.mjs
+++ b/module/data/chat-message/attack-message-data.mjs
@@ -18,9 +18,10 @@ export default class AttackMessageData extends RollMessageData {
   /*  Model Configuration                         */
   /* -------------------------------------------- */
 
-  /** @override */
+  /** @inheritDoc */
   static defineSchema() {
     return {
+      ...super.defineSchema(),
       ability: new StringField({ blank: false, initial: null, nullable: true }),
       ammunition: new DocumentIdField({ initial: null, nullable: true }),
       deltas: new ActorDeltasField({}, { initial: null, nullable: true }),
@@ -113,9 +114,7 @@ export default class AttackMessageData extends RollMessageData {
     if ( !game.user.isGM && (visibility === "none") ) return [];
     const showAC = game.user.isGM || (visibility === "all");
 
-    // TODO: Move this into model when effect targets are converted.
-    const targets = this.parent.getFlag("dnd5e", "targets") ?? [];
-    return targets
+    return this.targets
       .map(({ ac, actor, name, token }) => ({
         ac, actor, name, showAC, token,
         hasAC: ac !== null,

--- a/module/data/chat-message/check-message-data.mjs
+++ b/module/data/chat-message/check-message-data.mjs
@@ -17,9 +17,10 @@ export default class CheckMessageData extends RollMessageData {
   /*  Model Configuration                         */
   /* -------------------------------------------- */
 
-  /** @override */
+  /** @inheritDoc */
   static defineSchema() {
     return {
+      ...super.defineSchema(),
       ability: new StringField({ blank: false, required: true }),
       skill: new StringField({ blank: false, initial: null, nullable: true }),
       tool: new StringField({ blank: false, initial: null, nullable: true })

--- a/module/data/chat-message/damage-message-data.mjs
+++ b/module/data/chat-message/damage-message-data.mjs
@@ -18,9 +18,10 @@ export default class DamageMessageData extends RollMessageData {
   /*  Model Configuration                         */
   /* -------------------------------------------- */
 
-  /** @override */
+  /** @inheritDoc */
   static defineSchema() {
     return {
+      ...super.defineSchema(),
       onSave: new StringField({ blank: false, initial: null, nullable: true, required: false })
     };
   }

--- a/module/data/chat-message/fields/_module.mjs
+++ b/module/data/chat-message/fields/_module.mjs
@@ -1,2 +1,3 @@
 export {default as ActivationsField} from "./activations-field.mjs";
 export * from "./deltas-field.mjs";
+export {default as TargetsField} from "./targets-field.mjs";

--- a/module/data/chat-message/fields/_module.mjs
+++ b/module/data/chat-message/fields/_module.mjs
@@ -1,3 +1,3 @@
-export {default as ActivationsField} from "./activations-field.mjs";
+export { default as ActivationsField } from "./activations-field.mjs";
 export * from "./deltas-field.mjs";
-export {default as TargetsField} from "./targets-field.mjs";
+export { default as TargetsField } from "./targets-field.mjs";

--- a/module/data/chat-message/fields/targets-field.mjs
+++ b/module/data/chat-message/fields/targets-field.mjs
@@ -1,0 +1,74 @@
+const {
+  ArrayField, DocumentUUIDField, FilePathField, NumberField, SchemaField, StringField
+} = foundry.data.fields;
+
+/**
+ * @import { TargetDescriptor5e } from "../../../_types.mjs";
+ */
+
+/**
+ * A field for storing the tokens a message was rolled against.
+ */
+export default class TargetsField extends ArrayField {
+  constructor(options={}) {
+    super(new SchemaField({
+      ac: new NumberField({ integer: true }),
+      actor: new DocumentUUIDField({ type: "Actor" }),
+      img: new FilePathField({ categories: ["IMAGE"] }),
+      name: new StringField(),
+      token: new DocumentUUIDField({ type: "Token" })
+    }), options);
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Describe the given tokens for storage on a message.
+   * @param {Iterable<Token5e|TokenDocument5e>} [tokens]  Tokens to describe. Defaults to the user's current targets.
+   * @returns {TargetDescriptor5e[]}
+   */
+  static getDescriptors(tokens=game.user.targets) {
+    const targets = new Map();
+    for ( const target of tokens ) {
+      const token = target.document ?? target;
+      const { statuses, system, uuid: actor } = token.actor ?? {};
+      if ( !actor ) continue;
+      const ac = statuses.has("coverTotal") ? null : system.attributes?.ac?.value;
+      targets.set(token.uuid, {
+        actor,
+        ac: ac ?? null,
+        img: token.texture?.src,
+        name: token.name,
+        token: token.uuid
+      });
+    }
+    return Array.from(targets.values());
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Resolve a stored target descriptor back to the documents it describes, falling back through progressively weaker
+   * matches when the exact token is not available on the scene being viewed.
+   * @param {TargetDescriptor5e} descriptor  Descriptor stored when the target was captured.
+   * @returns {{ [actor]: Actor5e, [token]: Token5e }}
+   */
+  static resolve({ actor, token }={}) {
+    const document = token ? fromUuidSync(token, { strict: false }) : null;
+
+    // The exact token, if it is on the scene currently being viewed.
+    if ( document?.parent === canvas?.scene ) return { actor: document.actor, token: document.object };
+
+    // An unlinked token's actor exists only on that token, so no other token can stand in for it.
+    if ( foundry.utils.parseUuid(actor)?.primaryType === "Scene" ) {
+      return { actor: document?.actor ?? fromUuidSync(actor, { strict: false }) };
+    }
+
+    // Any token of the same actor on the viewed scene, otherwise the actor by itself.
+    const base = fromUuidSync(actor, { strict: false });
+    const [active] = base?.getActiveTokens() ?? [];
+    return { actor: base, token: active };
+  }
+}

--- a/module/data/chat-message/fields/targets-field.mjs
+++ b/module/data/chat-message/fields/targets-field.mjs
@@ -14,7 +14,7 @@ export default class TargetsField extends ArrayField {
     super(new SchemaField({
       ac: new NumberField({ integer: true }),
       actor: new DocumentUUIDField({ type: "Actor" }),
-      img: new FilePathField({ categories: ["IMAGE"] }),
+      img: new FilePathField({ categories: ["IMAGE", "VIDEO"] }),
       name: new StringField(),
       token: new DocumentUUIDField({ type: "Token" })
     }), options);

--- a/module/data/chat-message/generic-message-data.mjs
+++ b/module/data/chat-message/generic-message-data.mjs
@@ -15,13 +15,6 @@ export default class GenericMessageData extends RollMessageData {
   /*  Model Configuration                         */
   /* -------------------------------------------- */
 
-  /** @override */
-  static defineSchema() {
-    return {};
-  }
-
-  /* -------------------------------------------- */
-
   /** @inheritDoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     template: "systems/dnd5e/templates/chat/generic-card.hbs"

--- a/module/data/chat-message/hit-die-message-data.mjs
+++ b/module/data/chat-message/hit-die-message-data.mjs
@@ -15,13 +15,6 @@ export default class HitDieMessageData extends RollMessageData {
   /*  Model Configuration                         */
   /* -------------------------------------------- */
 
-  /** @override */
-  static defineSchema() {
-    return {};
-  }
-
-  /* -------------------------------------------- */
-
   /** @inheritDoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     template: "systems/dnd5e/templates/chat/hit-die-card.hbs"

--- a/module/data/chat-message/hit-points-message-data.mjs
+++ b/module/data/chat-message/hit-points-message-data.mjs
@@ -15,13 +15,6 @@ export default class HitPointsMessageData extends RollMessageData {
   /*  Model Configuration                         */
   /* -------------------------------------------- */
 
-  /** @override */
-  static defineSchema() {
-    return {};
-  }
-
-  /* -------------------------------------------- */
-
   /** @inheritDoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
     template: "systems/dnd5e/templates/chat/hit-points-card.hbs"

--- a/module/data/chat-message/item-message-data.mjs
+++ b/module/data/chat-message/item-message-data.mjs
@@ -4,6 +4,7 @@ import DurationField from "../shared/duration-field.mjs";
 import PropertyField from "../shared/property-field.mjs";
 import RangeField from "../shared/range-field.mjs";
 import TargetField from "../shared/target-field.mjs";
+import TargetsField from "./fields/targets-field.mjs";
 
 const {
   ArrayField, BooleanField, DocumentIdField, DocumentUUIDField, FilePathField, HTMLField, NumberField, SchemaField,
@@ -52,7 +53,8 @@ export default class ItemMessageData extends ChatMessageDataModel {
       }, { initial: null, nullable: true }),
       school: new StringField(),
       subtitle: new ArrayField(new StringField()),
-      target: new TargetField({}, { initial: null, nullable: true })
+      target: new TargetField({}, { initial: null, nullable: true }),
+      targets: new TargetsField()
     };
   }
 

--- a/module/data/chat-message/roll-message-data.mjs
+++ b/module/data/chat-message/roll-message-data.mjs
@@ -1,7 +1,14 @@
 import ChatMessageDataModel from "../abstract/chat-message-data-model.mjs";
+import TargetsField from "./fields/targets-field.mjs";
+
+/**
+ * @import { RollMessageSystemData } from "./_types.mjs";
+ */
 
 /**
  * Base data model for chat messages that display the results of rolls.
+ * @extends {ChatMessageDataModel<RollMessageSystemData>}
+ * @mixes RollMessageSystemData
  * @abstract
  */
 export default class RollMessageData extends ChatMessageDataModel {
@@ -11,6 +18,17 @@ export default class RollMessageData extends ChatMessageDataModel {
    * @type {string}
    */
   static ROLL_TEMPLATE = "systems/dnd5e/templates/chat/parts/roll.hbs";
+
+  /* -------------------------------------------- */
+  /*  Model Configuration                         */
+  /* -------------------------------------------- */
+
+  /** @override */
+  static defineSchema() {
+    return {
+      targets: new TargetsField()
+    };
+  }
 
   /* -------------------------------------------- */
   /*  Properties                                  */

--- a/module/data/chat-message/save-message-data.mjs
+++ b/module/data/chat-message/save-message-data.mjs
@@ -18,9 +18,10 @@ export default class SaveMessageData extends RollMessageData {
   /*  Model Configuration                         */
   /* -------------------------------------------- */
 
-  /** @override */
+  /** @inheritDoc */
   static defineSchema() {
     return {
+      ...super.defineSchema(),
       ability: new StringField({ blank: false, required: false }),
       deltas: new ActorDeltasField(),
       outcome: new StringField({

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -1,8 +1,8 @@
 import AttackSheet from "../../applications/activity/attack-sheet.mjs";
 import AttackRollConfigurationDialog from "../../applications/dice/attack-configuration-dialog.mjs";
 import BaseAttackActivityData from "../../data/activity/attack-data.mjs";
+import TargetsField from "../../data/chat-message/fields/targets-field.mjs";
 import D20RollModificationField from "../../data/shared/d20-roll-modification-field.mjs";
-import { getTargetDescriptors } from "../../utils.mjs";
 import ActivityMixin from "./mixin.mjs";
 
 /**
@@ -80,7 +80,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
    * @returns {Promise<D20Roll[]|null>}
    */
   async rollAttack(config={}, dialog={}, message={}) {
-    const targets = getTargetDescriptors();
+    const targets = TargetsField.getDescriptors();
 
     if ( (this.item.type === "weapon") && (this.item.system.quantity === 0) ) {
       ui.notifications.warn("DND5E.ATTACK.Warning.NoQuantity");
@@ -159,6 +159,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
         flavor: `${this.item.name} - ${_loc("DND5E.AttackRoll")}`,
         flags: { dnd5e: this.messageFlags },
         speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+        system: { targets },
         type: "attack"
       }
     }, message);

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -3,7 +3,8 @@ import ActivityUsageDialog from "../../applications/activity/activity-usage-dial
 import TemplatePlacement from "../../canvas/template-placement.mjs";
 import { ConsumptionError } from "../../data/activity/fields/consumption-targets-field.mjs";
 import { ActorDeltasField } from "../../data/chat-message/fields/deltas-field.mjs";
-import { formatNumber, getSceneTargets, getTargetDescriptors, localizeSchema } from "../../utils.mjs";
+import TargetsField from "../../data/chat-message/fields/targets-field.mjs";
+import { formatNumber, getSceneTargets, localizeSchema } from "../../utils.mjs";
 import AppliedRules from "../applied-rules.mjs";
 import DependentDocumentMixin from "../mixins/dependent.mjs";
 import PseudoDocumentMixin from "../mixins/pseudo-document.mjs";
@@ -149,8 +150,7 @@ export default function ActivityMixin(Base) {
     get messageFlags() {
       return {
         activity: { type: this.type, id: this.id, uuid: this.uuid },
-        item: { type: this.item.type, id: this.item.id, uuid: this.item.uuid },
-        targets: getTargetDescriptors()
+        item: { type: this.item.type, id: this.item.id, uuid: this.item.uuid }
       };
     }
 
@@ -212,9 +212,7 @@ export default function ActivityMixin(Base) {
       const messageConfig = foundry.utils.mergeObject({
         create: true,
         data: {
-          flags: {
-            dnd5e: { targets: getTargetDescriptors() }
-          }
+          system: { targets: TargetsField.getDescriptors() }
         },
         hasConsumption: usageConfig.hasConsumption
       }, message);
@@ -857,6 +855,7 @@ export default function ActivityMixin(Base) {
           flavor: `${this.item.name} - ${this.damageFlavor}`,
           flags: { dnd5e: this.messageFlags },
           speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+          system: { targets: TargetsField.getDescriptors() },
           type: "damage"
         }
       }, message);

--- a/module/documents/activity/utility.mjs
+++ b/module/documents/activity/utility.mjs
@@ -1,5 +1,6 @@
 import UtilitySheet from "../../applications/activity/utility-sheet.mjs";
 import BaseUtilityActivityData from "../../data/activity/utility-data.mjs";
+import TargetsField from "../../data/chat-message/fields/targets-field.mjs";
 import ActivityMixin from "./mixin.mjs";
 
 /**
@@ -93,7 +94,8 @@ export default class UtilityActivity extends ActivityMixin(BaseUtilityActivityDa
         type: "generic",
         flags: {
           dnd5e: this.messageFlags
-        }
+        },
+        system: { targets: TargetsField.getDescriptors() }
       }
     }, message);
 

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -1,4 +1,5 @@
 import aggregateDamageRolls from "../dice/aggregate-damage-rolls.mjs";
+import { resolveTargetDescriptor } from "../utils.mjs";
 
 export default class ChatMessage5e extends ChatMessage {
 
@@ -161,6 +162,7 @@ export default class ChatMessage5e extends ChatMessage {
     html.classList.add("dnd5e2");
 
     // Header matter
+    const token = this.getAssociatedToken();
     const actor = this.getAssociatedActor();
     const avatar = document.createElement("a");
     avatar.classList.add("avatar");
@@ -187,7 +189,8 @@ export default class ChatMessage5e extends ChatMessage {
     }
     img ??= CONST.DEFAULT_TOKEN;
 
-    if ( actor ) avatar.dataset.uuid = actor.uuid;
+    if ( actor ) avatar.dataset.actorUuid = actor.uuid;
+    if ( token ) avatar.dataset.tokenUuid = token.uuid;
     Object.assign(avatarImg, { src: img, alt: nameText });
     avatar.append(avatarImg);
 
@@ -320,10 +323,9 @@ export default class ChatMessage5e extends ChatMessage {
    */
   async _onTargetMouseDown(event) {
     event.stopPropagation();
-    const uuid = event.currentTarget.dataset.uuid;
-    const actor = fromUuidSync(uuid);
-    const token = actor?.token?.object ?? actor?.getActiveTokens()[0];
-    if ( !token || !actor.testUserPermission(game.user, "OBSERVER")) return;
+    const { actorUuid, tokenUuid } = event.currentTarget.dataset;
+    const { actor, token } = resolveTargetDescriptor({ actor: actorUuid, token: tokenUuid });
+    if ( !token || !actor?.testUserPermission(game.user, "OBSERVER")) return;
     const releaseOthers = !event.shiftKey;
     if ( token.controlled ) token.release();
     else {
@@ -340,9 +342,8 @@ export default class ChatMessage5e extends ChatMessage {
    * @protected
    */
   _onTargetHoverIn(event) {
-    const uuid = event.currentTarget.dataset.uuid;
-    const actor = fromUuidSync(uuid);
-    const token = actor?.token?.object ?? actor?.getActiveTokens()[0];
+    const { actorUuid, tokenUuid } = event.currentTarget.dataset;
+    const { token } = resolveTargetDescriptor({ actor: actorUuid, token: tokenUuid });
     if ( token && token.isVisible ) {
       if ( !token.controlled ) token._onHoverIn(event, { hoverOutOthers: true });
       this._highlighted = token;
@@ -392,18 +393,13 @@ export default class ChatMessage5e extends ChatMessage {
   selectTargets(li, type) {
     if ( !canvas?.ready ) return;
     const lis = li.closest("[data-message-id]").querySelectorAll(`.evaluation li.target.${type}`);
-    const uuids = new Set(Array.from(lis).map(n => n.dataset.uuid));
     canvas.tokens.releaseAll();
-    uuids.forEach(uuid => {
-      const actor = fromUuidSync(uuid);
-      if ( !actor ) return;
-      const tokens = actor.isToken ? [actor.token?.object] : actor.getActiveTokens();
-      for ( const token of tokens ) {
-        if ( token?.isVisible && actor.testUserPermission(game.user, "OWNER") ) {
-          token.control({ releaseOthers: false });
-        }
+    for ( const { dataset } of lis ) {
+      const { actor, token } = resolveTargetDescriptor({ actor: dataset.actorUuid, token: dataset.tokenUuid });
+      if ( token?.isVisible && actor?.testUserPermission(game.user, "OWNER") ) {
+        token.control({ releaseOthers: false });
       }
-    });
+    }
   }
 
   /* -------------------------------------------- */
@@ -548,12 +544,7 @@ export default class ChatMessage5e extends ChatMessage {
    * @returns {Actor|void}
    */
   getAssociatedActor() {
-    if ( this.speaker.scene && this.speaker.token ) {
-      const scene = game.scenes.get(this.speaker.scene);
-      const token = scene?.tokens.get(this.speaker.token);
-      if ( token ) return token.actor;
-    }
-    return game.actors.get(this.speaker.actor);
+    return this.getAssociatedToken()?.actor ?? game.actors.get(this.speaker.actor);
   }
 
   /* -------------------------------------------- */
@@ -595,6 +586,17 @@ export default class ChatMessage5e extends ChatMessage {
    */
   getAssociatedRolls(type) {
     return dnd5e.registry.messages.get(this.id, type);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Get the token which is the speaker of a chat card.
+   * @returns {TokenDocument5e|void}
+   */
+  getAssociatedToken() {
+    const { scene, token } = this.speaker;
+    if ( scene && token ) return game.scenes.get(scene)?.tokens.get(token);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -1,5 +1,5 @@
 import aggregateDamageRolls from "../dice/aggregate-damage-rolls.mjs";
-import { resolveTargetDescriptor } from "../utils.mjs";
+import TargetsField from "../data/chat-message/fields/targets-field.mjs";
 
 export default class ChatMessage5e extends ChatMessage {
 
@@ -324,7 +324,7 @@ export default class ChatMessage5e extends ChatMessage {
   async _onTargetMouseDown(event) {
     event.stopPropagation();
     const { actorUuid, tokenUuid } = event.currentTarget.dataset;
-    const { actor, token } = resolveTargetDescriptor({ actor: actorUuid, token: tokenUuid });
+    const { actor, token } = TargetsField.resolve({ actor: actorUuid, token: tokenUuid });
     if ( !token || !actor?.testUserPermission(game.user, "OBSERVER")) return;
     const releaseOthers = !event.shiftKey;
     if ( token.controlled ) token.release();
@@ -343,7 +343,7 @@ export default class ChatMessage5e extends ChatMessage {
    */
   _onTargetHoverIn(event) {
     const { actorUuid, tokenUuid } = event.currentTarget.dataset;
-    const { token } = resolveTargetDescriptor({ actor: actorUuid, token: tokenUuid });
+    const { token } = TargetsField.resolve({ actor: actorUuid, token: tokenUuid });
     if ( token && token.isVisible ) {
       if ( !token.controlled ) token._onHoverIn(event, { hoverOutOthers: true });
       this._highlighted = token;
@@ -395,7 +395,7 @@ export default class ChatMessage5e extends ChatMessage {
     const lis = li.closest("[data-message-id]").querySelectorAll(`.evaluation li.target.${type}`);
     canvas.tokens.releaseAll();
     for ( const { dataset } of lis ) {
-      const { actor, token } = resolveTargetDescriptor({ actor: dataset.actorUuid, token: dataset.tokenUuid });
+      const { actor, token } = TargetsField.resolve({ actor: dataset.actorUuid, token: dataset.tokenUuid });
       if ( token?.isVisible && actor?.testUserPermission(game.user, "OWNER") ) {
         token.control({ releaseOthers: false });
       }

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -325,7 +325,7 @@ export default class ChatMessage5e extends ChatMessage {
     event.stopPropagation();
     const { actorUuid, tokenUuid } = event.currentTarget.dataset;
     const { actor, token } = TargetsField.resolve({ actor: actorUuid, token: tokenUuid });
-    if ( !token || !actor?.testUserPermission(game.user, "OBSERVER")) return;
+    if ( !token || !actor?.testUserPermission(game.user, "OBSERVER") ) return;
     const releaseOthers = !event.shiftKey;
     if ( token.controlled ) token.release();
     else {

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -3,7 +3,8 @@ import AttackRollConfigurationDialog from "./applications/dice/attack-configurat
 import simplifyRollFormula from "./dice/simplify-roll-formula.mjs";
 import * as Trait from "./documents/actor/trait.mjs";
 import { rollItem } from "./documents/macro.mjs";
-import { formatNumber, getSceneTargets, getTargetDescriptors, loadingTooltip, log, simplifyBonus } from "./utils.mjs";
+import TargetsField from "./data/chat-message/fields/targets-field.mjs";
+import { formatNumber, getSceneTargets, loadingTooltip, log, simplifyBonus } from "./utils.mjs";
 
 const slugify = value => value?.slugify().replaceAll("-", "").replaceAll("(", "").replaceAll(")", "");
 const logWarning = (msg, options) =>
@@ -306,7 +307,7 @@ async function rollAttack(config, event) {
     if ( activity ) return activity.rollAttack({ attackMode, event });
   }
 
-  const targets = getTargetDescriptors();
+  const targets = TargetsField.getDescriptors();
   const rollConfig = {
     attackMode, event,
     hookNames: ["attack", "d20Test"],
@@ -1182,13 +1183,9 @@ async function rollDamage(config, event) {
   const messageConfig = {
     create: true,
     data: {
-      flags: {
-        dnd5e: {
-          targets: getTargetDescriptors()
-        }
-      },
       flavor: _loc(`DND5E.${rollType === "healing" ? "Healing" : "Damage"}Roll`),
       speaker: ChatMessage.implementation.getSpeaker(),
+      system: { targets: TargetsField.getDescriptors() },
       type: rollType === "healing" ? "healing" : "damage"
     }
   };

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -786,16 +786,25 @@ export function migrateMacroData(macro, migrationData) {
  * @returns {object}            The update data to apply.
  */
 export function migrateMessageData(messageData) {
-  if ( messageData.type !== "base" ) return {};
-
   const updateData = {};
   const { flags } = messageData;
-  const rollType = foundry.utils.getProperty(flags, "dnd5e.roll.type");
+  const targets = flags?.dnd5e?.targets?.map(({ ac, img, name, uuid }) => ({ ac, img, name, actor: uuid }));
+  if ( targets ) updateData["flags.dnd5e.targets"] = _del;
+
+  if ( messageData.type !== "base" ) {
+    if ( targets && CONFIG.ChatMessage.dataModels[messageData.type]?.schema.has("targets") ) {
+      updateData["system.targets"] = targets;
+    }
+    return updateData;
+  }
+
+  const rollType = flags?.dnd5e?.roll?.type;
 
   if ( flags?.dnd5e?.messageType === "usage" ) {
     const use = flags.dnd5e.use;
     updateData.type = "usage";
     updateData.system = _replace({
+      targets,
       cause: use?.cause,
       concentration: use?.concentrationId,
       deltas: use?.consumed,
@@ -803,7 +812,6 @@ export function migrateMessageData(messageData) {
       scaling: use?.scaling,
       spellLevel: use?.spellLevel
     });
-    updateData["flags.dnd5e.messageType"] = _del;
     updateData["flags.dnd5e.scaling"] = _del;
     updateData["flags.dnd5e.use.cause"] = _del;
     updateData["flags.dnd5e.use.concentrationId"] = _del;
@@ -827,64 +835,57 @@ export function migrateMessageData(messageData) {
       ?? "int";
     updateData.type = "check";
     updateData.system = _replace({ ability, skill: roll.skillId, tool: roll.toolId });
-    updateData["flags.dnd5e.messageType"] = _del;
-    updateData["flags.dnd5e.roll"] = _del;
   }
 
   else if ( rollType === "save" ) {
     const roll = flags.dnd5e.roll;
     updateData.type = "save";
     updateData.system = _replace({ ability: roll.ability, resisted: roll.forceSuccess });
-    updateData["flags.dnd5e.messageType"] = _del;
-    updateData["flags.dnd5e.roll"] = _del;
   }
 
   else if ( rollType === "death" ) {
     updateData.type = "save";
     updateData.system = _replace({ type: "death" });
-    updateData["flags.dnd5e.messageType"] = _del;
-    updateData["flags.dnd5e.roll"] = _del;
   }
 
   else if ( rollType === "attack" ) {
     const roll = flags.dnd5e.roll;
     updateData.type = "attack";
     updateData.system = _replace({
+      targets,
       ability: roll.ability,
       ammunition: roll.ammunition,
       deltas: roll.ammunitionData ? { deleted: [roll.ammunitionData] } : null,
       mastery: roll.mastery,
       mode: roll.attackMode
     });
-    updateData["flags.dnd5e.messageType"] = _del;
-    updateData["flags.dnd5e.roll"] = _del;
   }
 
   else if ( (rollType === "damage") || (rollType === "healing") ) {
     updateData.type = rollType;
-    updateData.system = _replace({ onSave: flags.dnd5e.roll.damageOnSave ?? null });
-    updateData["flags.dnd5e.messageType"] = _del;
-    updateData["flags.dnd5e.roll"] = _del;
+    updateData.system = _replace({ targets, onSave: flags.dnd5e.roll.damageOnSave ?? null });
   }
 
   /* TODO: Re-instate these migrations when foundryvtt/foundryvtt#14229 is resolved.
-  else if ( flags?.dnd5e?.roll?.type === "generic" ) {
+  else if ( rollType === "generic" ) {
     updateData.type = "generic";
-    updateData.system = _replace({});
-    updateData["flags.dnd5e.roll"] = _del;
+    updateData.system = _replace({ targets });
   }
 
-  else if ( flags?.dnd5e?.roll?.type === "hitDie" ) {
+  else if ( rollType === "hitDie" ) {
     updateData.type = "hitDie";
     updateData.system = _replace({});
-    updateData["flags.dnd5e.roll"] = _del;
   }
 
-  else if ( flags?.dnd5e?.roll?.type === "hitPoints" ) {
+  else if ( rollType === "hitPoints" ) {
     updateData.type = "hitPoints";
     updateData.system = _replace({});
-    updateData["flags.dnd5e.roll"] = _del;
   }*/
+
+  if ( updateData.type ) {
+    if ( rollType ) updateData["flags.dnd5e.roll"] = _del;
+    if ( flags.dnd5e.messageType ) updateData["flags.dnd5e.messageType"] = _del;
+  }
 
   return updateData;
 }

--- a/module/rules/falling.mjs
+++ b/module/rules/falling.mjs
@@ -1,4 +1,5 @@
-import { convertLength, formatLength, getTargetDescriptors } from "../utils.mjs";
+import TargetsField from "../data/chat-message/fields/targets-field.mjs";
+import { convertLength, formatLength } from "../utils.mjs";
 
 /**
  * @import Actor5e from "../documents/actor/actor.mjs";
@@ -51,14 +52,14 @@ export async function postFallDamage(targets, distance) {
     data: {
       flags: {
         dnd5e: {
-          context: { fall: true },
-          targets: getTargetDescriptors(targets)
+          context: { fall: true }
         }
       },
       flavor: _loc("DND5E.FALLING.DamageFlavor", {
         distance: formatLength(Math.round(distance), units)
       }),
       speaker: ChatMessage.implementation.getSpeaker(),
+      system: { targets: TargetsField.getDescriptors(targets) },
       type: "damage"
     }
   });

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -763,15 +763,45 @@ export function loadingTooltip({ uuid, passive=false }={}) {
  */
 export function getTargetDescriptors(tokens=game.user.targets) {
   const targets = new Map();
-  for ( const token of tokens ) {
-    const { name } = token;
-    const { img, system, uuid, statuses } = token.actor ?? {};
-    if ( uuid ) {
-      const ac = statuses.has("coverTotal") ? null : system.attributes?.ac?.value;
-      targets.set(uuid, { name, img, uuid, ac: ac ?? null });
-    }
+  for ( const target of tokens ) {
+    const token = target.document ?? target;
+    const { statuses, system, uuid: actor } = token.actor ?? {};
+    if ( !actor ) continue;
+    const ac = statuses.has("coverTotal") ? null : system.attributes?.ac?.value;
+    targets.set(token.uuid, {
+      actor,
+      ac: ac ?? null,
+      img: token.texture?.src,
+      name: token.name,
+      token: token.uuid
+    });
   }
   return Array.from(targets.values());
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Resolve a stored target descriptor back to the documents it describes, falling back through progressively weaker
+ * matches when the exact token is not available on the scene being viewed.
+ * @param {TargetDescriptor5e} descriptor  Descriptor stored when the target was captured.
+ * @returns {{ [actor]: Actor5e, [token]: Token5e }}
+ */
+export function resolveTargetDescriptor({ actor, token }={}) {
+  const document = token ? fromUuidSync(token, { strict: false }) : null;
+
+  // The exact token, if it is on the scene currently being viewed.
+  if ( document?.parent === canvas?.scene ) return { actor: document.actor, token: document.object };
+
+  // An unlinked token's actor exists only on that token, so no other token can stand in for it.
+  if ( foundry.utils.parseUuid(actor)?.primaryType === "Scene" ) {
+    return { actor: document?.actor ?? fromUuidSync(actor, { strict: false }) };
+  }
+
+  // Any token of the same actor on the viewed scene, otherwise the actor by itself.
+  const base = fromUuidSync(actor, { strict: false });
+  const [active] = base?.getActiveTokens() ?? [];
+  return { actor: base, token: active };
 }
 
 /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1,3 +1,5 @@
+import TargetsField from "./data/chat-message/fields/targets-field.mjs";
+
 /**
  * @import { TargetDescriptor5e, UnitConfiguration } from "./_types.mjs";
  * @import { RollData } from "./documents/_types.mjs";
@@ -760,48 +762,15 @@ export function loadingTooltip({ uuid, passive=false }={}) {
  * Grab the targeted tokens and return relevant information on them.
  * @param {Iterable<Token5e|TokenDocument5e>} [tokens]  Tokens to describe. Defaults to the user's current targets.
  * @returns {TargetDescriptor5e[]}
+ * @deprecated
+ * @since 6.0
  */
 export function getTargetDescriptors(tokens=game.user.targets) {
-  const targets = new Map();
-  for ( const target of tokens ) {
-    const token = target.document ?? target;
-    const { statuses, system, uuid: actor } = token.actor ?? {};
-    if ( !actor ) continue;
-    const ac = statuses.has("coverTotal") ? null : system.attributes?.ac?.value;
-    targets.set(token.uuid, {
-      actor,
-      ac: ac ?? null,
-      img: token.texture?.src,
-      name: token.name,
-      token: token.uuid
-    });
-  }
-  return Array.from(targets.values());
-}
-
-/* -------------------------------------------- */
-
-/**
- * Resolve a stored target descriptor back to the documents it describes, falling back through progressively weaker
- * matches when the exact token is not available on the scene being viewed.
- * @param {TargetDescriptor5e} descriptor  Descriptor stored when the target was captured.
- * @returns {{ [actor]: Actor5e, [token]: Token5e }}
- */
-export function resolveTargetDescriptor({ actor, token }={}) {
-  const document = token ? fromUuidSync(token, { strict: false }) : null;
-
-  // The exact token, if it is on the scene currently being viewed.
-  if ( document?.parent === canvas?.scene ) return { actor: document.actor, token: document.object };
-
-  // An unlinked token's actor exists only on that token, so no other token can stand in for it.
-  if ( foundry.utils.parseUuid(actor)?.primaryType === "Scene" ) {
-    return { actor: document?.actor ?? fromUuidSync(actor, { strict: false }) };
-  }
-
-  // Any token of the same actor on the viewed scene, otherwise the actor by itself.
-  const base = fromUuidSync(actor, { strict: false });
-  const [active] = base?.getActiveTokens() ?? [];
-  return { actor: base, token: active };
+  foundry.utils.logCompatibilityWarning(
+    "The getTargetDescriptors helper has been deprecated. Please use `TargetsField.getDescriptors` instead.",
+    { since: "DnD5e 6.0", until: "DnD5e 6.2" }
+  );
+  return TargetsField.getDescriptors(tokens);
 }
 
 /* -------------------------------------------- */

--- a/system.json
+++ b/system.json
@@ -46,32 +46,66 @@
       }
     },
     "ChatMessage": {
-      "attack": {},
+      "attack": {
+        "filePathFields": {
+          "targets.*.img": ["IMAGE", "VIDEO"]
+        }
+      },
       "bastionAttack": {},
       "bastionOrder": {},
       "bastionTurn": {},
-      "check": {},
-      "damage": {},
-      "generic": {},
-      "healing": {},
-      "hitDie": {},
-      "hitPoints": {},
+      "check": {
+        "filePathFields": {
+          "targets.*.img": ["IMAGE", "VIDEO"]
+        }
+      },
+      "damage": {
+        "filePathFields": {
+          "targets.*.img": ["IMAGE", "VIDEO"]
+        }
+      },
+      "generic": {
+        "filePathFields": {
+          "targets.*.img": ["IMAGE", "VIDEO"]
+        }
+      },
+      "healing": {
+        "filePathFields": {
+          "targets.*.img": ["IMAGE", "VIDEO"]
+        }
+      },
+      "hitDie": {
+        "filePathFields": {
+          "targets.*.img": ["IMAGE", "VIDEO"]
+        }
+      },
+      "hitPoints": {
+        "filePathFields": {
+          "targets.*.img": ["IMAGE", "VIDEO"]
+        }
+      },
       "item": {
         "filePathFields": {
-          "item.img": ["IMAGE"]
+          "item.img": ["IMAGE"],
+          "targets.*.img": ["IMAGE", "VIDEO"]
         },
         "htmlFields": ["description"]
       },
       "prompt": {},
       "request": {},
       "rest": {},
-      "save": {},
+      "save": {
+        "filePathFields": {
+          "targets.*.img": ["IMAGE", "VIDEO"]
+        }
+      },
       "timePassed": {},
       "turn": {},
       "usage": {
         "filePathFields": {
           "activity.img": ["IMAGE"],
-          "item.img": ["IMAGE"]
+          "item.img": ["IMAGE"],
+          "targets.*.img": ["IMAGE", "VIDEO"]
         },
         "htmlFields": ["description"]
       }

--- a/templates/chat/parts/targets-tray.hbs
+++ b/templates/chat/parts/targets-tray.hbs
@@ -7,7 +7,8 @@
     <div class="collapsible-content">
         <ul class="unlist evaluation wrapper">
             {{#each targets}}
-            <li class="target {{#if isMiss}}miss{{else}}hit{{/if}}" data-uuid="{{ uuid }}" data-miss="{{ isMiss }}">
+            <li class="target {{#if isMiss}}miss{{else}}hit{{/if}}" data-actor-uuid="{{ actor }}"
+                data-token-uuid="{{ token }}" data-miss="{{ isMiss }}">
                 <i class="fas {{#if isMiss}}fa-times{{else}}fa-check{{/if}}"></i>
                 <div class="name">{{ name }}</div>
                 {{#if showAC}}


### PR DESCRIPTION
- Closes #4720 

We should generally be able to losslessly retrieve the exact targeted token now. Also storing token image here rather than actor image. But with the planned new chat card designs I think I won't use it, so maybe it should be removed, and then we don't need such lengthy sanitisation schema.