### PR TITLE
CSS cleanup

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -477,6 +477,14 @@ Hooks.once("setup", function() {
     }
   `;
   document.head.append(style);
+
+  // Measure the space a scrollbar takes up so that sheets can center theirs within their padding.
+  const probe = document.createElement("div");
+  probe.style.cssText = "position: absolute; visibility: hidden; overflow-y: auto; scrollbar-gutter: stable; "
+    + "scrollbar-width: thin; inline-size: 100px; block-size: 100px";
+  document.body.append(probe);
+  document.documentElement.style.setProperty("--dnd5e-scrollbar-width", `${probe.offsetWidth - probe.clientWidth}px`);
+  probe.remove();
 });
 
 /* --------------------------------------------- */

--- a/lang/en.json
+++ b/lang/en.json
@@ -6858,10 +6858,6 @@
     "Hint": "Enable optional Piety tracking for player characters.",
     "Name": "Piety Score"
   },
-  "THEME": {
-    "Name": "Theme",
-    "Hint": "Theme that will apply to the UI and all sheets by default. Automatic will be determined by your browser or operating system settings."
-  },
   "PERMISSIONS": {
     "AllowRests": {
       "Hint": "Allow players to rest directly from their characters' sheets. When disabled, players will only be able to rest when the GM makes a request from the party.",
@@ -6952,15 +6948,6 @@
       "Hint": "Hide the descriptions of NPC items from players when posted to chat by the DM. Will only hide the descriptions for items without a Chat Description set.",
       "Name": "Conceal NPC Descriptions"
     }
-  }
-},
-
-"SHEETS.DND5E": {
-  "THEME": {
-    "Label": "Theme",
-    "Automatic": "Automatic",
-    "Dark": "Dark Mode",
-    "Light": "Light Mode"
   }
 },
 

--- a/less/v2/actors.less
+++ b/less/v2/actors.less
@@ -524,19 +524,8 @@
     padding: .375rem;
     width: 100%;
     height: 60px;
-    scrollbar-width: thin;
-    scrollbar-color: var(--dnd5e-color-scrollbar) transparent;
     background: var(--dnd5e-background-5);
-
-    &::-webkit-scrollbar-track {
-      box-shadow: none;
-      border-radius: 0;
-    }
-
-    &::-webkit-scrollbar-thumb {
-      border: none;
-      background: var(--dnd5e-color-scrollbar);
-    }
+    .scrollbar();
   }
 
   .tab[data-tab=biography] code-mirror .cm-scroller {

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -894,14 +894,7 @@
   /* ---------------------------------- */
 
   &.sidebar-info {
-    --sidebar-info-link-color: #ff6400;
-
-    h4 { color: var(--color-light-1); }
-
-    .themed.theme-light & {
-      --sidebar-info-link-color: var(--dnd5e-color-maroon);
-      h4 { color: var(--color-dark-1); }
-    }
+    h4 { color: var(--sidebar-info-heading-color); }
 
     ul.links {
       flex: 1;

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -1,4 +1,22 @@
 /* ---------------------------------- */
+/*  Scrollbars                        */
+/* ---------------------------------- */
+
+.scrollbar(@color: var(--dnd5e-color-scrollbar)) {
+  scrollbar-width: thin;
+  scrollbar-color: @color transparent;
+}
+
+.scroll-gutter(@gap) {
+  --dnd5e-scroll-inset: max(0px, calc((@gap - var(--dnd5e-scrollbar-width)) / 2));
+  --dnd5e-scroll-margin: min(var(--dnd5e-scrollbar-width), var(--dnd5e-scroll-inset));
+  --dnd5e-scroll-pad: calc(var(--dnd5e-scroll-inset) * 2 - var(--dnd5e-scroll-margin));
+  scrollbar-gutter: stable;
+  margin-inline-end: var(--dnd5e-scroll-margin);
+  padding-inline-end: var(--dnd5e-scroll-pad);
+}
+
+/* ---------------------------------- */
 /*  All DnD5e Apps                    */
 /* ---------------------------------- */
 
@@ -962,35 +980,11 @@
     .editor-content {
       font-family: var(--dnd5e-font-roboto-condensed);
       font-size: var(--font-size-13);
-      scrollbar-width: thin;
-      scrollbar-color: var(--dnd5e-color-scrollbar) transparent;
-
-      &::-webkit-scrollbar-track {
-        box-shadow: none;
-        border-radius: 0;
-      }
-
-      &::-webkit-scrollbar-thumb {
-        border: none;
-        background: var(--dnd5e-color-scrollbar);
-      }
+      .scrollbar();
     }
 
     code-mirror {
-      .cm-scroller {
-        scrollbar-width: thin;
-        scrollbar-color: var(--dnd5e-color-scrollbar) transparent;
-
-        &::-webkit-scrollbar-track {
-          box-shadow: none;
-          border-radius: 0;
-        }
-
-        &::-webkit-scrollbar-thumb {
-          border: none;
-          background: var(--dnd5e-color-scrollbar);
-        }
-      }
+      .cm-scroller { .scrollbar(); }
     }
 
     &[placeholder] {

--- a/less/v2/character.less
+++ b/less/v2/character.less
@@ -236,22 +236,10 @@
       position: absolute;
       inset: 0;
       padding: 8px;
-      padding-inline-end: 0;
       overflow: hidden auto;
-      scrollbar-width: thin;
-      scrollbar-gutter: stable;
-      scrollbar-color: var(--dnd5e-color-scrollbar) transparent;
       transition: all 450ms ease;
-
-      &::-webkit-scrollbar-track {
-        box-shadow: none;
-        border-radius: 0;
-      }
-
-      &::-webkit-scrollbar-thumb {
-        border: none;
-        background: var(--dnd5e-color-scrollbar);
-      }
+      .scrollbar();
+      .scroll-gutter(8px);
     }
 
     /* Sidebar */
@@ -696,8 +684,6 @@
           align-items: start;
         }
       }
-
-      .tab:not([data-tab="details"]) { padding-inline: .5rem; }
 
       .tab:not([data-tab="details"], [data-tab="biography"], [data-tab="bastion"], [data-tab="specialTraits"]) {
         // enough room that the "create new" button doesn't overlap when scrolled all the way down

--- a/less/v2/compendium-browser.less
+++ b/less/v2/compendium-browser.less
@@ -76,9 +76,9 @@
     height: 100%;
     overflow-y: auto;
     gap: 12px;
-    padding: 6px 4px 3px 12px;
+    padding: 6px 0 3px 12px;
     font-family: var(--dnd5e-font-roboto-condensed);
-    scrollbar-gutter: stable;
+    .scroll-gutter(12px);
 
     [data-application-part="types"] {
       display: flex;
@@ -217,10 +217,9 @@
 
   .results {
     --results-padding: 6px;
-    padding: var(--results-padding) 4px 12px 4px;
-    margin-right: 4px;
+    padding: var(--results-padding) 0 12px 0;
     overflow-y: auto;
-    scrollbar-gutter: stable;
+    .scroll-gutter(12px);
 
     > .note { margin-inline: 4px; }
 
@@ -295,9 +294,9 @@
 
   /* Sidebar */
   .sidebar {
-    scrollbar-gutter: stable;
-    padding: 6px 4px 0 12px;
+    padding: 6px 0 0 12px;
     overflow: hidden auto;
+    .scroll-gutter(12px);
 
     search { margin-bottom: 16px; }
   }
@@ -354,9 +353,9 @@
   /* Packs */
   .packs {
     display: flex;
-    scrollbar-gutter: stable;
-    padding: 6px 8px 0 4px;
+    padding: 6px 0 0 4px;
     overflow: hidden auto;
+    .scroll-gutter(12px);
     gap: 12px;
     align-items: start;
 

--- a/less/v2/encounter.less
+++ b/less/v2/encounter.less
@@ -107,9 +107,8 @@
   .tab {
     max-height: ~"calc(min(max(70vh, 1000px), 95vh) - var(--dnd5e-sheet-header-height))";
     overflow: hidden auto;
-    scrollbar-gutter: stable;
-    padding: 16px 4px 8px 16px;
-    margin-right: 4px;
+    padding: 16px 0 8px 16px;
+    .scroll-gutter(16px);
   }
 
   /* -------------------------------------------- */
@@ -248,9 +247,7 @@
   /* -------------------------------------------- */
 
   .tab[data-tab=inventory] {
-    padding: 8px 4px calc(1.5rem + 30px) 16px;
-    margin-right: 4px;
-    scrollbar-gutter: stable;
+    padding: 8px var(--dnd5e-scroll-pad) calc(1.5rem + 30px) 16px;
     overflow-y: auto;
   }
 

--- a/less/v2/group.less
+++ b/less/v2/group.less
@@ -50,7 +50,7 @@
       position: absolute;
       inset: 0;
       overflow: hidden auto;
-      scrollbar-gutter: stable;
+      .scroll-gutter(16px);
     }
   }
 
@@ -210,7 +210,7 @@
   .sheet-body .tab-body [data-application-part=members] {
     overflow: hidden auto;
     scrollbar-gutter: stable;
-    inset: 0 4px 0 0;
+    inset: 0;
     gap: 0;
 
     h3 { padding-left: 12px; }
@@ -221,7 +221,7 @@
     display: flex;
     flex-direction: column;
     gap: 12px;
-    padding: 16px 4px 16px 16px;
+    padding: 16px 0 16px 16px;
 
     &.stats {
       .member {
@@ -364,16 +364,19 @@
   /*  Inventory                         */
   /* ---------------------------------- */
 
-  [data-application-part=inventory] {
+  .tab[data-application-part=inventory] {
     gap: 0;
     grid-template-columns: 196px auto;
+    scrollbar-gutter: auto;
+    margin-inline-end: 0;
+    padding-inline-end: 0;
 
     &.active { display: grid; }
 
     .sidebar {
-      padding: 6px 4px 0 12px;
-      scrollbar-gutter: stable;
+      padding: 6px 0 0 12px;
       overflow-y: auto;
+      .scroll-gutter(12px);
       display: flex;
       flex-direction: column;
       gap: 8px;
@@ -436,10 +439,9 @@
     }
 
     .body {
-      padding: 6px 4px calc(1.5rem + 30px) 4px;
-      margin-right: 4px;
-      scrollbar-gutter: stable;
+      padding: 6px 0 calc(1.5rem + 30px) 4px;
       overflow-y: auto;
+      .scroll-gutter(12px);
       display: flex;
       flex-direction: column;
 

--- a/less/v2/high-contrast/apps.less
+++ b/less/v2/high-contrast/apps.less
@@ -25,9 +25,6 @@
 
 .dnd5e-flag-high-contrast item-list-controls search {
   border: var(--dnd5e-border-dark);
-  .filter-list{
-    & > li:hover button { font-weight: bold; }
-  }
 }
 
 .dnd5e-flag-high-contrast .effects-element {
@@ -42,47 +39,44 @@
 /*  Light Mode                        */
 /* ---------------------------------- */
 
-.dnd5e-flag-high-contrast:is(.dnd5e-theme-light, .theme-light) .dnd5e2,
-.dnd5e2.dnd5e-flag-high-contrast.dnd5e-theme-light {
-  &.sheet {
-    --filigree-background-color: #ffffff;
-    --filigree-border-color: var(--dnd5e-color-dark);
-    --dnd5e-background-card: #ffffff;
-    --dnd5e-background-parchment: #ffffff;
-    --dnd5e-border-dark: 1px solid #000;
-    --proficiency-cycle-enabled-color: color-mix(in oklab, var(--dnd5e-color-blue), black 20%);
-    --proficiency-cycle-disabled-color: var(--dnd5e-color-dark);
+@scope (.dnd5e-flag-high-contrast.theme-light, .dnd5e-flag-high-contrast .theme-light) to (.themed) {
+  .dnd5e2, :where(:scope).dnd5e2 {
+    &.sheet {
+      --filigree-background-color: #ffffff;
+      --filigree-border-color: var(--dnd5e-color-dark);
+      --dnd5e-background-card: #ffffff;
+      --dnd5e-background-parchment: #ffffff;
+      --dnd5e-border-dark: 1px solid #000;
+      --proficiency-cycle-enabled-color: color-mix(in oklab, var(--dnd5e-color-blue), black 20%);
+      --proficiency-cycle-disabled-color: var(--dnd5e-color-dark);
+    }
   }
-}
-
-.dnd5e-flag-high-contrast.dnd5e-theme-light item-list-controls search {
-  .filter-list .filter-item.active::after { color: var(--color-text-dark-3); }
-  .dropdown:focus-within .filter { color: var(--dnd5e-color-dark); }
 }
 
 /* ---------------------------------- */
 /*  Dark Mode                         */
 /* ---------------------------------- */
 
-.dnd5e-flag-high-contrast:is(.dnd5e-theme-dark, .theme-dark) .dnd5e2,
-.dnd5e2.dnd5e-flag-high-contrast.dnd5e-theme-dark {
-  &.sheet {
-    --color-text-dark-primary: #fff;
-    --color-text-dark-secondary: var(--color-text-light-3);
-    --dnd5e-background-card: #000000;
-    --dnd5e-background-parchment: #000000;
-    --dnd5e-border-dark: 1px solid #999;
-    --dnd5e-color-blue-white: #fff;
-    --dnd5e-color-card: #fff;
-    --filigree-background-color: #000000;
-    --filigree-border-color: #999;
-    --proficiency-cycle-enabled-color: unset;
-    --proficiency-cycle-disabled-color: unset;
+@scope (.dnd5e-flag-high-contrast.theme-dark, .dnd5e-flag-high-contrast .theme-dark) to (.themed) {
+  .dnd5e2, :where(:scope).dnd5e2 {
+    &.sheet {
+      --color-text-dark-primary: #fff;
+      --color-text-dark-secondary: var(--color-text-light-3);
+      --dnd5e-background-card: #000000;
+      --dnd5e-background-parchment: #000000;
+      --dnd5e-border-dark: 1px solid #999;
+      --dnd5e-color-blue-white: #fff;
+      --dnd5e-color-card: #fff;
+      --filigree-background-color: #000000;
+      --filigree-border-color: #999;
+      --proficiency-cycle-enabled-color: unset;
+      --proficiency-cycle-disabled-color: unset;
+    }
+
+    .card { border: var(--dnd5e-border-dark); }
   }
 
-  .card { border: var(--dnd5e-border-dark); }
-}
-
-.dnd5e-flag-high-contrast:is(.dnd5e-theme-dark, .theme-dark) item-list-controls search {
-  .filter-control:not(.active) { color: var(--color-text-light-6); }
+  item-list-controls search {
+    .filter-control:not(.active) { color: var(--color-text-light-6); }
+  }
 }

--- a/less/v2/high-contrast/apps.less
+++ b/less/v2/high-contrast/apps.less
@@ -1,12 +1,11 @@
 .dnd5e-flag-high-contrast .dnd5e2,
 .dnd5e2.dnd5e-flag-high-contrast {
   &.sheet {
-    --color-text-dark-primary: #000000;
     --dnd5e-color-gold: #e3ce9e;
     --dnd5e-color-scrollbar: var(--dnd5e-color-maroon);
   }
 
-  .card { border-color: var(--dnd5e-color-dark); }
+  .card { border: var(--dnd5e-border-dark); }
 
   .pill-lg {
     border-color: var(--dnd5e-color-dark);
@@ -42,6 +41,7 @@
 @scope (.dnd5e-flag-high-contrast.theme-light, .dnd5e-flag-high-contrast .theme-light) to (.themed) {
   .dnd5e2, :where(:scope).dnd5e2 {
     &.sheet {
+      --color-text-dark-primary: #000000;
       --filigree-background-color: #ffffff;
       --filigree-border-color: var(--dnd5e-color-dark);
       --dnd5e-background-card: #ffffff;
@@ -72,8 +72,6 @@
       --proficiency-cycle-enabled-color: unset;
       --proficiency-cycle-disabled-color: unset;
     }
-
-    .card { border: var(--dnd5e-border-dark); }
   }
 
   item-list-controls search {

--- a/less/v2/high-contrast/character.less
+++ b/less/v2/high-contrast/character.less
@@ -38,24 +38,26 @@
 /*  Light Mode                        */
 /* ---------------------------------- */
 
-.dnd5e-flag-high-contrast:is(.dnd5e-theme-light, .theme-dark) .dnd5e2.sheet.actor.character,
-.dnd5e2.sheet.actor.character.dnd5e-flag-high-contrast.dnd5e-theme-light {
-  .sheet-header { background: var(--dnd5e-color-maroon); }
-  .sidebar .favorites > h3 { color: var(--dnd5e-color-dark); }
-  .tab.features .classes .class .level > span { color: var(--dnd5e-color-dark); }
+@scope (.dnd5e-flag-high-contrast.theme-light, .dnd5e-flag-high-contrast .theme-light) to (.themed) {
+  .dnd5e2.sheet.actor.character, :where(:scope).dnd5e2.sheet.actor.character {
+    .sheet-header { background: var(--dnd5e-color-maroon); }
+    .sidebar .favorites > h3 { color: var(--dnd5e-color-dark); }
+    .tab.features .classes .class .level > span { color: var(--dnd5e-color-dark); }
+  }
 }
 
 /* ---------------------------------- */
 /*  Dark Mode                         */
 /* ---------------------------------- */
 
-.dnd5e-flag-high-contrast:is(.dnd5e-theme-dark, .theme-dark) .dnd5e2.sheet.actor.character,
-.dnd5e2.sheet.actor.character.dnd5e-flag-high-contrast.dnd5e-theme-dark {
-  .sheet-header { background: none; }
-  .sidebar .favorites > h3 { color: var(--dnd5e-color-light); }
-  .tab.features .classes .class .level > span { color: var(--dnd5e-color-light); }
-  .ability-scores .ability-score {
-    &::before { filter: invert(100%); }
-    .label { color: var(--color-text-light-1); }
+@scope (.dnd5e-flag-high-contrast.theme-dark, .dnd5e-flag-high-contrast .theme-dark) to (.themed) {
+  .dnd5e2.sheet.actor.character, :where(:scope).dnd5e2.sheet.actor.character {
+    .sheet-header { background: none; }
+    .sidebar .favorites > h3 { color: var(--dnd5e-color-light); }
+    .tab.features .classes .class .level > span { color: var(--dnd5e-color-light); }
+    .ability-scores .ability-score {
+      &::before { filter: invert(100%); }
+      .label { color: var(--color-text-light-1); }
+    }
   }
 }

--- a/less/v2/high-contrast/character.less
+++ b/less/v2/high-contrast/character.less
@@ -29,7 +29,6 @@
 
   .ability-scores .ability-score {
     &::before { background: transparent url("ui/ability-score-tab-hc.svg") no-repeat top center / contain; }
-    .label { color: var(--dnd5e-color-dark); }
     .score { color: var(--color-text-light-1); }
   }
 }
@@ -43,6 +42,7 @@
     .sheet-header { background: var(--dnd5e-color-maroon); }
     .sidebar .favorites > h3 { color: var(--dnd5e-color-dark); }
     .tab.features .classes .class .level > span { color: var(--dnd5e-color-dark); }
+    .ability-scores .ability-score .label { color: var(--dnd5e-color-dark); }
   }
 }
 

--- a/less/v2/high-contrast/inventory.less
+++ b/less/v2/high-contrast/inventory.less
@@ -16,9 +16,7 @@
 @scope (.dnd5e-flag-high-contrast.theme-light, .dnd5e-flag-high-contrast .theme-light) to (.themed) {
   .dnd5e2, :where(:scope).dnd5e2 {
     .inventory-element {
-      .encumbrance .meter { border-color: var(--dnd5e-color-dark); }
       .middle .attunement {
-        border-color: var(--dnd5e-color-dark);
         .fa-sun, .separator { color: var(--dnd5e-color-dark); }
       }
     }

--- a/less/v2/high-contrast/inventory.less
+++ b/less/v2/high-contrast/inventory.less
@@ -13,19 +13,20 @@
 /*  Light Mode                        */
 /* ---------------------------------- */
 
-.dnd5e-flag-high-contrast:is(.dnd5e-theme-light, .theme-light) .dnd5e2,
-.dnd5e2.dnd5e-flag-high-contrast.dnd5e-theme-light {
-  .inventory-element {
-    .encumbrance .meter { border-color: var(--dnd5e-color-dark); }
-    .middle .attunement {
-      border-color: var(--dnd5e-color-dark);
-      .fa-sun, .separator { color: var(--dnd5e-color-dark); }
+@scope (.dnd5e-flag-high-contrast.theme-light, .dnd5e-flag-high-contrast .theme-light) to (.themed) {
+  .dnd5e2, :where(:scope).dnd5e2 {
+    .inventory-element {
+      .encumbrance .meter { border-color: var(--dnd5e-color-dark); }
+      .middle .attunement {
+        border-color: var(--dnd5e-color-dark);
+        .fa-sun, .separator { color: var(--dnd5e-color-dark); }
+      }
     }
-  }
-  .items-section {
-    :is(.items-header, .item) .item-name .tags { opacity: .5; }
-    .item-school { --icon-fill: var(--dnd5e-color-black); }
-    .item-roll .ability { color: var(--color-text-dark-4); }
+    .items-section {
+      :is(.items-header, .item) .item-name .tags { opacity: .5; }
+      .item-school { --icon-fill: var(--dnd5e-color-black); }
+      .item-roll .ability { color: var(--color-text-dark-4); }
+    }
   }
 }
 
@@ -33,19 +34,20 @@
 /*  Dark Mode                         */
 /* ---------------------------------- */
 
-.dnd5e-flag-high-contrast:is(.dnd5e-theme-dark, .theme-dark) .dnd5e2,
-.dnd5e2.dnd5e-flag-high-contrast.dnd5e-theme-dark {
-  .inventory-element {
-    .middle .attunement {
-      .fa-sun, .separator { color: var(--dnd5e-color-light); }
+@scope (.dnd5e-flag-high-contrast.theme-dark, .dnd5e-flag-high-contrast .theme-dark) to (.themed) {
+  .dnd5e2, :where(:scope).dnd5e2 {
+    .inventory-element {
+      .middle .attunement {
+        .fa-sun, .separator { color: var(--dnd5e-color-light); }
+      }
     }
-  }
-  .items-section {
-    :is(.items-header, .item) .item-name .tags { opacity: 1; }
-    .item-school { --icon-fill: var(--dnd5e-color-blue-white); }
-    .item-roll .ability { color: var(--color-text-light-4); }
-    .item .item-controls .item-control:not(.active) {
-      color: var(--color-text-light-6);
+    .items-section {
+      :is(.items-header, .item) .item-name .tags { opacity: 1; }
+      .item-school { --icon-fill: var(--dnd5e-color-blue-white); }
+      .item-roll .ability { color: var(--color-text-light-4); }
+      .item .item-controls .item-control:not(.active) {
+        color: var(--color-text-light-6);
+      }
     }
   }
 }

--- a/less/v2/items.less
+++ b/less/v2/items.less
@@ -226,14 +226,14 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    margin: -6px -11px -6px -6px;
-    padding: 6px 2px 6px 6px;
-    scrollbar-width: thin;
-    scrollbar-color: var(--dnd5e-color-scrollbar) transparent;
-    scrollbar-gutter: stable;
+    margin: -6px 0 -6px -6px;
+    padding: 6px 0 6px 6px;
+    .scrollbar();
+    .scroll-gutter(12px);
+    margin-inline-end: calc(-1 * (var(--dnd5e-scroll-pad) + var(--dnd5e-scrollbar-width)));
 
     &:not(.active) { display: none; }
-    &.effects, &.activities { padding: 12px 2px 58px 6px; }
+    &.effects, &.activities { padding: 12px var(--dnd5e-scroll-pad) 58px 6px; }
 
     > .pills .pill {
       font-size: var(--font-size-10);

--- a/less/v2/journal.less
+++ b/less/v2/journal.less
@@ -20,18 +20,7 @@
   }
 
   &.journal-entry .scrollable, &.journal-entry-page.editor-content, .toc {
-    scrollbar-width: thin;
-    scrollbar-color: var(--dnd5e-color-gold) transparent;
-
-    &::-webkit-scrollbar-track {
-      box-shadow: none;
-      border-radius: 0;
-    }
-
-    &::-webkit-scrollbar-thumb {
-      border: none;
-      background: var(--dnd5e-color-gold);
-    }
+    .scrollbar(var(--dnd5e-color-gold));
   }
 
   &.journal-entry .scrollable { overflow-anchor: none; } /* https://github.com/foundryvtt/dnd5e/issues/6599 */
@@ -80,9 +69,8 @@
     margin: 0;
 
     .editor-content {
-      scrollbar-gutter: stable;
-      margin: 0 4px 0 16px;
-      padding-right: 4px;
+      margin: 0 0 0 16px;
+      .scroll-gutter(16px);
     }
   }
 
@@ -249,8 +237,8 @@
     }
 
     .editor-content {
-      scrollbar-gutter: stable;
-      padding: 0 4px 0 0;
+      padding: 0;
+      .scroll-gutter(12px);
     }
   }
   h1, h2, h3, h4, h5, h6 {
@@ -399,8 +387,8 @@
 
     > .right {
       overflow-y: auto;
-      padding: 16px 4px 16px 8px;
-      scrollbar-gutter: stable;
+      padding: 16px 0 16px 8px;
+      .scroll-gutter(12px);
     }
 
     h3 { margin-block-start: 1rem; }

--- a/less/v2/npc.less
+++ b/less/v2/npc.less
@@ -455,8 +455,8 @@
     flex-direction: column;
     position: relative;
     overflow: hidden auto;
-    scrollbar-gutter: stable;
-    scrollbar-color: var(--dnd5e-color-gold) transparent;
+    .scrollbar(var(--dnd5e-color-gold));
+    .scroll-gutter(8px);
 
     .main-content {
       --sidebar-padding: 8px;
@@ -501,7 +501,7 @@
         .tab {
           flex: 1;
           display: flex;
-          padding: 8px 4px 8px 16px;
+          padding: 8px var(--dnd5e-scroll-pad) 8px 16px;
           gap: 8px;
 
           &[data-tab="spells"], &[data-tab="biography"] { flex-direction: column; }

--- a/less/v2/sheets.less
+++ b/less/v2/sheets.less
@@ -170,9 +170,8 @@ body.detached .dnd5e2.sheet .tab { max-height: unset; }
 
     .editor-container {
       overflow: hidden auto;
-      scrollbar-gutter: stable;
-      margin: 0 4px 0 16px;
-      padding-right: 4px;
+      margin: 0 0 0 16px;
+      .scroll-gutter(16px);
     }
 
     .editor-content {

--- a/less/v2/tooltips.less
+++ b/less/v2/tooltips.less
@@ -138,8 +138,7 @@
       overflow: hidden;
       padding-right: .5rem;
       margin-right: -.5rem;
-      scrollbar-width: thin;
-      scrollbar-color: var(--dnd5e-color-gold) transparent;
+      .scrollbar(var(--dnd5e-color-gold));
 
       table { display: none; }
 

--- a/less/v2/vehicle.less
+++ b/less/v2/vehicle.less
@@ -197,8 +197,8 @@
 
         .tab {
           overflow: hidden auto;
-          scrollbar-gutter: stable;
-          inset: 0 2px 0 0;
+          inset: 0;
+          .scroll-gutter(8px);
           position: absolute;
           flex-direction: column;
 
@@ -212,14 +212,14 @@
 
     /* Inventory */
     .inventory-element {
-      padding: 8px 4px 0;
+      padding: 8px 0 0;
       flex: 1;
 
       .encumbrance .breakpoint { display: none; }
     }
 
     /* Effects */
-    .effects-element { padding: 8px 4px 0; }
+    .effects-element { padding: 8px 0 0; }
 
   }
 
@@ -235,12 +235,12 @@
   /* -------------------------------------------- */
 
   .sheet-stations {
-    padding: 8px 4px 0 8px;
+    padding: 8px 0 0 8px;
     display: flex;
     flex-direction: column;
     gap: 16px;
     overflow: hidden auto;
-    scrollbar-gutter: stable;
+    .scroll-gutter(12px);
 
     /* Abilities */
     .abilities {
@@ -395,7 +395,6 @@
   /* -------------------------------------------- */
 
   .sheet-body .main-content .tab-body .tab.sheet-crew {
-    left: 4px;
     &.active { display: grid; }
   }
 
@@ -488,8 +487,6 @@
   /*  Description                                 */
   /* -------------------------------------------- */
 
-  .sheet-body .main-content .tab-body .tab.sheet-description { left: 4px; }
-
   .sheet-description {
     padding-top: 8px;
 
@@ -498,6 +495,7 @@
         overflow: hidden;
         scrollbar-gutter: auto;
         margin: 0 0 0 8px;
+        padding-inline-end: 0;
       }
 
       .editor-content {

--- a/less/variables/base.less
+++ b/less/variables/base.less
@@ -135,6 +135,10 @@
 
   --dnd5e-statblock-column-width: 400px;
 
+  /* System Badge */
+  --sidebar-info-link-color: #ff6400;
+  --sidebar-info-heading-color: var(--color-light-1);
+
   /* Font Awesome */
   --fa-width: auto;
 }

--- a/less/variables/base.less
+++ b/less/variables/base.less
@@ -92,6 +92,9 @@
   --dnd5e-border-light: 1px solid #CCC;
   --dnd5e-border-groove: 2px groove var(--dnd5e-color-groove);
 
+  /* Space taken up by a scrollbar, measured at setup. Zero in browsers that draw overlay scrollbars. */
+  --dnd5e-scrollbar-width: 0px;
+
   --font-primary: Signika, sans-serif;
   --dnd5e-font-modesto: "Modesto Condensed", "Palatino Linotype", serif;
   --dnd5e-font-roboto: Roboto, sans-serif;

--- a/less/variables/dark.less
+++ b/less/variables/dark.less
@@ -1,4 +1,4 @@
-.mixin-variables-dark {
+.mixin-variables-dark() {
   /* Applications */
   --dnd5e-application-background: var(--dnd5e-background-texture-denim);
   --dnd5e-item-header-content: "";
@@ -236,14 +236,8 @@
   --dnd5e-statblock-title-border: var(--dnd5e-color-blue-gray-3);
 }
 
-@layer general {
-  body.theme-dark .dnd5e2 {
-    .mixin-variables-dark();
-  }
-}
-
-@layer specific {
-  .themed.theme-dark.dnd5e2 {
+@scope (.theme-dark) to (.themed) {
+  .dnd5e2, :where(:scope).dnd5e2 {
     .mixin-variables-dark();
   }
 }

--- a/less/variables/light.less
+++ b/less/variables/light.less
@@ -1,4 +1,4 @@
-.mixin-variables-light {
+.mixin-variables-light() {
   /* Applications */
   --dnd5e-application-background: var(--dnd5e-background-texture-paper-gray);
   --dnd5e-item-header-content: none;
@@ -131,6 +131,10 @@
     --color-revealed-bg: rgb(0 53 0 / 5%);
   }
 
+  /* System Badge */
+  --sidebar-info-link-color: var(--dnd5e-color-maroon);
+  --sidebar-info-heading-color: var(--color-dark-1);
+
   /* Forms */
   --slide-toggle-track-color-unchecked: var(--dnd5e-background-25);
   --slide-toggle-track-color-checked: var(--dnd5e-color-gold);
@@ -228,14 +232,8 @@
   --dnd5e-statblock-title-border: currentcolor;
 }
 
-@layer general {
-  body.theme-light .dnd5e2 {
-    .mixin-variables-light();
-  }
-}
-
-@layer specific {
-  .themed.theme-light.dnd5e2, .themed.theme-light.dnd5e2-journal, .themed.theme-light .dnd5e2.chat-message {
+@scope (.theme-light) to (.themed) {
+  .dnd5e2, :where(:scope).dnd5e2 {
     .mixin-variables-light();
   }
 }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -5009,20 +5009,6 @@ DND5E.sourceBooks = {};
 preLocalize("sourceBooks", { sort: true });
 
 /* -------------------------------------------- */
-/*  Themes                                      */
-/* -------------------------------------------- */
-
-/**
- * Themes that can be set for the system or on sheets.
- * @enum {string}
- */
-DND5E.themes = {
-  light: "SHEETS.DND5E.THEME.Light",
-  dark: "SHEETS.DND5E.THEME.Dark"
-};
-preLocalize("themes");
-
-/* -------------------------------------------- */
 /*  Enrichment                                  */
 /* -------------------------------------------- */
 

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -747,36 +747,8 @@ export function registerDeferredSettings() {
     default: { Actor: game.user.isGM ? "npc" : "character", Item: "feat" }
   });
 
-  game.settings.register("dnd5e", "theme", {
-    name: "SETTINGS.DND5E.THEME.Name",
-    hint: "SETTINGS.DND5E.THEME.Hint",
-    scope: "client",
-    config: false,
-    default: "",
-    type: String,
-    choices: {
-      "": "SHEETS.DND5E.THEME.Automatic",
-      ...CONFIG.DND5E.themes
-    },
-    onChange: s => setTheme(document.body, s)
-  });
-
-  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
-    setTheme(document.body, game.settings.get("dnd5e", "theme"));
-  });
-  matchMedia("(prefers-contrast: more)").addEventListener("change", () => {
-    setTheme(document.body, game.settings.get("dnd5e", "theme"));
-  });
-
-  // Hook into core color scheme setting.
-  const setting = game.settings.get("core", "uiConfig");
-  const settingConfig = game.settings.settings.get("core.uiConfig");
-  const { onChange } = settingConfig ?? {};
-  if ( onChange ) settingConfig.onChange = (s, ...args) => {
-    onChange(s, ...args);
-    setTheme(document.body, s.colorScheme);
-  };
-  setTheme(document.body, setting.colorScheme);
+  matchMedia("(prefers-contrast: more)").addEventListener("change", setThemeFlags);
+  setThemeFlags();
 }
 
 /* -------------------------------------------- */
@@ -868,28 +840,8 @@ export function disableExhaustionAutomation() {
 /* -------------------------------------------- */
 
 /**
- * Set the theme on an element, removing the previous theme class in the process.
- * @param {HTMLElement} element     Body or sheet element on which to set the theme data.
- * @param {string} [theme=""]       Theme key to set.
- * @param {Set<string>} [flags=[]]  Additional theming flags to set.
+ * Apply theming flag classes to the document body based on user preferences.
  */
-export function setTheme(element, theme="", flags=new Set()) {
-  if ( foundry.utils.getType(theme) === "Object" ) theme = theme.applications;
-  element.className = element.className.replace(/\bdnd5e-(theme|flag)-[\w-]+\b/g, "");
-
-  // Primary Theme
-  if ( !theme && (element === document.body) ) {
-    if ( matchMedia("(prefers-color-scheme: dark)").matches ) theme = "dark";
-    if ( matchMedia("(prefers-color-scheme: light)").matches ) theme = "light";
-  }
-  if ( theme ) {
-    element.classList.add(`dnd5e-theme-${theme.slugify()}`);
-    element.dataset.theme = theme;
-  }
-  else delete element.dataset.theme;
-
-  // Additional Flags
-  if ( (element === document.body) && matchMedia("(prefers-contrast: more)").matches ) flags.add("high-contrast");
-  for ( const flag of flags ) element.classList.add(`dnd5e-flag-${flag.slugify()}`);
-  element.dataset.themeFlags = Array.from(flags).join(" ");
+export function setThemeFlags() {
+  document.body.classList.toggle("dnd5e-flag-high-contrast", matchMedia("(prefers-contrast: more)").matches);
 }


### PR DESCRIPTION
- Normalises scrollbar styles across all browser/OS combos (that I could test). Firefox on Linux has 1px overlay scrollbars which means several sheets/tabs have no padding on the right. MacOS has an OS-level setting apparently which controls overlay scrollbars that most browsers seem to honour. And Chrome's 'thin' non-overlay scrollbars are the fattest of the lot.
- Use doughnut scoping to implement theming rather than layers.
- Remove vestigial system theme machinery.