### PR TITLE
[#7131] Add embedding support for activities

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -106,7 +106,7 @@ Hooks.once("init", function() {
     sidebarIcon: "fa-solid fa-person-hiking",
     typeLabels: new Proxy(CONFIG.DND5E.activityTypes, {
       get(target, prop) {
-        return target[prop]?.documentClass?.metadata?.title
+        return target[prop]?.documentClass?.metadata?.title;
       }
     })
   };
@@ -116,7 +116,7 @@ Hooks.once("init", function() {
     sidebarIcon: "fa-solid fa-person-dress-burst",
     typeLabels: new Proxy(CONFIG.DND5E.advancementTypes, {
       get(target, prop) {
-        return target[prop]?.documentClass?.metadata?.title
+        return target[prop]?.documentClass?.metadata?.title;
       }
     })
   };

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -99,6 +99,28 @@ Hooks.once("init", function() {
   CONFIG.ui.items = applications.item.ItemDirectory5e;
   CONFIG.ux.DragDrop = DragDrop5e;
 
+  // Add configuration sections for activities & advancement
+  CONFIG.Activity = {
+    documentClass: documents.activity.UtilityActivity,
+    embedHandlers: [],
+    sidebarIcon: "fa-solid fa-person-hiking",
+    typeLabels: new Proxy(CONFIG.DND5E.activityTypes, {
+      get(target, prop) {
+        return target[prop]?.documentClass?.metadata?.title
+      }
+    })
+  };
+  CONFIG.Advancement = {
+    documentClass: documents.advancement.Advancement,
+    embedHandlers: [],
+    sidebarIcon: "fa-solid fa-person-dress-burst",
+    typeLabels: new Proxy(CONFIG.DND5E.advancementTypes, {
+      get(target, prop) {
+        return target[prop]?.documentClass?.metadata?.title
+      }
+    })
+  };
+
   // Register System Settings
   registerSystemSettings();
   registerSystemKeybindings();

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,7 +1,7 @@
 {
+"DOCUMENT.Activity": "Activity",
+"DOCUMENT.Advancement": "Advancement",
 "DOCUMENT.DND5E": {
-  "Activity": "Activity",
-  "Advancement": "Advancement",
   "Warning": {
     "SelectType": "{name} type must be selected for creation."
   }

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -985,22 +985,22 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
 
   /**
    * Handle dropping an Activity onto the sheet.
-   * @param {DragEvent} event       The drag event.
-   * @param {object} transfer       The dropped data.
-   * @param {object} transfer.data  The Activity data.
+   * @param {DragEvent} event   The concluding DragEvent which contains drop data.
+   * @param {object} data       The data transfer extracted from the event.
    * @protected
    */
-  _onDropActivity(event, { data }) {
-    const { _id: id, type } = data;
-    const source = this.item.system.activities.get(id);
-    const config = CONFIG.DND5E.activityTypes[type] ?? {};
+  async _onDropActivity(event, data) {
+    const activity = await dnd5e.documents.activity.UtilityActivity.fromDropData(data);
+    if ( !activity ) return;
+    const source = this.item.system.activities.get(activity.id);
+    const config = CONFIG.DND5E.activityTypes[activity.type] ?? {};
 
     // Reordering
     if ( source ) {
       const targetId = event.target.closest(".activity[data-activity-id]")?.dataset.activityId;
       const target = this.item.system.activities.get(targetId);
       if ( !target || (target === source) ) return;
-      const siblings = this.item.system.activities.filter(a => a._id !== id);
+      const siblings = this.item.system.activities.filter(a => a._id !== activity.id);
       const sortUpdates = foundry.utils.performIntegerSort(source, { target, siblings });
       const updateData = Object.fromEntries(sortUpdates.map(({ target, update }) => {
         return [target._id, { sort: update.sort }];
@@ -1010,8 +1010,9 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
 
     // Copying
     else if ( (config?.configurable !== false) && config.documentClass.availableForItem(this.item) ) {
-      delete data._id;
-      this.item.createActivity(type, data, { renderSheet: false });
+      const sourceData = activity.toObject();
+      delete sourceData._id;
+      this.item.createActivity(activity.type, sourceData, { renderSheet: false });
     }
   }
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -38,7 +38,7 @@ export default function ActivityMixin(Base) {
      */
     static metadata = Object.freeze({
       collection: "activities",
-      label: "DOCUMENT.DND5E.Activity",
+      label: "DOCUMENT.Activity",
       name: "Activity",
       sheetClass: ActivitySheet,
       usage: {
@@ -1172,6 +1172,21 @@ export default function ActivityMixin(Base) {
         range: this.range,
         uses: { ...this.uses, name: "uses.value" }
       };
+    }
+
+    /* -------------------------------------------- */
+    /*  Helpers                                     */
+    /* -------------------------------------------- */
+
+    /** @override */
+    async _buildEmbedHTML(config, options={}) {
+      if ( !this.description?.value ) return null;
+      const enriched = await foundry.applications.ux.TextEditor.implementation.enrichHTML(this.description.value, {
+        rollData: this.item.getRollData(), ...options, relativeTo: this.item
+      });
+      const container = document.createElement("div");
+      container.innerHTML = enriched;
+      return container.children;
     }
 
     /* -------------------------------------------- */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1182,7 +1182,7 @@ export default function ActivityMixin(Base) {
     async _buildEmbedHTML(config, options={}) {
       if ( !this.description?.value ) return null;
       const enriched = await foundry.applications.ux.TextEditor.implementation.enrichHTML(this.description.value, {
-        rollData: this.item.getRollData(), ...options, relativeTo: this.item
+        ...options, rollData: this.getRollData(), relativeTo: this.item
       });
       const container = document.createElement("div");
       container.innerHTML = enriched;

--- a/module/documents/advancement/advancement.mjs
+++ b/module/documents/advancement/advancement.mjs
@@ -150,6 +150,16 @@ export default class Advancement extends PseudoDocumentMixin(BaseAdvancementData
   /* -------------------------------------------- */
 
   /**
+   * Name of the advancement.
+   * @type {string}
+   */
+  get name() {
+    return this.title;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Does this Advancement type support HTML hints in the config dialog, flow, and summary?
    * Any Advancement type that has upgraded its Flow application to ApplicationV2 is assumed to support this.
    * @type {boolean}

--- a/module/documents/advancement/advancement.mjs
+++ b/module/documents/advancement/advancement.mjs
@@ -68,7 +68,7 @@ export default class Advancement extends PseudoDocumentMixin(BaseAdvancementData
       collection: "advancement",
       hint: "",
       icon: "icons/svg/upgrade.svg",
-      label: "DOCUMENT.DND5E.Advancement",
+      label: "DOCUMENT.Advancement",
       multiLevel: false,
       name: "Advancement",
       order: 100,

--- a/module/documents/mixins/pseudo-document.mjs
+++ b/module/documents/mixins/pseudo-document.mjs
@@ -154,7 +154,7 @@ export default function PseudoDocumentMixin(Base) {
      * @returns {string}
      */
     get link() {
-      return `@UUID[${this.uuid}]{${foundry.utils.escapeHTML(this.name ?? this.title)}}`;
+      return `@UUID[${this.uuid}]{${foundry.utils.escapeHTML(this.name)}}`;
     }
 
     /* -------------------------------------------- */
@@ -274,7 +274,7 @@ export default function PseudoDocumentMixin(Base) {
     async deleteDialog({ sheet, ...options }={}) {
       const type = _loc(this.metadata.label);
       const config = foundry.utils.mergeObject({
-        window: { title: `${_loc("DOCUMENT.Delete", { type })}: ${this.name || this.title}` },
+        window: { title: `${_loc("DOCUMENT.Delete", { type })}: ${this.name}` },
         content: `
           <p>
             <strong>${_loc("COMMON.AreYouSure")}</strong> ${_loc("SIDEBAR.DeleteWarning", { type })}

--- a/module/documents/mixins/pseudo-document.mjs
+++ b/module/documents/mixins/pseudo-document.mjs
@@ -1,4 +1,10 @@
 import CreateDocumentDialog from "../../applications/create-document-dialog.mjs";
+import EmbeddableDocumentMixin from "./embeddable.mjs";
+
+const COPIED_METHODS = [
+  "toAnchor", "toDragData", "_createDocumentLink", "_onClickDocumentLink",
+  "toEmbed", "onEmbed", "_buildEmbedHTML", "_createInlineEmbed", "_createFigureEmbed"
+];
 
 /**
  * A mixin which extends a DataModel to provide behavior shared between activities & advancement.
@@ -8,7 +14,9 @@ import CreateDocumentDialog from "../../applications/create-document-dialog.mjs"
  * @mixin
  */
 export default function PseudoDocumentMixin(Base) {
-  class PseudoDocument extends Base {
+  const _PseudoDocument = class extends Base {};
+  COPIED_METHODS.forEach(m => _PseudoDocument.prototype[m] ??= Actor.prototype[m]);
+  class PseudoDocument extends EmbeddableDocumentMixin(_PseudoDocument) {
     constructor(data, { parent=null, ...options }={}) {
       if ( parent instanceof Item ) parent = parent.system;
       super(data, { parent, ...options });
@@ -142,6 +150,16 @@ export default function PseudoDocumentMixin(Base) {
     /* -------------------------------------------- */
 
     /**
+     * Return a string which creates a dynamic link to this PseudoDocument instance.
+     * @returns {string}
+     */
+    get link() {
+      return `@UUID[${this.uuid}]{${foundry.utils.escapeHTML(this.name ?? this.title)}}`;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
      * Lazily obtain a Application instance used to configure this PseudoDocument, or null if no sheet is available.
      * @type {Application|ApplicationV2|null}
      */
@@ -261,13 +279,35 @@ export default function PseudoDocumentMixin(Base) {
     /* -------------------------------------------- */
 
     /**
-     * Serialize salient information for this PseudoDocument when dragging it.
-     * @returns {object}  An object of drag data.
+     * Handle obtaining the relevant PseudoDocument from dropped data provided via a DataTransfer event.
+     * @param {object} data               The data object extracted from a DataTransfer event.
+     * @returns {Promise<PseudoDocument>} The resolved PseudoDocument.
+     * @throws If a PseudoDocument could not be retrieved from the provided data.
      */
-    toDragData() {
-      const dragData = { type: this.documentName, data: this.toObject() };
-      if ( this.id ) dragData.uuid = this.uuid;
-      return dragData;
+    static async fromDropData(data) {
+      let doc = null;
+
+      // Case 1 - Data explicitly provided
+      if ( data.data ) {
+        const Class = this.documentConfig[data.data.type]?.documentClass;
+        if ( !Class ) throw new Error(
+          `Invalid ${this.documentName} type '${data.data.type}' provided to ${this.name}.fromDropData.`
+        );
+        doc = new Class(data.data);
+      }
+
+      // Case 2 - UUID provided
+      else if ( data.uuid ) doc = await fromUuid(data.uuid);
+
+      // Ensure that we retrieved a valid document
+      if ( !doc ) {
+        throw new Error("Failed to resolve Document from provided DragData. Either data or a UUID must be provided.");
+      }
+      if ( doc.documentName !== this.documentName ) {
+        throw new Error(`Invalid Document type '${doc.type}' provided to ${this.name}.fromDropData.`);
+      }
+
+      return doc;
     }
 
     /* -------------------------------------------- */

--- a/module/documents/mixins/pseudo-document.mjs
+++ b/module/documents/mixins/pseudo-document.mjs
@@ -160,6 +160,16 @@ export default function PseudoDocumentMixin(Base) {
     /* -------------------------------------------- */
 
     /**
+     * Compendium pack containing this activity.
+     * @type {CompendiumCollection|null}
+     */
+    get pack() {
+      return this.item?.pack ?? null;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
      * Lazily obtain a Application instance used to configure this PseudoDocument, or null if no sheet is available.
      * @type {Application|ApplicationV2|null}
      */


### PR DESCRIPTION
Adds embedding methods in activities by copying the methods over from `Actor`. Because of citations this also required copying over methods like `toAnchor` add `_createDocumentLink`. This does mean that Advancement and Activity documents can now be linked like all other document types.

These copied methods also required adding `CONFIG.Activity` and `CONFIG.Advancement` so that core could fetch the document class, icon, embed handlers, and type labels.

Activties have gained a `_buildEmbedHTML` method so they will show their descriptions when embedding. No embed support has been done for Advancement documents yet.