### PR TITLE
Add deprecation path for legacy cards.

### DIFF
--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -222,7 +222,9 @@ export default class ItemDataModel extends SystemDataModel {
         ...this.cardProperties ?? [],
         ...PropertyField.getUsageProperties(usage),
         ...this.equippableItemCardProperties ?? []
-      ],
+      ]
+        // Entries without a type are pre-6.0 label strings, which would cause a validation failure.
+        .filter(p => p?.type),
       subtitle: [this.type?.label ?? _loc(CONFIG.Item.typeLabels[type])]
     };
   }

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -100,14 +100,17 @@ export default class UsageMessageData extends ItemMessageData {
   _prepareButtons() {
     const activity = this.parent.getAssociatedActivity();
     const isCreator = game.user.isGM || this.actor?.isOwner || this.parent.isAuthor;
-    return this.buttons.map((button, index) => ({
-      ...button, index,
-      hidden: button.visibility === "all"
-        ? false
-        : ((button.visibility === "gm") && !game.user.isGM)
-          || !isCreator
-          || !!activity?.shouldHideChatButton(button, this.parent)
-    }));
+    return this.buttons.map((button, index) => {
+      const descriptor = { ...button, dataset: { ...button.dataset, /** @deprecated */ action: button.action } };
+      return {
+        ...descriptor, index,
+        hidden: button.visibility === "all"
+          ? false
+          : ((button.visibility === "gm") && !game.user.isGM)
+            || !isCreator
+            || !!activity?.shouldHideChatButton(descriptor, this.parent)
+      };
+    });
   }
 
   /* -------------------------------------------- */

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -119,7 +119,9 @@ export default class UsageMessageData extends ItemMessageData {
   _onRender(element) {
     super._onRender(element);
     if ( this.parent.shouldDisplayChallenge ) element.dataset.displayChallenge = "";
-    this.parent.getAssociatedActivity()?.onRenderChatCard(this.parent, element);
+    const activity = this.parent.getAssociatedActivity();
+    activity?.onRenderChatCard(this.parent, element);
+    activity?._activateLegacyChatListeners(this.parent, element);
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -760,6 +760,7 @@ export default function ActivityMixin(Base) {
         type: messageType
       };
       const buttons = this._usageChatButtons(message);
+      this.#migrateLegacyChatButtons(buttons);
       if ( buttons.length ) foundry.utils.setProperty(data, "system.buttons", buttons);
       const messageConfig = foundry.utils.mergeObject({
         data,
@@ -1232,6 +1233,40 @@ export default function ActivityMixin(Base) {
       return Object.entries(CONFIG.DND5E.activityTypes)
         .filter(([, c]) => (c.configurable !== false) && c.documentClass.availableForItem(parent))
         .map(([k]) => k);
+    }
+
+    /* -------------------------------------------- */
+    /*  Deprecations                                */
+    /* -------------------------------------------- */
+
+    /**
+     * Convert legacy chat buttons from the pre-6.0 shape.
+     * @param {ActivityUsageChatButton[]} buttons  Descriptors from `_usageChatButtons`.
+     * @deprecated
+     * @since 6.0.0
+     */
+    #migrateLegacyChatButtons(buttons) {
+      const legacy = buttons.filter(b => !b.action || (typeof b.label === "string") || b.icon?.startsWith("<"));
+      if ( !legacy.length ) return;
+      foundry.utils.logCompatibilityWarning(
+        `The "${this.type}" activity supplies chat buttons in a legacy format. Buttons must now define an "action", `
+        + 'a "label" object, and an "icon" given as FontAwesome classes or an image path.',
+        { since: "DnD5e 6.0", until: "DnD5e 6.2", once: true }
+      );
+      for ( const button of legacy ) {
+        button.action ??= button.dataset?.action;
+        if ( typeof button.label === "string" ) {
+          const label = foundry.utils.parseHTML(`<div>${button.label}</div>`);
+          const dc = label.querySelector(".visible-dc");
+          button.label = dc
+            ? { hidden: label.querySelector(".hidden-dc")?.textContent.trim(), value: dc.textContent.trim() }
+            : { value: button.label };
+        }
+        if ( button.icon?.startsWith("<") ) {
+          const icon = foundry.utils.parseHTML(button.icon);
+          button.icon = icon?.dataset?.src ?? icon?.getAttribute?.("src") ?? icon?.className ?? "";
+        }
+      }
     }
   }
   return Activity;

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1240,6 +1240,37 @@ export default function ActivityMixin(Base) {
     /* -------------------------------------------- */
 
     /**
+     * Legacy activateChatListeners stub so that super calls do not throw.
+     * @param {ChatMessage5e} message  Associated chat message.
+     * @param {HTMLElement} html       Element in the chat log.
+     * @deprecated
+     * @since 6.0.0
+     */
+    activateChatListeners(message, html) {}
+
+    /* -------------------------------------------- */
+
+    /**
+     * Invoke a legacy activateChatListeners override if this activity still defines one.
+     * @param {ChatMessage5e} message  Associated chat message.
+     * @param {HTMLElement} html       Element in the chat log.
+     * @internal
+     * @deprecated
+     * @since 6.0.0
+     */
+    _activateLegacyChatListeners(message, html) {
+      if ( foundry.utils.getDefiningClass(this, "activateChatListeners") === Activity ) return;
+      foundry.utils.logCompatibilityWarning(
+        `The "${this.type}" activity defines "activateChatListeners". Register chat card actions through the `
+        + '"usage.actions" metadata or "_onChatAction" instead.',
+        { since: "DnD5e 6.0", until: "DnD5e 6.2", once: true }
+      );
+      this.activateChatListeners(message, html);
+    }
+
+    /* -------------------------------------------- */
+
+    /**
      * Convert legacy chat buttons from the pre-6.0 shape.
      * @param {ActivityUsageChatButton[]} buttons  Descriptors from `_usageChatButtons`.
      * @deprecated

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -4,7 +4,8 @@ import TemplatePlacement from "../../canvas/template-placement.mjs";
 import { ConsumptionError } from "../../data/activity/fields/consumption-targets-field.mjs";
 import { ActorDeltasField } from "../../data/chat-message/fields/deltas-field.mjs";
 import TargetsField from "../../data/chat-message/fields/targets-field.mjs";
-import { formatNumber, getSceneTargets, localizeSchema } from "../../utils.mjs";
+import PropertyField from "../../data/shared/property-field.mjs";
+import { formatNumber, generateIcon, getSceneTargets, localizeSchema } from "../../utils.mjs";
 import AppliedRules from "../applied-rules.mjs";
 import DependentDocumentMixin from "../mixins/dependent.mjs";
 import PseudoDocumentMixin from "../mixins/pseudo-document.mjs";
@@ -762,6 +763,8 @@ export default function ActivityMixin(Base) {
       const buttons = this._usageChatButtons(message);
       this.#migrateLegacyChatButtons(buttons);
       if ( buttons.length ) foundry.utils.setProperty(data, "system.buttons", buttons);
+      const legacyContent = await this.#legacyUsageContent(message);
+      if ( legacyContent ) data.content = legacyContent;
       const messageConfig = foundry.utils.mergeObject({
         data,
         rollMode: CONFIG.Dice.BasicRoll.getMessageMode()
@@ -1240,23 +1243,18 @@ export default function ActivityMixin(Base) {
     /* -------------------------------------------- */
 
     /**
-     * Legacy activateChatListeners stub so that super calls do not throw.
-     * @param {ChatMessage5e} message  Associated chat message.
-     * @param {HTMLElement} html       Element in the chat log.
      * @deprecated
      * @since 6.0.0
+     * @ignore
      */
     activateChatListeners(message, html) {}
 
     /* -------------------------------------------- */
 
     /**
-     * Invoke a legacy activateChatListeners override if this activity still defines one.
-     * @param {ChatMessage5e} message  Associated chat message.
-     * @param {HTMLElement} html       Element in the chat log.
-     * @internal
      * @deprecated
      * @since 6.0.0
+     * @ignore
      */
     _activateLegacyChatListeners(message, html) {
       if ( foundry.utils.getDefiningClass(this, "activateChatListeners") === Activity ) return;
@@ -1271,10 +1269,54 @@ export default function ActivityMixin(Base) {
     /* -------------------------------------------- */
 
     /**
-     * Convert legacy chat buttons from the pre-6.0 shape.
-     * @param {ActivityUsageChatButton[]} buttons  Descriptors from `_usageChatButtons`.
      * @deprecated
      * @since 6.0.0
+     * @ignore
+     */
+    async _usageChatContext(message) {
+      const data = await this.item.system.getCardData({ activity: this });
+      const properties = PropertyField.getLabels(data.properties, { ...data, properties: data.item.properties });
+      const supplements = [];
+      if ( this.activation.condition ) {
+        supplements.push(`<strong>${_loc("DND5E.Trigger")}</strong> ${this.activation.condition}`);
+      }
+      if ( data.materials ) {
+        supplements.push(`<strong>${_loc("DND5E.Materials")}</strong> ${data.materials}`);
+      }
+      const buttons = this._usageChatButtons(message);
+      this.#migrateLegacyChatButtons(buttons);
+      const legacy = buttons.map(button => {
+        const label = _loc(button.label?.value ?? "");
+        return {
+          ...button,
+          dataset: { ...button.dataset, action: button.action },
+          icon: generateIcon(button.icon)?.outerHTML ?? "",
+          label: button.label?.hidden
+            ? `<span class="visible-dc">${label}</span><span class="hidden-dc">${_loc(button.label.hidden)}</span>`
+            : label
+        };
+      });
+
+      return {
+        activity: this,
+        actor: this.item.actor,
+        item: this.item,
+        token: this.item.actor?.token,
+        buttons: legacy.length ? legacy : null,
+        concealed: data.concealed,
+        description: data.description,
+        properties: properties.length ? properties : null,
+        subtitle: this.description.chatFlavor || data.subtitle.filterJoin(" • "),
+        supplements
+      };
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * @deprecated
+     * @since 6.0.0
+     * @ignore
      */
     #migrateLegacyChatButtons(buttons) {
       const legacy = buttons.filter(b => !b.action || (typeof b.label === "string") || b.icon?.startsWith("<"));
@@ -1298,6 +1340,27 @@ export default function ActivityMixin(Base) {
           button.icon = icon?.dataset?.src ?? icon?.getAttribute?.("src") ?? icon?.className ?? "";
         }
       }
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * @deprecated
+     * @since 6.0.0
+     * @ignore
+     */
+    async #legacyUsageContent(message) {
+      const { chatCard } = this.metadata.usage;
+      if ( !chatCard
+        && (foundry.utils.getDefiningClass(this, "_usageChatContext") === Activity) ) return;
+      foundry.utils.logCompatibilityWarning(
+        `The "${this.type}" activity supplies a legacy usage card. "usage.chatCard" and "_usageChatContext" are `
+        + 'deprecated. Set "message.data.content" in "_createUsageMessage" to keep custom card content.',
+        { since: "DnD5e 6.0", until: "DnD5e 6.2", once: true }
+      );
+      return foundry.applications.handlebars.renderTemplate(
+        chatCard ?? "systems/dnd5e/templates/chat/activity-card.hbs", await this._usageChatContext(message)
+      );
     }
   }
   return Activity;

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -536,12 +536,14 @@ export default class ChatMessage5e extends ChatMessage {
    * @returns {Activity|void}
    */
   getAssociatedActivity({ scaled=false }={}) {
-    const activity = fromUuidSync(this.system.activity?.uuid, { strict: false });
+    const uuid = this.system.activity?.uuid ?? this.getFlag("dnd5e", "activity.uuid");
+    const activity = fromUuidSync(uuid, { strict: false });
     if ( activity ) {
       const scaling = scaled ? this.system.scaling : null;
       return scaling ? activity.item.scaledClone(scaling).system.activities.get(activity.id) : activity;
     }
-    return this.getAssociatedItem({ scaled })?.system.activities?.get(this.system.activity?.id);
+    const id = this.system.activity?.id ?? this.getFlag("dnd5e", "activity.id");
+    return this.getAssociatedItem({ scaled })?.system.activities?.get(id);
   }
 
   /* -------------------------------------------- */
@@ -563,7 +565,8 @@ export default class ChatMessage5e extends ChatMessage {
    * @returns {Item5e|void}
    */
   getAssociatedItem({ scaled=false }={}) {
-    const item = fromUuidSync(this.system.item?.uuid, { strict: false });
+    const uuid = this.system.item?.uuid ?? this.getFlag("dnd5e", "item.uuid");
+    const item = fromUuidSync(uuid, { strict: false });
     const scaling = scaled ? this.system.scaling : null;
     if ( item ) return scaling ? item.scaledClone(scaling) : item;
     const actor = this.getAssociatedActor();
@@ -579,8 +582,8 @@ export default class ChatMessage5e extends ChatMessage {
    * @returns {object|void}
    */
   #getStoredItemData() {
-    const id = this.system.item?.id;
-    return this.system.deltas?.deleted?.find(i => i._id === id);
+    const id = this.system.item?.id ?? this.getFlag("dnd5e", "item.id");
+    return this.system.deltas?.deleted?.find(i => i._id === id) ?? this.getFlag("dnd5e", "item.data");
   }
 
   /* -------------------------------------------- */
@@ -613,6 +616,6 @@ export default class ChatMessage5e extends ChatMessage {
    * @type {ChatMessage5e}
    */
   getOriginatingMessage() {
-    return this.system.origin ?? this;
+    return this.system.origin ?? game.messages.get(this.getFlag("dnd5e", "originatingMessage")) ?? this;
   }
 }

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -761,16 +761,16 @@ export function loadingTooltip({ uuid, passive=false }={}) {
 /**
  * Grab the targeted tokens and return relevant information on them.
  * @param {Iterable<Token5e|TokenDocument5e>} [tokens]  Tokens to describe. Defaults to the user's current targets.
- * @returns {TargetDescriptor5e[]}
+ * @returns {(TargetDescriptor5e & { uuid: string })[]}
  * @deprecated
- * @since 6.0
+ * @since 6.0.0
  */
 export function getTargetDescriptors(tokens=game.user.targets) {
   foundry.utils.logCompatibilityWarning(
     "The getTargetDescriptors helper has been deprecated. Please use `TargetsField.getDescriptors` instead.",
     { since: "DnD5e 6.0", until: "DnD5e 6.2" }
   );
-  return TargetsField.getDescriptors(tokens);
+  return TargetsField.getDescriptors(tokens).map(t => ({ ...t, uuid: t.actor }));
 }
 
 /* -------------------------------------------- */

--- a/templates/chat/activity-card.hbs
+++ b/templates/chat/activity-card.hbs
@@ -1,0 +1,46 @@
+{{!-- Deprecated since DnD5e 6.0, removed in 6.2. --}}
+<div class="chat-card activation-card">
+    <section class="card-header description {{~#if description}} collapsible{{/if}}"
+             {{~#if concealed}} data-concealed{{/if}}>
+        <header class="summary">
+            <img class="gold-icon" src="{{ item.img }}" alt="{{ item.name }}">
+            <div class="name-stacked border">
+                <span class="title">{{ item.name }}</span>
+                {{#if subtitle}}
+                <span class="subtitle">{{{ subtitle }}}</span>
+                {{/if}}
+            </div>
+            {{#if description}}<i class="fa-solid fa-chevron-down fa-fw" inert></i>{{/if}}
+        </header>
+        {{#if description}}
+        <section class="details collapsible-content card-content">
+            <div class="wrapper">{{{ description }}}</div>
+        </section>
+        {{/if}}
+    </section>
+
+    {{#if buttons}}
+    <div class="card-buttons">
+        {{#each buttons}}
+        <button type="button" {{ dnd5e-dataset dataset }}
+                {{~#if visibility}} data-visibility="{{ visibility }}"{{/if}}>
+            {{{ icon }}} <span>{{{ label }}}</span>
+        </button>
+        {{/each}}
+    </div>
+    {{/if}}
+
+    {{#each supplements}}
+    <p class="supplement">{{{ this }}}</p>
+    {{/each}}
+
+    {{#if properties}}
+    <ul class="card-footer pills unlist">
+        {{#each properties}}
+        <li class="pill transparent">
+            <span class="label">{{ this }}</span>
+        </li>
+        {{/each}}
+    </ul>
+    {{/if}}
+</div>


### PR DESCRIPTION
I've added shims for a selection of things that should be relatively low cost to maintain until 6.2. I might still end up having to remove them if the chat card redesign is hindered by them.

- Restored `flags.dnd5e.item.*` and `flags.dnd5e.activity.*` lookups.
- Fixed `getTargetDescriptors` not returning legacy properties.
- Add `action` back into dataset when preparing buttons.
- Prevent legacy properties causing chat messages to fail to validate (they will not show the pills still though).
- Add shim for legacy format returns from `_usageChatButtons`.
- Add `activateChatListeners` shim.
- Add shim for `metadata.usage.chatCard` and `_usageChatContext`.