### PR TITLE
Standardise pill properties across all locations they appear.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -5282,8 +5282,8 @@
         "any": "any allies",
         "each": "each ally",
         "every": "every ally",
-        "one": "{number} ally",
-        "other": "{number} allies"
+        "one": "ally",
+        "other": "allies"
       }
     },
     "Any": {
@@ -5292,8 +5292,8 @@
     "Circle": {
       "Label": "Circle",
       "Counted": {
-        "one": "{number} circle",
-        "other": "{number} circles",
+        "one": "circle",
+        "other": "circles",
         "oneSized": "{sizes} Circle",
         "otherSized": "{number} {sizes} Circles"
       }
@@ -5301,8 +5301,8 @@
     "Cone": {
       "Label": "Cone",
       "Counted": {
-        "one": "{number} cone",
-        "other": "{number} cones",
+        "one": "cone",
+        "other": "cones",
         "oneSized": "{sizes} Cone",
         "otherSized": "{number} {sizes} Cones"
       }
@@ -5313,8 +5313,8 @@
         "any": "any creatures",
         "each": "each creature",
         "every": "every creature",
-        "one": "{number} creature",
-        "other": "{number} creatures"
+        "one": "creature",
+        "other": "creatures"
       }
     },
     "CreatureOrObject": {
@@ -5323,15 +5323,15 @@
         "any": "any creatures or objects",
         "each": "each creature or object",
         "every": "every creature or object",
-        "one": "{number} creature or object",
-        "other": "{number} creatures or objects"
+        "one": "creature or object",
+        "other": "creatures or objects"
       }
     },
     "Cube": {
       "Label": "Cube",
       "Counted": {
-        "one": "{number} cube",
-        "other": "{number} cubes",
+        "one": "cube",
+        "other": "cubes",
         "oneSized": "{sizes} Cube",
         "otherSized": "{number} {sizes} Cubes"
       }
@@ -5339,8 +5339,8 @@
     "Cylinder": {
       "Label": "Cylinder",
       "Counted": {
-        "one": "{number} cylinder",
-        "other": "{number} cylinders",
+        "one": "cylinder",
+        "other": "cylinders",
         "oneSized": "{sizes} Cylinder",
         "otherSized": "{number} {sizes} Cylinders"
       }
@@ -5348,8 +5348,8 @@
     "Emanation": {
       "Label": "Emanation",
       "Counted": {
-        "one": "{number} emanation",
-        "other": "{number} emanations",
+        "one": "emanation",
+        "other": "emanations",
         "oneSized": "{sizes} Emanation",
         "otherSized": "{number} {sizes} Emanations"
       }
@@ -5360,15 +5360,15 @@
         "any": "any enemies",
         "each": "each enemy",
         "every": "every enemy",
-        "one": "{number} enemy",
-        "other": "{number} enemies"
+        "one": "enemy",
+        "other": "enemies"
       }
     },
     "Line": {
       "Label": "Line",
       "Counted": {
-        "one": "{number} line",
-        "other": "{number} lines",
+        "one": "line",
+        "other": "lines",
         "oneSized": "{sizes} Line",
         "otherSized": "{number} {sizes} Lines"
       }
@@ -5379,15 +5379,15 @@
         "any": "any objects",
         "each": "each object",
         "every": "every object",
-        "one": "{number} object",
-        "other": "{number} objects"
+        "one": "object",
+        "other": "objects"
       }
     },
     "Radius": {
       "Label": "Radius",
       "Counted": {
-        "one": "{number} radius",
-        "other": "{number} radii",
+        "one": "radius",
+        "other": "radii",
         "oneSized": "{sizes} Radius",
         "otherSized": "{number} {sizes} Radii"
       }
@@ -5395,8 +5395,8 @@
     "Ring": {
       "Label": "Ring",
       "Counted": {
-        "one": "{number} ring",
-        "other": "{number} rings",
+        "one": "ring",
+        "other": "rings",
         "oneSized": "{sizes} Ring",
         "otherSized": "{number} {sizes} Rings"
       }
@@ -5410,15 +5410,15 @@
         "any": "any spaces",
         "each": "each space",
         "every": "every space",
-        "one": "{number} Space",
-        "other": "{number} Spaces"
+        "one": "space",
+        "other": "spaces"
       }
     },
     "Sphere": {
       "Label": "Sphere",
       "Counted": {
-        "one": "{number} sphere",
-        "other": "{number} spheres",
+        "one": "sphere",
+        "other": "spheres",
         "oneSized": "{sizes} Sphere",
         "otherSized": "{number} {sizes} Spheres"
       }
@@ -5429,15 +5429,15 @@
         "any": "any {special}",
         "each": "each {special}",
         "every": "every {special}",
-        "one": "{number} {special}",
-        "other": "{number} {special}"
+        "one": "{special}",
+        "other": "{special}"
       }
     },
     "Square": {
       "Label": "Square",
       "Counted": {
-        "one": "{number} square",
-        "other": "{number} squares",
+        "one": "square",
+        "other": "squares",
         "oneSized": "{sizes} Square",
         "otherSized": "{number} {sizes} Squares"
       }
@@ -5448,15 +5448,15 @@
         "any": "any targets",
         "each": "each target",
         "every": "every target",
-        "one": "{number} target",
-        "other": "{number} targets"
+        "one": "target",
+        "other": "targets"
       }
     },
     "Wall": {
       "Label": "Wall",
       "Counted": {
-        "one": "{number} wall",
-        "other": "{number} walls",
+        "one": "wall",
+        "other": "walls",
         "oneSized": "{sizes} Wall",
         "otherSized": "{number} {sizes} Walls"
       }
@@ -5467,8 +5467,8 @@
         "any": "any willing creatures",
         "each": "each willing creature",
         "every": "every willing creature",
-        "one": "{number} willing creature",
-        "other": "{number} willing creatures"
+        "one": "willing creature",
+        "other": "willing creatures"
       }
     }
   },

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -417,14 +417,15 @@
     gap: .25rem;
 
     .pill {
-      font-family: var(--dnd5e-font-roboto);
-      font-weight: bold;
+      font-family: var(--dnd5e-font-roboto-condensed);
+      font-weight: 400;
       font-size: var(--font-size-11);
-      text-transform: uppercase;
+      line-height: 1;
+      text-transform: none;
       border: var(--pill-border);
       border-radius: 3px;
       background: var(--dnd5e-background-card);
-      padding: .1875rem .375rem;
+      padding: 2px 5px;
       display: flex;
       gap: .25rem;
       margin: 0;
@@ -437,16 +438,10 @@
       &.green { background-color: var(--pill-background-green); }
       &.maroon { background-color: var(--pill-background-maroon); }
 
-      &.transparent, &.pill-sm {
+      &.transparent {
         color: var(--pill-transparent-color);
         border: var(--pill-border-dotted);
         background-color: transparent;
-      }
-
-      &.pill-xs {
-        font-size: var(--font-size-9);
-        padding: 2px 4px;
-        gap: 3px;
       }
 
       > .separator { color: var(--color-text-tertiary); }

--- a/less/v2/character.less
+++ b/less/v2/character.less
@@ -868,7 +868,13 @@
         > h3 > a { color: var(--dnd5e-color-black); }
       }
 
-      .pill { padding: .25rem .5rem; }
+      .pill {
+        font-family: var(--dnd5e-font-roboto);
+        font-weight: bold;
+        line-height: normal;
+        padding: .25rem .5rem;
+        text-transform: uppercase;
+      }
     }
 
     /* Item Sections */

--- a/less/v2/group.less
+++ b/less/v2/group.less
@@ -271,15 +271,7 @@
         }
       }
 
-      .pills {
-        margin-top: -5px;
-
-        .pill {
-          font-size: var(--font-size-10);
-          line-height: 1;
-          padding: 3px 6px;
-        }
-      }
+      .pills { margin-top: -5px; }
 
       .primary-vehicle {
         position: absolute;
@@ -414,6 +406,9 @@
 
           .pill {
             border: none;
+            font-family: var(--dnd5e-font-roboto);
+            font-weight: bold;
+            line-height: normal;
             padding: 1px 4px;
           }
         }

--- a/less/v2/items.less
+++ b/less/v2/items.less
@@ -235,12 +235,6 @@
     &:not(.active) { display: none; }
     &.effects, &.activities { padding: 12px var(--dnd5e-scroll-pad) 58px 6px; }
 
-    > .pills .pill {
-      font-size: var(--font-size-10);
-      padding: 3px 6px;
-      line-height: 1;
-    }
-
     &.single-description {
       padding-right: 9px;
       scrollbar-gutter: auto;

--- a/less/v2/npc.less
+++ b/less/v2/npc.less
@@ -483,12 +483,6 @@
 
             > i, > span { font-size: var(--font-size-11); }
           }
-
-          .pill {
-            font-size: var(--font-size-10);
-            padding: 2px 4px;
-            gap: 3px;
-          }
         }
       }
 

--- a/less/v2/tooltips.less
+++ b/less/v2/tooltips.less
@@ -173,12 +173,6 @@
         &.overflowing { mask-image: unset; }
       }
     }
-
-    .pill {
-      font-size: var(--font-size-10);
-      padding: .1875rem .375rem;
-      line-height: 1;
-    }
   }
 
   /* ---------------------------------- */

--- a/less/v2/vehicle.less
+++ b/less/v2/vehicle.less
@@ -168,12 +168,6 @@
         }
       }
 
-      .pill {
-        font-size: var(--font-size-10);
-        padding: 2px 4px;
-        gap: 3px;
-      }
-
       .form-fields input { font-size: var(--font-size-11); }
     }
   }

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -227,7 +227,9 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
         ...this.item.system.cardProperties ?? [],
         ...PropertyField.getUsageProperties(usage),
         ...this.item.system.equippableItemCardProperties ?? []
-      ], { ...usage, properties: this.item.system.properties }));
+      ].filter(p => {
+        return (p.type !== "duration") || (usage.duration.units !== "inst") || this.item.system.alwaysShowDuration;
+      }), { ...usage, properties: this.item.system.properties }));
     }
 
     await this.item.system.getSheetData?.(context);

--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -66,6 +66,16 @@ export default class ItemDataModel extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
+   * Whether this item should always record a duration property, even if just the default 'instantaneous'.
+   * @type {boolean}
+   */
+  get alwaysShowDuration() {
+    return false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Modes that can be used when making an attack with this item.
    * @type {FormSelectOption[]}
    */
@@ -219,12 +229,16 @@ export default class ItemDataModel extends SystemDataModel {
       },
       level: enrichmentOptions.rollData.item?.level ?? null,
       properties: (identified === false) ? [] : [
+        { type: "text", text: this.type?.label ?? _loc(CONFIG.Item.typeLabels[type]), identity: true },
         ...this.cardProperties ?? [],
         ...PropertyField.getUsageProperties(usage),
         ...this.equippableItemCardProperties ?? []
       ]
         // Entries without a type are pre-6.0 label strings, which would cause a validation failure.
-        .filter(p => p?.type),
+        .filter(p => p?.type)
+        .filter(p => {
+          return (p.type !== "duration") || (usage.duration.units !== "inst") || this.alwaysShowDuration;
+        }),
       subtitle: [this.type?.label ?? _loc(CONFIG.Item.typeLabels[type])]
     };
   }
@@ -272,7 +286,9 @@ export default class ItemDataModel extends SystemDataModel {
       controlHints: game.settings.get("dnd5e", "controlHints"),
       description: await TextEditor.enrichHTML(description || "", enrichmentOptions),
       labels: foundry.utils.deepClone((activity ?? this.parent).labels),
-      properties: PropertyField.getLabels(context.properties, { ...context, properties: context.item.properties }),
+      properties: PropertyField.getLabels(context.properties.filter(p => !p.identity), {
+        ...context, properties: context.item.properties
+      }),
       subtitle: context.subtitle.filterJoin(" • "),
       weight: this.weight
     });

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -124,6 +124,13 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   /*  Properties                                  */
   /* -------------------------------------------- */
 
+  /** @override */
+  get alwaysShowDuration() {
+    return true;
+  }
+
+  /* -------------------------------------------- */
+
   /**
    * Attack classification of this spell.
    * @type {"spell"}
@@ -202,8 +209,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
     return [
       { type: "level", level: this.level },
       { type: "components", materials: this.properties.has("material") ? this.materials.value : "" },
-      ...this.tagProperties,
-      { type: "duration" }
+      ...this.tagProperties
     ];
   }
 
@@ -481,6 +487,11 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
     context.subtitle = [
       CONFIG.DND5E.spellLevels[context.level], CONFIG.DND5E.spellSchools[this.school]?.label
     ].filter(_ => _);
+    context.properties = [
+      { type: "level", level: context.level, identity: true },
+      { type: "school", school: this.school, identity: true },
+      ...context.properties.filter(p => !p.identity)
+    ];
     return context;
   }
 

--- a/module/data/item/subclass.mjs
+++ b/module/data/item/subclass.mjs
@@ -106,7 +106,14 @@ export default class SubclassData extends ItemDataModel.mixin(AdvancementTemplat
   async getCardData(options) {
     const context = await super.getCardData(options);
     const cls = dnd5e.registry.classes.get(this.classIdentifier)?.name;
-    if ( cls ) context.subtitle = [_loc("DND5E.SubclassOf", { class: cls })];
+    if ( cls ) {
+      const label = _loc("DND5E.SubclassOf", { class: cls });
+      context.subtitle = [label];
+      context.properties = [
+        { type: "text", text: label, identity: true },
+        ...context.properties.filter(p => !p.identity)
+      ];
+    }
     return context;
   }
 

--- a/module/data/item/templates/equippable-item.mjs
+++ b/module/data/item/templates/equippable-item.mjs
@@ -63,7 +63,7 @@ export default class EquippableItemTemplate extends SystemDataModel {
     return [
       (this.attuned || CONFIG.DND5E.attunementTypes[this.attunement])
         ? { type: "attunement", attuned: this.attuned, attunement: this.attunement } : null,
-      { type: "label", label: this.equipped ? "DND5E.Equipped" : "DND5E.Unequipped" },
+      this.equipped ? null : { type: "label", label: "DND5E.Unequipped" },
       ("proficient" in this) ? { type: "proficiency", proficiency: this.prof?.multiplier || 0 } : null
     ].filter(_ => _);
   }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -513,6 +513,16 @@ export default class WeaponData extends ItemDataModel.mixin(
     context.mastery = this.mastery;
     const masteryLabel = CONFIG.DND5E.weaponMasteries[this.mastery]?.label;
     if ( masteryLabel ) context.subtitle.push(masteryLabel);
+
+    const identity = [{ type: "label", label: CONFIG.Item.typeLabels.weapon, identity: true }];
+    const category = CONFIG.DND5E.weaponProficienciesMap[this.type.value];
+    if ( category ) identity.push({ type: "weapon:category", category, identity: true });
+    else if ( this.type.label ) identity.push({ type: "text", text: this.type.label, identity: true });
+    const cls = CONFIG.DND5E.weaponTypeMap[this.type.value];
+    if ( cls ) identity.push({ type: "weapon:class", class: cls, identity: true });
+    if ( this.mastery ) identity.push({ type: "mastery", mastery: this.mastery, identity: true });
+    context.properties = [...identity, ...context.properties.filter(p => !p.identity)];
+
     return context;
   }
 

--- a/module/data/shared/property-field.mjs
+++ b/module/data/shared/property-field.mjs
@@ -15,7 +15,7 @@ const { BooleanField, NumberField, StringField, TypedSchemaField } = foundry.dat
  */
 export default class PropertyField extends TypedSchemaField {
   constructor(options={}, context={}) {
-    super({
+    const types = {
       ability: { ability: new StringField() },
       ac: { value: new NumberField({ integer: true }) },
       activation: {},
@@ -31,13 +31,18 @@ export default class PropertyField extends TypedSchemaField {
       property: { property: new StringField() },
       range: {},
       reach: {},
+      school: { school: new StringField() },
       target: {},
       text: { text: new StringField() },
+      "weapon:category": { category: new StringField() },
+      "weapon:class": { class: new StringField() },
       weight: {
         units: new StringField({ blank: false, initial: () => defaultUnits("weight"), required: true }),
         value: new NumberField()
       }
-    }, options, context);
+    };
+    for ( const type of Object.values(types) ) type.identity = new BooleanField();
+    super(types, options, context);
   }
 
   /* -------------------------------------------- */
@@ -55,7 +60,7 @@ export default class PropertyField extends TypedSchemaField {
       switch ( p.type ) {
         case "ability": return CONFIG.DND5E.abilities[p.ability]?.label;
         case "ac": return `${p.value} ${_loc("DND5E.AC")}`;
-        case "activation": return ActivationField.getLabels({ activation, properties }).simple;
+        case "activation": return ActivationField.getLabels({ activation, properties }).simple?.titleCase();
         case "attunement": return p.attuned
           ? _loc("DND5E.AttunementAttuned")
           : CONFIG.DND5E.attunementTypes[p.attunement];
@@ -70,7 +75,7 @@ export default class PropertyField extends TypedSchemaField {
           );
           return p.materials ? `${components} (${p.materials})` : components;
         }
-        case "duration": return DurationField.getLabels({ duration, properties }).simple;
+        case "duration": return DurationField.getLabels({ duration, properties }).simple?.titleCase();
         case "label": return _loc(p.label);
         case "level": return CONFIG.DND5E.spellLevels[p.level];
         case "mastery": return CONFIG.DND5E.weaponMasteries[p.mastery]?.label;
@@ -82,12 +87,17 @@ export default class PropertyField extends TypedSchemaField {
         case "range": return (range.long && (range.long !== range.value))
           ? `${formatNumber(range.value)}/${formatLength(range.long, range.units)}`
           : RangeField.getLabels({ range }).simple;
-        case "reach": return _loc("DND5E.RANGE.Formatted.Reach", { reach: formatLength(range.reach, range.units) });
+        case "reach": return _loc("DND5E.RANGE.Formatted.Reach", {
+          reach: formatLength(range.reach, range.units)
+        }).capitalize();
+        case "school": return CONFIG.DND5E.spellSchools[p.school]?.label;
         case "target": {
-          const labels = TargetField.getLabels({ target });
+          const labels = TargetField.getLabels({ target, capitalize: true });
           return labels.template.statblock || labels.affects.sheet;
         }
         case "text": return p.text;
+        case "weapon:category": return CONFIG.DND5E.weaponProficiencies[p.category];
+        case "weapon:class": return CONFIG.DND5E.attackTypes[p.class]?.label;
         case "weight": return formatWeight(p.value, p.units);
         default: return null;
       }

--- a/module/data/shared/target-field.mjs
+++ b/module/data/shared/target-field.mjs
@@ -42,12 +42,29 @@ export default class TargetField extends SchemaField {
   /**
    * Build the display labels for target data.
    * @param {object} data                               Data from which to build the labels.
+   * @param {boolean} [data.capitalize=false]           Capitalize the target type in labels intended to stand alone,
+   *                                                    rather than read as part of a sentence.
    * @param {Record<string, string>} [data.dimensions]  Template dimensions, derived from the type when omitted.
    * @param {TargetData} data.target                    Resolved target data.
    * @returns {TargetLabels}
    */
-  static getLabels({ dimensions, target }) {
+  static getLabels({ capitalize=false, dimensions, target }) {
     const pr = getPluralRules();
+
+    /**
+     * Combine a count with its localized target type.
+     * @param {string} count                        Formatted count.
+     * @param {string} key                          Localization key for the target type.
+     * @param {object} [options={}]
+     * @param {boolean} [options.capitalize=false]  Capitalize the target type.
+     * @param {string} [options.special]            Description of a special target type.
+     * @returns {string}
+     */
+    const fmt = (count, key, { capitalize=false, special }={}) => {
+      let type = _loc(key, { special });
+      if ( capitalize ) type = type.capitalize();
+      return _loc("DND5E.TARGET.Formatted", { count, type }).trim();
+    };
 
     // Generate the template labels
     const template = {};
@@ -59,12 +76,13 @@ export default class TargetField extends SchemaField {
       if ( target.template.units in CONFIG.DND5E.movementUnits ) {
         parts.push(formatLength(target.template.size, target.template.units));
       }
-      template.statblock = _loc(`${templateConfig.counted}.${pr.select(target.template.count || 1)}`, {
-        number: parts.filterJoin(" ")
-      }).trim().capitalize();
+      template.statblock = fmt(
+        parts.filterJoin(" "), `${templateConfig.counted}.${pr.select(target.template.count || 1)}`,
+        { capitalize }
+      ).capitalize();
 
       const sizeUnit = CONFIG.DND5E.movementUnits[target.template.units]?.template ?? "";
-      if ( Object.keys(dimensions).length === 1 ) template.size = _loc("DND5E.AreaOfEffect.Description.SizeSimple",{
+      if ( Object.keys(dimensions).length === 1 ) template.size = _loc("DND5E.AreaOfEffect.Description.SizeSimple", {
         number: formatNumber(target.template.size), unit: sizeUnit
       });
       else template.size = game.i18n.getListFormatter({ type: "unit" })
@@ -85,23 +103,18 @@ export default class TargetField extends SchemaField {
 
     // Generate the affects labels
     const affectsConfig = CONFIG.DND5E.individualTargetTypes[target.affects.type];
+    const { count, special } = target.affects;
+    const counted = affectsConfig?.counted ?? "DND5E.TARGET.Type.Target.Counted";
+    const described = special ? "DND5E.TARGET.Type.Special.Counted" : counted;
     const affects = {
-      description: _loc(
-        `${target.affects.special ? "DND5E.TARGET.Type.Special.Counted"
-          : affectsConfig?.counted ?? "DND5E.TARGET.Type.Target.Counted"}.${target.affects.count
-          ? pr.select(target.affects.count) : target.template.type ? "each" : "any"}`, {
-          number: formatNumber(target.affects.count, { words: true }),
-          special: target.affects.special
-        }),
-      sheet: affectsConfig?.counted ? _loc(
-        `${affectsConfig.counted}.${target.affects.count ? pr.select(target.affects.count) : "other"}`, {
-          number: target.affects.count ? formatNumber(target.affects.count)
-            : _loc(`DND5E.TARGET.Count.${target.template.type ? "Every" : "Any"}`)
-        }).trim().capitalize() : (affectsConfig?.label ?? ""),
-      statblock: _loc(
-        `${affectsConfig?.counted ?? "DND5E.TARGET.Type.Target.Counted"}.${pr.select(target.affects.count || 1)}`,
-        { number: formatNumber(target.affects.count || 1, { words: true }) }
-      )
+      description: count
+        ? fmt(formatNumber(count, { words: true }), `${described}.${pr.select(count)}`, { special })
+        : _loc(`${described}.${target.template.type ? "each" : "any"}`, { special }),
+      sheet: affectsConfig?.counted ? fmt(
+        count ? formatNumber(count) : _loc(`DND5E.TARGET.Count.${target.template.type ? "Every" : "Any"}`),
+        `${affectsConfig.counted}.${count ? pr.select(count) : "other"}`, { capitalize }
+      ).capitalize() : (affectsConfig?.label ?? ""),
+      statblock: fmt(formatNumber(count || 1, { words: true }), `${counted}.${pr.select(count || 1)}`)
     };
 
     return { affects, template };

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -839,7 +839,9 @@ export default class Item5e extends SystemDocumentMixin(Item) {
       ...this.system.chatProperties ?? [],
       ...this.system.equippableItemCardProperties ?? [],
       ...PropertyField.getUsageProperties(usage)
-    ], { ...usage, properties: this.system.properties });
+    ].filter(p => {
+      return (p.type !== "duration") || (usage.duration.units !== "inst") || this.system.alwaysShowDuration;
+    }), { ...usage, properties: this.system.properties });
 
     return context;
   }

--- a/templates/effects/parts/effect-summary.hbs
+++ b/templates/effects/parts/effect-summary.hbs
@@ -2,6 +2,6 @@
     {{{ description }}}
 
     <div class="item-properties pills">
-        {{#each properties}}<span class="tag pill transparent pill-xs">{{this}}</span>{{/each}}
+        {{#each properties}}<span class="tag pill transparent">{{this}}</span>{{/each}}
     </div>
 </div>

--- a/templates/items/parts/item-summary.hbs
+++ b/templates/items/parts/item-summary.hbs
@@ -2,6 +2,6 @@
     {{{description}}}
 
     <div class="item-properties pills">
-        {{#each properties}}<span class="tag pill transparent pill-xs">{{this}}</span>{{/each}}
+        {{#each properties}}<span class="tag pill transparent">{{this}}</span>{{/each}}
     </div>
 </div>


### PR DESCRIPTION
Precursor to the chat card redesign. I did it as one larger body of work but tried to find some things I could split off, so there is some duplicating of pills in chat cards in this PR that gets fixed in the later PR.

Summary of the changes is:
- Reworked some of our countable lang strings so that we could isolate the noun part and separately capitalise/lowercase it. This only become visible now that pills are not all uppercased. We had some places where the pill would read, e.g. '1 minute' next to other pills which were all title case like 'Bonus Action'.
- Removed all the various special-case pill styles and replaced them with a single, unified 'small' pill style. We still have 'large' pills that appear on the character sheet details tab, and 'extra large' pills that aren't really pills that we use for class/species/background items. Those are unchanged. All other places pills appear: NPC/Vehicle sidebar, expanded inventory descriptions, item sheet footers, all of them are standardised to one style.
- Added the concept of 'identity' properties. Not particularly rigorously defined but just a way I could split out 'Martial Ranged Weapon' to '[Weapon] [Martial] [Ranged]' in some contexts (i.e. chat cards) but leave them as 'Martial Ranged Weapon' in other contexts (like subtitles and legacy cards). Probably some more pills can be split out this way but I was mainly focused on weapons & spells.
- Did a pass on trimming some redundant/unnecessary pills. Again, probably some more could use this treatment but for now we strip out the 'instantaneous' duration from anything that's not a spell. A non-instantaneous duration will still show up though. We also strip out 'Equipped' but will flag an item as 'Unequipped'. Essentially things that are assumed to be default and we probably don't need a pill for them, but exceptions to this default are still shown.

<img width="926" height="929" alt="image" src="https://github.com/user-attachments/assets/1253ea7d-01c6-4343-8963-76f9d8afa1b6" />
