### PR TITLE
Expose `transfer` field for enchantments, use to determine `isApplied`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2883,6 +2883,11 @@
     "Never": "Never",
     "ShortRest": "Short Rest"
   },
+  "Transfer": {
+    "DisabledTooltip": "This Enchantment is currently selected in one or more of its Item's Enchant Activities, and therefore cannot apply directly to the Item.",
+    "Hint": "If checked, this Enchantment will be applied directly to its parent Item.",
+    "Label": "Apply Enchantment to Item"
+  },
   "Warning": {
     "NotOnActor": "Enchantments can only be added to items, not directly to actors.",
     "Override": "This value is being modified by an Enchantment and cannot be edited. Disable the enchantment in the effects tab to edit it."

--- a/module/applications/activity/enchant-sheet.mjs
+++ b/module/applications/activity/enchant-sheet.mjs
@@ -130,7 +130,8 @@ export default class EnchantSheet extends ActivitySheet {
       type: "enchantment",
       name: name || this.item.name,
       img: img || this.item.img,
-      disabled: true
+      disabled: true,
+      transfer: false
     };
   }
 }

--- a/module/applications/advancement/modify-item-config.mjs
+++ b/module/applications/advancement/modify-item-config.mjs
@@ -69,7 +69,8 @@ export default class ModifyItemConfig extends AdvancementConfig {
     const effectData = {
       name: this.advancement._source.title || this.item.name,
       img: this.advancement._source.icon || this.item.img,
-      type: "enchantment"
+      type: "enchantment",
+      transfer: false
     };
     const [created] = await this.item.createEmbeddedDocuments("ActiveEffect", [effectData], { render: false });
     this.advancement.update({

--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -189,7 +189,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
       else if ( e.isTemporary ) categories.temporary.effects.push(e);
       else categories.passive.effects.push(e);
     }
-    categories.enchantment.hidden = !parent?.system.isEnchantment;
+    categories.enchantment.hidden = !parent?.system.isEnchantment && !categories.enchantment.effects.length;
     categories.enchantmentActive.hidden = !categories.enchantmentActive.effects.length;
     categories.enchantmentInactive.hidden = !categories.enchantmentInactive.effects.length;
     categories.suppressed.hidden = !categories.suppressed.effects.length;

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -974,6 +974,7 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
 
     if ( effect.type === "enchantment" ) {
       effectData.system.origin.item ??= effect.parent?.uuid;
+      if ( effect.system.isOnActivity ) effectData.transfer = true;
       options.keepOrigin = true;
       options.dnd5e = {
         enchantmentProfile: effect.id,

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -39,6 +39,16 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
   }
 
   /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareBaseData() {
+    super.prepareBaseData();
+    if ( this.isOnActivity ) this.parent.transfer = this.parent.disabled = false;
+  }
+
+  /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
 
@@ -69,6 +79,17 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
    */
   get isConcealed() {
     return false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Is this effect selected by any activity on its parent item?
+   * @type {boolean}
+   */
+  get isOnActivity() {
+    return !!this.item
+      && (this.item.system.activities?.contents ?? []).some(a => a.effects?.some(e => e._id === this.parent._id));
   }
 
   /* -------------------------------------------- */

--- a/module/data/active-effect/base.mjs
+++ b/module/data/active-effect/base.mjs
@@ -35,33 +35,12 @@ export default class BaseEffectData extends ActiveEffectDataModel {
   }
 
   /* -------------------------------------------- */
-  /*  Data Preparation                            */
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  prepareBaseData() {
-    super.prepareBaseData();
-    if ( this.isOnActivity ) this.parent.transfer = this.parent.disabled = false;
-  }
-
-  /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
 
   /** @override */
   get applicableType() {
     return this.isRider ? "" : "Actor";
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Is this effect selected by any activity on its parent item?
-   * @type {boolean}
-   */
-  get isOnActivity() {
-    return this.item
-      && (this.item.system.activities?.contents ?? []).some(a => a.effects.some(e => e._id === this.parent._id));
   }
 
   /* -------------------------------------------- */

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -67,7 +67,9 @@ export default class EnchantmentData extends ActiveEffectDataModel {
   /** @inheritDoc */
   prepareDerivedData() {
     super.prepareDerivedData();
-    if ( this.isApplied && this.parent.uuid ) dnd5e.registry.enchantments.track(this.parent.origin, this.parent.uuid);
+    if ( this.isApplied && this.parent.uuid && this.parent.origin ) {
+      dnd5e.registry.enchantments.track(this.parent.origin, this.parent.uuid);
+    }
   }
 
   /* -------------------------------------------- */
@@ -172,8 +174,9 @@ export default class EnchantmentData extends ActiveEffectDataModel {
       if ( this.isOnActivity ) {
         const transferCheckbox = transferFormGroup.querySelector('dnd5e-checkbox[name="transfer"]');
         if ( transferCheckbox ) {
-          transferCheckbox.dataset.tooltip = "DND5E.ENCHANTMENT.Transfer.DisabledTooltip";
+          if ( app.isEditable ) transferCheckbox.dataset.tooltip = "DND5E.ENCHANTMENT.Transfer.DisabledTooltip";
           transferCheckbox.disabled = true;
+          transferCheckbox.checked = false;
         }
       }
     }

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -43,11 +43,11 @@ export default class EnchantmentData extends ActiveEffectDataModel {
   /* -------------------------------------------- */
 
   /**
-   * Has this enchantment been applied by another item, or was it directly created.
+   * Should this enchantment apply to its parent item?
    * @type {boolean}
    */
   get isApplied() {
-    return !!this.parent.origin && (this.parent.origin !== this.item?.uuid);
+    return this.parent.transfer && !!this.item;
   }
 
   /* -------------------------------------------- */
@@ -161,8 +161,22 @@ export default class EnchantmentData extends ActiveEffectDataModel {
 
   /** @override */
   onRenderActiveEffectConfig(app, html, context) {
-    const toRemove = html.querySelectorAll('.form-group:has([name="transfer"], [name="statuses"], [name="showIcon"])');
+    const toRemove = html.querySelectorAll('.form-group:has([name="statuses"], [name="showIcon"])');
     toRemove.forEach(f => f.remove());
+    const transferFormGroup = html.querySelector('.form-group:has([name="transfer"])');
+    if ( transferFormGroup ) {
+      const transferLabel = transferFormGroup.querySelector("label");
+      const transferHint = transferFormGroup.querySelector(".hint");
+      if ( transferLabel ) transferLabel.innerText = _loc("DND5E.ENCHANTMENT.Transfer.Label");
+      if ( transferHint ) transferHint.innerText = _loc("DND5E.ENCHANTMENT.Transfer.Hint");
+      if ( this.isOnActivity ) {
+        const transferCheckbox = transferFormGroup.querySelector('dnd5e-checkbox[name="transfer"]');
+        if ( transferCheckbox ) {
+          transferCheckbox.dataset.tooltip = "DND5E.ENCHANTMENT.Transfer.DisabledTooltip";
+          transferCheckbox.disabled = true;
+        }
+      }
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/cast.mjs
+++ b/module/documents/activity/cast.mjs
@@ -131,7 +131,8 @@ export default class CastActivity extends ActivityMixin(BaseCastActivityData) {
             origin: {
               activity: this.uuid
             }
-          }
+          },
+          transfer: true
         }
       ],
       flags: {

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -172,7 +172,9 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
           activity: this.uuid,
           effect: concentration?.uuid
         }
-      }
+      },
+      disabled: false,
+      transfer: true
     }).toObject();
     enchantmentData.system.changes = await ActiveEffect5e.forApplication(enchantmentData.system.changes, this, item);
 

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -466,7 +466,8 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
             changes,
             origin: { activity: this.uuid }
           },
-          type: "enchantment"
+          type: "enchantment",
+          transfer: true
         })).toObject();
         actorUpdates.items.push({ _id: item.id, effects: [effect, ...item.effects.map(e => e.toObject())] });
       }

--- a/module/documents/advancement/modify-item.mjs
+++ b/module/documents/advancement/modify-item.mjs
@@ -61,7 +61,8 @@ export default class ModifyItemAdvancement extends Advancement {
             origin: {
               item: this.item.uuid
             }
-          }
+          },
+          transfer: true
         }, { keepId: true }).toObject();
         item.updateSource({ effects: [clone] });
         modified.push({ change: change._id, effect: clone._id, item: item._id });

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -1181,7 +1181,8 @@ function _migrateEffectMagical(effect, parent, updateData) {
  * @returns {object}           The updateData to apply.
  */
 function _migrateEnchantmentTransfer(effect, parent, updateData) {
-  if ( effect.type !== "enchantment" ) return updateData;
+  if ( (effect.type !== "enchantment")
+    || foundry.utils.objectValues(effect.system?.origin ?? {}).some(k => k) ) return updateData;
   const origin = effect.flags?.core?.originText ?? effect.origin;
   updateData.transfer = !!origin && !origin.endsWith(parent._id);
   return updateData;

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -755,7 +755,10 @@ export function migrateEffectData(effect, migrationData, { bypassVersionCheck, p
 
   _migrateDocumentIcon(effect, updateData, { ...migrationData, field: "img" });
   _migrateEffectChanges(effect, updateData, { setIds: migrate600 });
-  if ( migrate600 ) _migrateEffectMagical(effect, parent, updateData);
+  if ( migrate600 ) {
+    _migrateEffectMagical(effect, parent, updateData);
+    _migrateEnchantmentTransfer(effect, parent, updateData);
+  }
   _migrateEffectOrigin(effect, parent, updateData);
   if ( bypassVersionCheck || foundry.utils.isNewerVersion("3.1.0", version) ) {
     _migrateEffectTransfer(effect, parent, updateData);
@@ -1165,6 +1168,22 @@ function _migrateEffectChanges(effect, updateData, { setIds }={}) {
  */
 function _migrateEffectMagical(effect, parent, updateData) {
   if ( isSpellOrScroll(parent) || parent.system?.properties?.includes("mgc") ) updateData["system.magical"] = true;
+  return updateData;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Migrates Enchantment effect's transfer field according to whether they should be applied.
+ * @param {object} effect      Effect data to migrate.
+ * @param {object} parent      The parent of this effect.
+ * @param {object} updateData  Existing update to expand upon.
+ * @returns {object}           The updateData to apply.
+ */
+function _migrateEnchantmentTransfer(effect, parent, updateData) {
+  if ( effect.type !== "enchantment" ) return updateData;
+  const origin = effect.flags?.core?.originText ?? effect.origin;
+  updateData.transfer = !!origin && !origin.endsWith(parent._id);
   return updateData;
 }
 

--- a/templates/effects/effect-details.hbs
+++ b/templates/effects/effect-details.hbs
@@ -9,7 +9,7 @@
 
     {{#if isActorEffect}}
     {{ formGroup fields.origin value=source.origin rootId=rootId disabled=true }}
-    {{else if isItemEffect}}
+    {{else if (or isItemEffect (eq source.type "enchantment"))}}
     {{ formGroup fields.transfer value=source.transfer input=inputs.createCheckboxInput rootId=rootId }}
     {{/if}}
 


### PR DESCRIPTION
Closes #7318 
An enchantment created directly on an item may now be set to apply to said item. Most of the code changes should be fairly self-explanatory. Potential exceptions:
- `EnchantSheet#_processSubmitData` newly overridden. Any newly-added local enchantments on an Enchant activity will be updated to `transfer: false` if they were previously `transfer: true`. While not _necessary_ (this is double checked in `isApplied`) it is cleaner if all enchantments which exist as an enchant activity have a visibly false `transfer` checkbox. In theory this logic could be done in `_onUpdate` somewhere to also account for programmatic changes I suppose. And could block `transfer: true` in `EnchantmentData#_preUpdate` when necessary.
- `EnchantmentData#onRenderActiveEffectConfig` now also replaces label & hint text for the transfer form group (if it exists) and disables & adds a tooltip to the checkbox itself (if it should be disabled).
- Don't _love_ the `_migrateEnchantmentTransfer` origin/id comparison, but I think it's the best we can do since we don't have direct access to the uuid at that point. With the migration as-is, any existing enchantments for which `isApplied` would have returned `true` will receive `transfer: true`, all others will receive `transfer: false`. The exception introduced by the lack of uuid would be if an enchantment had an `origin` of an _Activity_ whose id matched exactly the id of the _Item_ the activity was on. In that absurdly unlikely scenario, `isApplied` would have returned `true` but it would receive `transfer: false`. I'm not worried about it.
- Exposed the transfer checkbox for parentless Enchantments. This is just so that one could configure whether a compendium Enchantment should be "I drag this on to affect this item" or "I drag this on because I'm going to use it on an enchant activity." Would be open to adding a `isEnchantment` property to context rather than doing a string comparison there.