### PR TITLE
Refactor chat cards around compact design. Add dark mode theming.

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -635,6 +635,9 @@ Hooks.on("renderSettings", (app, html) => applications.settings.sidebar.renderSe
 
 Hooks.on("applyCompendiumArt", (documentClass, ...args) => documentClass.applyCompendiumArt?.(...args));
 
+Hooks.on("renderChatInput", (_log, elements) => {
+  elements["#chat-notifications"]?.querySelector(".chat-log")?.classList.remove("themed", "theme-light");
+});
 Hooks.on("renderChatPopout", documents.ChatMessage5e.onRenderChatPopout);
 Hooks.on("getChatMessageContextOptions", documents.ChatMessage5e.addChatMessageContextOptions);
 

--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -635,10 +635,9 @@ Hooks.on("renderSettings", (app, html) => applications.settings.sidebar.renderSe
 
 Hooks.on("applyCompendiumArt", (documentClass, ...args) => documentClass.applyCompendiumArt?.(...args));
 
-Hooks.on("renderChatInput", (_log, elements) => {
-  elements["#chat-notifications"]?.querySelector(".chat-log")?.classList.remove("themed", "theme-light");
-});
+Hooks.on("renderChatInput", () => applications.ChatLog5e.applyTheme());
 Hooks.on("renderChatPopout", documents.ChatMessage5e.onRenderChatPopout);
+Hooks.on("renderChatPopout", () => applications.ChatLog5e.applyTheme());
 Hooks.on("getChatMessageContextOptions", documents.ChatMessage5e.addChatMessageContextOptions);
 
 Hooks.on("renderChatLog", (app, html, data) => {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1756,6 +1756,12 @@
     "PartyMembers": "Party Members",
     "Title": "Request"
   },
+  "Row": {
+    "Actions": "Item actions",
+    "Properties": "Item properties",
+    "rollCheck": "Ability checks",
+    "rollSave": "Saving throws"
+  },
   "TURN": {
     "NoCombatant": "Combatant no longer exists!"
   }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1734,6 +1734,13 @@
 
 "DND5E.CHATMESSAGE": {
   "Activities": "Activities",
+  "Button": {
+    "rollAttack": "Attack",
+    "rollCheck": "Ability Check",
+    "rollDamage": "Damage",
+    "rollFormula": "Roll",
+    "rollSave": "Saving Throw"
+  },
   "Deltas": {
     "Created": "Item Created",
     "Deleted": "Item Deleted",

--- a/lang/en.json
+++ b/lang/en.json
@@ -6766,6 +6766,15 @@
     "Player": "Only Display for Friendly Tokens",
     "None": "Never Display"
   },
+  "CHATLOG": {
+    "Hint": "Specify a theme for the chat log. By default this will inherit from the Application theme.",
+    "Name": "Chat Log",
+    "Options": {
+      "blank": "Default",
+      "dark": "Dark",
+      "light": "Light"
+    }
+  },
   "COLLAPSETRAYS": {
     "Name": "Collapse Trays in Chat",
     "Hint": "Automatically collapse damage, hit, and effect trays that appear in chat cards.",

--- a/less/dnd5e.less
+++ b/less/dnd5e.less
@@ -36,6 +36,9 @@
 @import "v2/region-behaviors.less";
 @import "v2/blocks.less";
 
+/* V3 */
+@import "v3/chat.less";
+
 /* High Contrast */
 @import "v2/high-contrast/apps.less";
 @import "v2/high-contrast/character.less";

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -22,6 +22,7 @@
 
   /* Header */
   .message-header {
+    color: var(--color-text-secondary);
     margin-bottom: .375rem;
 
     .message-delete { display: none; }
@@ -73,18 +74,13 @@
       color: var(--color-text-primary);
     }
 
-    .subtitle {
-      font-size: var(--font-size-11);
-      color: var(--color-text-secondary);
-    }
+    .subtitle { font-size: var(--font-size-11); }
 
     .message-metadata {
       font-size: var(--font-size-10);
       transform: translate(2px, -4px);
       flex: none;
     }
-
-    time { color: var(--color-text-secondary); }
 
     .flavor-text {
       margin-block-start: 4px;

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -2,31 +2,23 @@
 /*  Chat Cards                        */
 /* ---------------------------------- */
 
-:is(.chat-popout, #chat-log, .chat-log) .message {
+:is(.chat-popout, #chat-log, .chat-log) .message:not(.compact) {
   padding: .5rem;
-  border-width: 1px;
+  border: var(--dnd5e-border-gold);
   border-block-end-width: 2px;
   border-radius: 6px;
   font-family: var(--dnd5e-font-roboto);
   font-size: var(--font-size-13);
   position: relative;
-  background: var(--dnd5e-color-parchment);
-
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: transparent url("ui/texture-gray1.webp") no-repeat top left;
-    border-radius: 6px;
-  }
+  background: var(--dnd5e-chat-background);
+  color: var(--color-text-primary);
 
   > .message-header, > .message-content { position: relative; }
 
-  &.emote { background-color: #f3edde; }
-  &.whisper { background-color: #e8e8ef; }
-  &.whisper::before { filter: grayscale(1); }
-  &.blind { background-color: #f5eaf5; }
-  &.blind::before { mix-blend-mode: luminosity; }
+  &.blind, &.emote, &.whisper { border-block-end-width: 3px; }
+  &.emote { border-block-end-color: #e5af29; }
+  &.whisper { border-block-end-color: #7d7df1; }
+  &.blind { border-block-end-color: #c12fc1; }
 
   /* Header */
   .message-header {
@@ -60,7 +52,7 @@
         object-position: top;
       }
       .avatar.token :is(img, video) {
-        object-fix: contain;
+        object-fit: contain;
         object-position: center;
       }
     }
@@ -141,7 +133,7 @@
     &::before {
       content: "";
       width: 36px;
-      border-left: 1px solid #bbb;
+      border-inline-start: var(--dnd5e-border-separator-heavy);
     }
 
     &::after {
@@ -411,7 +403,7 @@
 /*  Item Cards                        */
 /* ---------------------------------- */
 
-.dnd5e2 .chat-card {
+.dnd5e2:not(.compact) .chat-card {
   display: flex;
   flex-direction: column;
   gap: .375rem;
@@ -420,9 +412,9 @@
 
   .description {
     padding: .5rem;
-    border: 1px solid var(--dnd5e-color-gold);
+    border: var(--dnd5e-border-gold);
     border-radius: 3px;
-    background: var(--dnd5e-color-card);
+    background: var(--dnd5e-background-card);
     overflow: hidden;
 
     .summary {
@@ -506,18 +498,18 @@
   }
 }
 
-.dice-roll + .chat-card {
+.message:not(.compact) .dice-roll + .chat-card {
   margin-block-start: .375rem;
 }
 
 .chat-sidebar, .chat-popout, #chat-notifications {
-  &:not([data-gm-user]) .card-header[data-concealed] {
+  &:not([data-gm-user]) .message:not(.compact) .card-header[data-concealed] {
     .summary { cursor: inherit; }
     .fa-chevron-down, .details { display: none; }
   }
 }
 
-.message {
+.message:not(.compact) {
   p.supplement {
     margin: 0;
     font-size: var(--font-size-11);
@@ -729,18 +721,20 @@
 /* ---------------------------------- */
 
 enchantment-application.dnd5e2 {
-  margin: 4px;
+  margin: 4px 0 -6px;
 
   .drop-area {
-    background: var(--dnd5e-color-card);
-    border: 1px dashed var(--dnd5e-color-crimson);
-    color: inherit;
-    font-size: inherit;
-    font-style: normal;
     gap: 4px;
-    min-block-size: 40px;
     place-content: normal;
     text-align: start;
+
+    &.empty { min-block-size: 38px; }
+
+    &:not(.empty) {
+      color: inherit;
+      font-size: var(--font-size-12);
+      font-style: normal;
+    }
 
     p {
       place-content: center;
@@ -753,14 +747,14 @@ enchantment-application.dnd5e2 {
       gap: 6px;
 
       &:not(:last-child) {
-        border-block-end: 1px dotted var(--color-border-light-2);
+        border-block-end: var(--dnd5e-border-dotted);
         padding-block-end: 4px;
       }
 
       > img {
-        block-size: 32px;
-        inline-size: 32px;
-        flex: 0 0 32px;
+        block-size: 24px;
+        inline-size: 24px;
+        flex: 0 0 24px;
       }
       > .name {
         flex: 1;
@@ -774,8 +768,7 @@ enchantment-application.dnd5e2 {
   }
 
   .count-area {
-    margin-block-start: 2px;
-    margin-inline-end: 4px;
+    margin: 4px 4px 0;
     font-size: var(--font-size-10);
     text-align: end;
     text-transform: uppercase;
@@ -849,7 +842,7 @@ enchantment-application.dnd5e2 {
 /*  Rest & Turn Cards                 */
 /* ---------------------------------- */
 
-.dnd5e2 .chat-card {
+.dnd5e2:not(.compact) .chat-card {
   section > strong:first-child {
     display: block;
     margin-block-start: 1em;

--- a/less/v3/chat.less
+++ b/less/v3/chat.less
@@ -1,0 +1,197 @@
+/* ---------------------------------- */
+/*  Chat Cards                        */
+/* ---------------------------------- */
+
+.chat-log, .chat-popout {
+  .message.compact {
+    background: var(--dnd5e-chat-background);
+    border: var(--dnd5e-border-gold);
+    border-block-end-width: 2px;
+    border-radius: 6px;
+    color: var(--color-text-primary);
+    font-family: var(--dnd5e-font-roboto);
+    font-size: var(--font-size-13);
+    padding: 8px;
+
+    &.blind, &.emote, &.whisper { border-block-end-width: 3px; }
+    &.emote { border-block-end-color: #e5af29; }
+    &.whisper { border-block-end-color: #7d7df1; }
+    &.blind { border-block-end-color: #c12fc1; }
+
+    .message-content {
+      color: var(--color-text-primary);
+      overflow: visible;
+    }
+
+    .message-delete { display: none; }
+
+    .message-header {
+      align-items: center;
+      color: var(--color-text-primary);
+      gap: 8px;
+      margin-block-end: 4px;
+    }
+
+    .message-metadata {
+      color: var(--color-text-secondary);
+      flex: none;
+      font-size: var(--font-size-10);
+    }
+
+    .message-sender {
+      flex: 1;
+      font-family: var(--dnd5e-font-roboto-slab);
+      font-size: var(--font-size-14);
+      font-weight: bold;
+      font-variant: small-caps;
+
+      &:hover {
+        cursor: var(--cursor-pointer);
+        text-shadow: 0 0 8px var(--color-shadow-primary);
+      }
+    }
+
+    .chat-card {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .card-header {
+      --icon-size: 24px;
+      display: flex;
+      gap: 4px;
+
+      &[data-action] { cursor: var(--cursor-pointer); }
+
+      .activity-icon, .item-icon {
+        --size: 24px;
+
+        dnd5e-icon, img {
+          --icon-fill: var(--activity-icon-color);
+          --gold-icon-size: var(--size);
+          max-width: unset;
+        }
+      }
+
+      .activity-icon {
+        block-size: var(--size);
+        inline-size: var(--size);
+
+        &:has(> dnd5e-icon) {
+          border: 1px solid var(--dnd5e-color-gold);
+          border-radius: 4px;
+          padding: 2px;
+        }
+
+        dnd5e-icon { --icon-size: calc(var(--size) - 6px); }
+      }
+
+      .item-icon:hover { box-shadow: 0 0 6px var(--dnd5e-color-gold); }
+
+      .name-stacked {
+        flex: 1;
+        justify-content: space-between;
+        line-height: 1;
+
+        .title { font-size: var(--font-size-12); }
+      }
+
+      .chevron {
+        block-size: 24px;
+        font-size: var(--font-size-11);
+        inline-size: 24px;
+        place-content: center;
+
+        .fa-chevron-down { transition: transform 250ms ease; }
+      }
+
+      &.collapsed .chevron .fa-chevron-down { transform: rotate(-90deg); }
+    }
+
+    .card-flavor {
+      color: var(--color-text-secondary);
+      font-family: var(--dnd5e-font-roboto-condensed);
+      font-size: var(--font-size-11);
+      font-style: italic;
+
+      .content-link, .inline-roll { --content-link-text-color: var(--color-text-secondary); }
+    }
+
+    .card-description {
+      background: var(--dnd5e-chat-description-background);
+      border-block: 1px dashed var(--dnd5e-color-blue-gray-3);
+      font-size: var(--font-size-11);
+      margin-inline: -8px;
+      padding-inline: 16px;
+      text-align: justify;
+
+      &.collapsed { border: none; }
+
+      .wrapper {
+        p:first-child { margin-block-start: 12px; }
+        p:last-child { margin-block-end: 12px; }
+      }
+    }
+
+    .icon-row {
+      align-items: center;
+      display: flex;
+      gap: 8px;
+
+      > i {
+        color: var(--dnd5e-color-gold);
+        font-size: var(--font-size-12);
+        padding-block-start: 2px;
+      }
+
+      ul {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        justify-content: end;
+        margin-left: auto;
+      }
+
+      button {
+        --icon-fill: currentcolor;
+        --button-background-color: var(--dnd5e-chat-button-background);
+        --button-border-color: var(--dnd5e-chat-button-border);
+        --button-hover-background-color: var(--dnd5e-chat-button-hover-background);
+        --button-hover-border-color: var(--dnd5e-chat-button-hover-border);
+        --button-size: 24px;
+        block-size: var(--button-size);
+        box-shadow: none;
+        padding: 0;
+
+        &:hover:not(:disabled), &:focus { box-shadow: var(--dnd5e-chat-button-hover-shadow); }
+        &[hidden] { display: none; }
+      }
+    }
+
+    p.supplement {
+      color: var(--color-text-secondary);
+      font-size: var(--font-size-11);
+      margin: 0;
+
+      > strong {
+        color: var(--color-text-primary);
+        font-size: var(--font-size-10);
+        margin-inline-end: .25rem;
+        text-transform: uppercase;
+      }
+    }
+  }
+}
+
+/* ---------------------------------- */
+/*  Hidden Content                    */
+/* ---------------------------------- */
+
+.chat-sidebar, .chat-popout, #chat-notifications {
+  &:not([data-gm-user]) .message.compact .card-header[data-concealed] {
+    cursor: inherit;
+    .chevron { display: none; }
+    & ~ .card-description { display: none; }
+  }
+}

--- a/less/v3/chat.less
+++ b/less/v3/chat.less
@@ -15,7 +15,7 @@
 
     &.blind, &.emote, &.whisper { border-block-end-width: 3px; }
     &.emote { border-block-end-color: #e5af29; }
-    &.whisper { border-block-end-color: #7d7df1; }
+    &.whisper { border-block-end-color: #6b5cff; }
     &.blind { border-block-end-color: #c12fc1; }
 
     .message-content {
@@ -28,8 +28,13 @@
     .message-header {
       align-items: center;
       color: var(--color-text-primary);
-      gap: 8px;
       margin-block-end: 4px;
+
+      .whisper-to {
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-10);
+        font-style: italic;
+      }
     }
 
     .message-metadata {
@@ -39,16 +44,14 @@
     }
 
     .message-sender {
+      cursor: var(--cursor-pointer);
       flex: 1;
       font-family: var(--dnd5e-font-roboto-slab);
       font-size: var(--font-size-14);
       font-weight: bold;
       font-variant: small-caps;
 
-      &:hover {
-        cursor: var(--cursor-pointer);
-        text-shadow: 0 0 8px var(--color-shadow-primary);
-      }
+      &:hover { text-shadow: 0 0 8px var(--color-shadow-primary); }
     }
 
     .chat-card {
@@ -79,7 +82,7 @@
         inline-size: var(--size);
 
         &:has(> dnd5e-icon) {
-          border: 1px solid var(--dnd5e-color-gold);
+          border: 1px solid transparent;
           border-radius: 4px;
           padding: 2px;
         }

--- a/less/variables/dark.less
+++ b/less/variables/dark.less
@@ -234,6 +234,15 @@
   --dnd5e-statblock-text-primary: var(--color-text-primary);
   --dnd5e-statblock-text-secondary: color-mix(in oklab, var(--color-text-primary), transparent 25%);
   --dnd5e-statblock-title-border: var(--dnd5e-color-blue-gray-3);
+
+  /* Chat Cards */
+  --dnd5e-chat-background: var(--dnd5e-background-texture-denim);
+  --dnd5e-chat-description-background: rgb(255 255 255 / 3%);
+  --dnd5e-chat-button-background: var(--dnd5e-color-blue-gray-1);
+  --dnd5e-chat-button-border: var(--dnd5e-color-blue-gray-4);
+  --dnd5e-chat-button-hover-background: var(--dnd5e-color-blue-gray-3);
+  --dnd5e-chat-button-hover-border: var(--dnd5e-color-blue-gray-4);
+  --dnd5e-chat-button-hover-shadow: none;
 }
 
 @scope (.theme-dark) to (.themed) {

--- a/less/variables/light.less
+++ b/less/variables/light.less
@@ -230,6 +230,15 @@
   --dnd5e-statblock-text-primary: rgb(31, 30, 30);
   --dnd5e-statblock-text-secondary: rgb(73 72 73 / .75);
   --dnd5e-statblock-title-border: currentcolor;
+
+  /* Chat Cards */
+  --dnd5e-chat-background: var(--dnd5e-color-parchment) url("ui/texture-gray1.webp") no-repeat top left;
+  --dnd5e-chat-description-background: transparent;
+  --dnd5e-chat-button-background: var(--dnd5e-color-card);
+  --dnd5e-chat-button-border: var(--color-border-light-2);
+  --dnd5e-chat-button-hover-background: var(--dnd5e-color-card);
+  --dnd5e-chat-button-hover-border: var(--dnd5e-color-gold);
+  --dnd5e-chat-button-hover-shadow: 0 0 5px var(--color-shadow-primary);
 }
 
 @scope (.theme-light) to (.themed) {

--- a/module/applications/chat-log.mjs
+++ b/module/applications/chat-log.mjs
@@ -12,11 +12,24 @@ export default class ChatLog5e extends foundry.applications.sidebar.tabs.ChatLog
 
   /* -------------------------------------------- */
 
+  /**
+   * Apply the configured chat log theme.
+   */
+  static applyTheme() {
+    const theme = game.settings.get("dnd5e", "chatLogTheme");
+    for ( const element of foundry.applications.detached.querySelectorAll(".chat-log, .chat-popout") ) {
+      element.classList.remove("themed", "theme-light", "theme-dark");
+      if ( theme ) element.classList.add("themed", `theme-${theme}`);
+    }
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   async _onFirstRender(context, options) {
     const scroll = this.element.querySelector(".chat-scroll");
     const log = this.element.querySelector(".chat-log");
-    log.classList.remove("themed", "theme-light");
+    this.constructor.applyTheme();
     new MutationObserver(this.#onLogMutated.bind(this)).observe(log, { childList: true });
     this.#intersections = new IntersectionObserver(this.#onCardIntersects.bind(this), { root: scroll });
     return super._onFirstRender(context, options);

--- a/module/applications/chat-log.mjs
+++ b/module/applications/chat-log.mjs
@@ -16,6 +16,7 @@ export default class ChatLog5e extends foundry.applications.sidebar.tabs.ChatLog
   async _onFirstRender(context, options) {
     const scroll = this.element.querySelector(".chat-scroll");
     const log = this.element.querySelector(".chat-log");
+    log.classList.remove("themed", "theme-light");
     new MutationObserver(this.#onLogMutated.bind(this)).observe(log, { childList: true });
     this.#intersections = new IntersectionObserver(this.#onCardIntersects.bind(this), { root: scroll });
     return super._onFirstRender(context, options);

--- a/module/applications/components/enchantment-application.mjs
+++ b/module/applications/components/enchantment-application.mjs
@@ -130,6 +130,7 @@ export default class EnchantmentApplicationElement extends MaybeAdoptable {
     });
     if ( enchantedItems.length ) this.dropArea.replaceChildren(...enchantedItems);
     else this.dropArea.innerHTML = `<p>${_loc("DND5E.ENCHANT.DropArea")}</p>`;
+    this.dropArea.classList.toggle("empty", !enchantedItems.length);
     if ( this.countArea ) this.countArea.querySelector(".current").innerText = enchantedItems.length;
   }
 

--- a/module/applications/context-menu.mjs
+++ b/module/applications/context-menu.mjs
@@ -12,7 +12,7 @@ export default class ContextMenu5e extends foundry.applications.ux.ContextMenu {
   /* -------------------------------------------- */
 
   /**
-   * Trigger a context menu event in response to a normal click on a additional options button.
+   * Trigger a context menu event in response to a normal click on an additional options button.
    * @param {PointerEvent} event
    */
   static triggerEvent(event) {

--- a/module/data/abstract/chat-message-data-model.mjs
+++ b/module/data/abstract/chat-message-data-model.mjs
@@ -1,7 +1,7 @@
 import { loadingTooltip } from "../../utils.mjs";
 
 /**
- * @import { ChatMessageDataModelMetadata } from "./types.mjs";
+ * @import { ChatMessageDataModelMetadata } from "./_types.mjs";
  */
 
 /**
@@ -16,6 +16,8 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
    */
   static metadata = Object.freeze({
     actions: {
+      showDocument: ChatMessageDataModel.#showDocument,
+      toggleDescription: ChatMessageDataModel.#toggleDescription,
       use: ChatMessageDataModel.#useActivity
     },
     template: ""
@@ -57,7 +59,7 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
   async getHTML(element, options) {
     const rendered = await this.render(options);
     if ( rendered ) element.querySelector(".message-content").innerHTML = rendered;
-    this.parent._enrichChatCard(element);
+    this.parent._enrichChatCard(element, this._getEnrichmentOptions());
     this.parent._collapseTrays(element);
 
     const click = this.#onClick.bind(this);
@@ -76,6 +78,17 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
   async render(options) {
     if ( !this.template ) return "";
     return foundry.applications.handlebars.renderTemplate(this.template, await this._prepareContext(options));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Options to forward to ChatMessage5e#_enrichChatCard.
+   * @returns {ChatMessageEnrichmentOptions}
+   * @protected
+   */
+  _getEnrichmentOptions() {
+    return {};
   }
 
   /* -------------------------------------------- */
@@ -145,6 +158,51 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
    * @protected
    */
   _onClickAction(event, target) {}
+
+  /* -------------------------------------------- */
+
+  /**
+   * Context menu options for button groups.
+   * @returns {ContextMenuEntry[]}
+   * @protected
+   */
+  _getButtonGroupContextOptions() {
+    return [];
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle showing a Document's sheet.
+   * @this {ChatMessageDataModel}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Action target.
+   * @returns {Promise}
+   */
+  static async #showDocument(event, target) {
+    event.stopPropagation();
+    const { uuid } = target.closest("[data-uuid]")?.dataset ?? {};
+    const doc = await fromUuid(uuid);
+    return doc?.sheet.render({ force: true });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle toggling the card's description.
+   * @this {ChatMessageDataModel}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Action target.
+   */
+  static #toggleDescription(event, target) {
+    const card = target.closest(".chat-card");
+    target.classList.toggle("collapsed");
+    card.querySelector(".card-description")?.classList.toggle("collapsed");
+
+    // Clear the height from the chat popout container so that it appropriately resizes.
+    const popout = card.closest(".chat-popout");
+    if ( popout ) popout.style.height = "";
+  }
 
   /* -------------------------------------------- */
 

--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -216,6 +216,10 @@ export default class ItemDataModel extends SystemDataModel {
     const source = (await activity?.getCardData()) ?? {};
     const usage = this.getUsageData({ activity });
 
+    if ( source.activity?.chatFlavor ) {
+      source.activity.chatFlavor = await TextEditor.enrichHTML(source.activity.chatFlavor, enrichmentOptions);
+    }
+
     let description = source.description ?? "";
     description ||= (identified === false) ? unidentified?.description : (desc.chat || desc.value);
 

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -5,7 +5,7 @@ import { DamageData } from "../shared/damage-field.mjs";
 const { BooleanField } = foundry.data.fields;
 
 /**
- * @import { EnchantmentActiveEffectSystemData } from "./types.mjs";
+ * @import { EnchantmentActiveEffectSystemData } from "./_types.mjs";
  */
 
 /**

--- a/module/data/chat-message/_types.mjs
+++ b/module/data/chat-message/_types.mjs
@@ -153,7 +153,9 @@
 
 /**
  * @typedef ItemMessageProperty
- * @property {string} type  Kind of property, which determines how it is rendered and what other data it carries.
+ * @property {boolean} identity  Whether this property identifies what the item is, and so is displayed only on cards
+ *                               that do not render it in their subtitle.
+ * @property {string} type       Kind of property, which determines how it is rendered and what other data it carries.
  */
 
 /* -------------------------------------------- */

--- a/module/data/chat-message/item-message-data.mjs
+++ b/module/data/chat-message/item-message-data.mjs
@@ -90,7 +90,8 @@ export default class ItemMessageData extends ChatMessageDataModel {
           entries: PropertyField.getLabels(showIdentity ? this.properties : this.properties.filter(p => !p.identity), {
             ...this, properties: item.properties
           }),
-          icon: "fa-solid fa-tag"
+          icon: "fa-solid fa-tag",
+          label: "DND5E.CHATMESSAGE.Row.Properties"
         }
       },
       subtitle: subtitle.filterJoin(" • "),

--- a/module/data/chat-message/item-message-data.mjs
+++ b/module/data/chat-message/item-message-data.mjs
@@ -65,18 +65,44 @@ export default class ItemMessageData extends ChatMessageDataModel {
   }, { inplace: false }));
 
   /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * Whether the properties that identify the item are displayed as pills, rather than in the card's subtitle.
+   * @type {boolean}
+   */
+  get showIdentity() {
+    return false;
+  }
+
+  /* -------------------------------------------- */
   /*  Rendering                                   */
   /* -------------------------------------------- */
 
   /** @override */
   async _prepareContext(options) {
-    const { concealed, description, item, subtitle } = this;
+    const { concealed, description, item, showIdentity, subtitle } = this;
     return {
       concealed, description, item,
-      properties: PropertyField.getLabels(this.properties, { ...this, properties: item.properties }),
+      rows: {
+        properties: {
+          entries: PropertyField.getLabels(showIdentity ? this.properties : this.properties.filter(p => !p.identity), {
+            ...this, properties: item.properties
+          }),
+          icon: "fa-solid fa-tag"
+        }
+      },
       subtitle: subtitle.filterJoin(" • "),
       supplements: this._prepareSupplements()
     };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _getEnrichmentOptions() {
+    return { avatar: false };
   }
 
   /* -------------------------------------------- */
@@ -100,8 +126,9 @@ export default class ItemMessageData extends ChatMessageDataModel {
   /** @inheritDoc */
   _onRender(element) {
     super._onRender(element);
+    element.classList.add("compact");
     if ( game.settings.get("dnd5e", "autoCollapseItemCards") ) {
-      element.querySelectorAll(".description.collapsible").forEach(el => el.classList.add("collapsed"));
+      element.querySelectorAll(".card-header, .card-description").forEach(el => el.classList.add("collapsed"));
     }
   }
 }

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -101,9 +101,9 @@ export default class UsageMessageData extends ItemMessageData {
   async _prepareContext(options) {
     let context;
     if ( this.parent.content ) context = {
-      content: await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-        this.parent.content, { rollData: this.parent.getRollData() }
-      )
+      content: await foundry.applications.ux.TextEditor.implementation.enrichHTML(this.parent.content, {
+        rollData: this.parent.getRollData()
+      })
     };
     else {
       context = await super._prepareContext(options);
@@ -156,7 +156,7 @@ export default class UsageMessageData extends ItemMessageData {
       if ( hidden ) return obj;
       obj[action] ??= { icon, entries: [] };
       if ( canGroup ) {
-        context.rows[action] ??= { icon, entries: [] };
+        context.rows[action] ??= { icon, entries: [], label: `DND5E.CHATMESSAGE.Row.${action}` };
         context.rows[action].entries.push(label);
         if ( obj[action].entries.length ) {
           obj[action].entries[0].singleton = false;

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -2,7 +2,9 @@ import ItemMessageData from "./item-message-data.mjs";
 import { ActorDeltasField } from "./fields/deltas-field.mjs";
 import SourceReferenceField from "./fields/source-reference-field.mjs";
 
-const { ArrayField, DocumentIdField, NumberField, ObjectField, SchemaField, StringField } = foundry.data.fields;
+const {
+  ArrayField, BooleanField, DocumentIdField, HTMLField, NumberField, ObjectField, SchemaField, StringField
+} = foundry.data.fields;
 
 /**
  * @import { ActivityUsageChatButton } from "../../documents/activity/_types.mjs";
@@ -25,11 +27,12 @@ export default class UsageMessageData extends ItemMessageData {
     return {
       ...super.defineSchema(),
       activity: new SourceReferenceField({
-        chatFlavor: new StringField(),
+        chatFlavor: new HTMLField(),
         uuid: new StringField({ blank: false, nullable: true, required: true })
       }),
       buttons: new ArrayField(new SchemaField({
         action: new StringField({ blank: false, required: true }),
+        canGroup: new BooleanField(),
         dataset: new ObjectField(),
         icon: new StringField(),
         label: new SchemaField({
@@ -66,7 +69,32 @@ export default class UsageMessageData extends ItemMessageData {
   }
 
   /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  get showIdentity() {
+    return !!this.activity.name;
+  }
+
+  /* -------------------------------------------- */
   /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _getButtonGroupContextOptions() {
+    const { forwardAction } = ui.context.target.dataset;
+    const activity = this.parent.getAssociatedActivity();
+    if ( typeof activity?.onChatAction !== "function" ) return [];
+    return this._prepareButtons()
+      .filter(b => b.canGroup && !b.hidden && (b.action === forwardAction))
+      .map(({ icon, index, label }) => ({
+        icon, label,
+        onClick: (event, group) => {
+          group.dataset.index = index;
+          return activity.onChatAction(event, group, this.parent);
+        }
+      }));
+  }
+
   /* -------------------------------------------- */
 
   /** @inheritDoc */
@@ -79,8 +107,10 @@ export default class UsageMessageData extends ItemMessageData {
     };
     else {
       context = await super._prepareContext(options);
+      context.activity = this.activity;
       context.buttons = this._prepareButtons();
-      if ( this.activity.chatFlavor ) context.subtitle = this.activity.chatFlavor;
+      this._prepareButtonGroups(context);
+      if ( this.activity.name ) context.subtitle = this.activity.name;
     }
 
     const item = this.parent.getAssociatedItem();
@@ -100,16 +130,45 @@ export default class UsageMessageData extends ItemMessageData {
     const activity = this.parent.getAssociatedActivity();
     const isCreator = game.user.isGM || this.actor?.isOwner || this.parent.isAuthor;
     return this.buttons.map((button, index) => {
-      const descriptor = { ...button, dataset: { ...button.dataset, /** @deprecated */ action: button.action } };
-      return {
-        ...descriptor, index,
-        hidden: button.visibility === "all"
-          ? false
-          : ((button.visibility === "gm") && !game.user.isGM)
-            || !isCreator
-            || !!activity?.shouldHideChatButton(descriptor, this.parent)
-      };
+      const { action, visibility } = button;
+      let hidden = visibility !== "all";
+      if ( hidden ) {
+        hidden = (visibility === "gm") && !game.user.isGM;
+        hidden ||= !isCreator || activity?.shouldHideChatButton(button, this.parent);
+      }
+      const label = this.parent.shouldDisplayChallenge
+        ? button.label.value
+        : (button.label.hidden || button.label.value);
+      return { ...button, hidden, index, label, dataset: { ...button.dataset, /** @deprecated */ action } };
     });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare render context for button groups.
+   * @param {object} context  Render context.
+   * @protected
+   */
+  _prepareButtonGroups(context) {
+    context.buttonGroups = context.buttons.reduce((obj, button) => {
+      const { action, canGroup, hidden, icon, label } = button;
+      if ( hidden ) return obj;
+      obj[action] ??= { icon, entries: [] };
+      if ( canGroup ) {
+        context.rows[action] ??= { icon, entries: [] };
+        context.rows[action].entries.push(label);
+        if ( obj[action].entries.length ) {
+          obj[action].entries[0].singleton = false;
+          return obj;
+        }
+        obj[action].entries.push({ ...button, label: `DND5E.CHATMESSAGE.Button.${action}`, singleton: true });
+      } else {
+        obj[action].entries.push(button);
+      }
+      return obj;
+    }, {});
+    if ( foundry.utils.isEmpty(context.buttonGroups) ) delete context.buttonGroups;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/_types.mjs
+++ b/module/documents/_types.mjs
@@ -30,6 +30,13 @@
 /* -------------------------------------------- */
 
 /**
+ * @typedef ChatMessageEnrichmentOptions
+ * @property {boolean} [avatar=true]  Whether to inject an avatar image.
+ */
+
+/* -------------------------------------------- */
+
+/**
  * @typedef {ActorUpdatesDescription} CombatRecoveryResults
  * @property {BasicRoll[]} rolls  Any recovery rolls performed.
  */

--- a/module/documents/activity/_types.mjs
+++ b/module/documents/activity/_types.mjs
@@ -73,6 +73,7 @@
 /**
  * @typedef ActivityUsageChatButton
  * @property {string} action                      Action performed when the button is clicked.
+ * @property {boolean} [canGroup]                 Whether this button can be grouped with others that share an action.
  * @property {object} [dataset]                   Parameters passed to the action that handles the button.
  * @property {string} icon                        FontAwesome classes or a path to an icon image.
  * @property {object} label                       Labels displayed on the button.

--- a/module/documents/activity/attack.mjs
+++ b/module/documents/activity/attack.mjs
@@ -50,7 +50,7 @@ export default class AttackActivity extends ActivityMixin(BaseAttackActivityData
   _usageChatButtons(message) {
     const buttons = [{
       action: "rollAttack",
-      icon: "systems/dnd5e/icons/svg/trait-weapon-proficiencies.svg",
+      icon: "fa-solid fa-sword",
       label: { value: "DND5E.Attack" }
     }];
     if ( this.damage.parts.length || this.item.system.properties?.has("amm") ) buttons.push({

--- a/module/documents/activity/check.mjs
+++ b/module/documents/activity/check.mjs
@@ -57,8 +57,8 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
       const button = {
         dataset,
         action: "rollCheck",
-        icon: checkType === "tool" ? "fa-solid fa-hammer"
-          : "systems/dnd5e/icons/svg/ability-score-improvement.svg",
+        canGroup: true,
+        icon: checkType === "tool" ? "fa-solid fa-hammer" : "fa-solid fa-dumbbell",
         label: {
           hidden: check,
           value: dc ? _loc("EDITOR.DND5E.Inline.DC", { check, dc }) : check
@@ -67,7 +67,7 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
       if ( this.check.visible ) button.visibility = "all";
       buttons.push(button);
     };
-    const wrap = check => _loc("EDITOR.DND5E.Inline.CheckShort", { check });
+    const wrap = check => _loc("EDITOR.DND5E.Inline.CheckLong", { check });
 
     const associated = Array.from(this.check.associated);
     if ( !associated.length && (this.item.type === "tool") ) associated.push(this.item.system.type.baseItem);
@@ -86,7 +86,6 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
 
   /**
    * Handle performing an ability check.
-   * @this {CheckActivity}
    * @param {PointerEvent} event     Triggering click event.
    * @param {HTMLElement} target     The capturing HTML element which defined a [data-action].
    * @param {ChatMessage5e} message  Message associated with the activation.

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -996,8 +996,7 @@ export default function ActivityMixin(Base) {
         "flags.dnd5e": { consumed, scaling }
       }, { keepId: true }) : this.item;
       const activity = item.system.activities.get(this.id);
-
-      const action = target.dataset.action;
+      const action = target.dataset.action ?? message.system.getButton(target)?.action;
       const handler = this.metadata.usage?.actions?.[action];
       target.disabled = true;
       try {
@@ -1006,7 +1005,7 @@ export default function ActivityMixin(Base) {
         else if ( action === "refundResource" ) await this.#refundResource(event, target, message);
         else if ( action === "placeTemplate" ) await this.#placeTemplate();
         else await activity._onChatAction(event, target, message);
-      } catch(err) {
+      } catch (err) {
         Hooks.onError("Activity#onChatAction", err, { log: "error", notify: "error" });
       } finally {
         target.disabled = false;
@@ -1273,7 +1272,9 @@ export default function ActivityMixin(Base) {
      */
     async _usageChatContext(message) {
       const data = await this.item.system.getCardData({ activity: this });
-      const properties = PropertyField.getLabels(data.properties, { ...data, properties: data.item.properties });
+      const properties = PropertyField.getLabels(data.properties.filter(p => !p.identity), {
+        ...data, properties: data.item.properties
+      });
       const supplements = [];
       if ( this.activation.condition ) {
         supplements.push(`<strong>${_loc("DND5E.Trigger")}</strong> ${this.activation.condition}`);

--- a/module/documents/activity/save.mjs
+++ b/module/documents/activity/save.mjs
@@ -47,6 +47,7 @@ export default class SaveActivity extends ActivityMixin(BaseSaveActivityData) {
       const promptTitle = _loc("DND5E.SavePromptTitle", { ability });
       const button = {
         action: "rollSave",
+        canGroup: true,
         dataset: { dc, ability: abilityId },
         icon: "fa-solid fa-shield-heart",
         label: {

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -1,5 +1,10 @@
 import aggregateDamageRolls from "../dice/aggregate-damage-rolls.mjs";
 import TargetsField from "../data/chat-message/fields/targets-field.mjs";
+import ContextMenu5e from "../applications/context-menu.mjs";
+
+/**
+ * @import { ChatMessageEnrichmentOptions } from "./_types.mjs";
+ */
 
 export default class ChatMessage5e extends ChatMessage {
 
@@ -119,7 +124,6 @@ export default class ChatMessage5e extends ChatMessage {
       if ( game.settings.get("dnd5e", "autoCollapseItemCards") ) {
         html.querySelectorAll(".description.collapsible").forEach(el => el.classList.add("collapsed"));
       }
-
       await this._enrichChatCard(html);
       this._collapseTrays(html);
     }
@@ -164,62 +168,15 @@ export default class ChatMessage5e extends ChatMessage {
   /**
    * Augment the chat card markup for additional styling.
    * @param {HTMLElement} html  The chat card markup.
+   * @param {ChatMessageEnrichmentOptions} [options]
    * @protected
    */
-  async _enrichChatCard(html) {
+  async _enrichChatCard(html, options={}) {
     html.querySelectorAll(".dnd5e2").forEach(el => el.classList.remove("dnd5e2")); // Legacy
     html.classList.add("dnd5e2");
 
     // Header matter
-    const token = this.getAssociatedToken();
-    const actor = this.getAssociatedActor();
-    const avatar = document.createElement("a");
-    avatar.classList.add("avatar");
-    let avatarImg = document.createElement("img");
-
-    let img;
-    let nameText;
-    if ( this.isContentVisible ) {
-      const artworkData = await actor?.getPreferredArtwork();
-      img = artworkData?.src ?? this.author?.avatar;
-      nameText = this.alias;
-      if ( artworkData?.isToken ) avatar.classList.add("token");
-      if ( artworkData?.isVideo ) {
-        avatarImg = document.createElement("video");
-        avatarImg.toggleAttribute("autoplay", true);
-        avatarImg.toggleAttribute("muted", true);
-        avatarImg.toggleAttribute("disablepictureinpicture", true);
-        avatarImg.toggleAttribute("loop", true);
-        avatarImg.toggleAttribute("playsinline", true);
-      }
-    } else {
-      img = this.author?.avatar;
-      nameText = this.author?.name ?? "";
-    }
-    img ??= CONST.DEFAULT_TOKEN;
-
-    if ( actor ) avatar.dataset.actorUuid = actor.uuid;
-    if ( token ) avatar.dataset.tokenUuid = token.uuid;
-    Object.assign(avatarImg, { src: img, alt: nameText });
-    avatar.append(avatarImg);
-
-    const name = document.createElement("span");
-    name.classList.add("name-stacked");
-    const title = document.createElement("span");
-    title.classList.add("title");
-    title.append(nameText);
-    name.append(title);
-
-    const subtitle = document.createElement("span");
-    subtitle.classList.add("subtitle");
-    if ( this.whisper.length ) subtitle.innerText = html.querySelector(".whisper-to")?.innerText ?? "";
-    if ( (nameText !== this.author?.name) && !subtitle.innerText.length ) subtitle.innerText = this.author?.name ?? "";
-
-    name.appendChild(subtitle);
-
-    const sender = html.querySelector(".message-sender");
-    sender?.replaceChildren(avatar, name);
-    html.querySelector(".whisper-to")?.remove();
+    await this._enrichHeader(html, options);
 
     // Context menu
     const metadata = html.querySelector(".message-metadata");
@@ -232,6 +189,13 @@ export default class ChatMessage5e extends ChatMessage {
     anchor.dataset.contextMenu = "";
     anchor.innerHTML = '<i class="fas fa-ellipsis-vertical fa-fw"></i>';
     metadata.appendChild(anchor);
+
+    if ( typeof this.system?._getButtonGroupContextOptions === "function" ) {
+      new ContextMenu5e(html, "button[data-group]", [], {
+        eventName: "click", jQuery: false,
+        onOpen: () => ui.context.menuItems = this.system._getButtonGroupContextOptions()
+      });
+    }
 
     // SVG icons
     html.querySelectorAll("i.dnd5e-icon").forEach(el => {
@@ -246,10 +210,77 @@ export default class ChatMessage5e extends ChatMessage {
     } else {
       html.querySelectorAll(".dice-roll").forEach(el => el.classList.add("secret-roll"));
     }
+  }
 
-    avatar.addEventListener("click", this._onTargetMouseDown.bind(this));
-    avatar.addEventListener("pointerover", this._onTargetHoverIn.bind(this));
-    avatar.addEventListener("pointerout", this._onTargetHoverOut.bind(this));
+  /* -------------------------------------------- */
+
+  /**
+   * Enrich chat card header matter.
+   * @param {HTMLElement} html  The chat card markup.
+   * @param {ChatMessageEnrichmentOptions} options
+   * @protected
+   */
+  async _enrichHeader(html, options={}) {
+    const token = this.getAssociatedToken();
+    const actor = this.getAssociatedActor();
+    const sender = html.querySelector(".message-sender");
+    let avatar;
+
+    if ( options.avatar !== false ) {
+      avatar = document.createElement("a");
+      avatar.classList.add("avatar");
+      let avatarImg = document.createElement("img");
+
+      let img;
+      let nameText;
+      if ( this.isContentVisible ) {
+        const artworkData = await actor?.getPreferredArtwork();
+        img = artworkData?.src ?? this.author?.avatar;
+        nameText = this.alias;
+        if ( artworkData?.isToken ) avatar.classList.add("token");
+        if ( artworkData?.isVideo ) {
+          avatarImg = document.createElement("video");
+          avatarImg.toggleAttribute("autoplay", true);
+          avatarImg.toggleAttribute("muted", true);
+          avatarImg.toggleAttribute("disablepictureinpicture", true);
+          avatarImg.toggleAttribute("loop", true);
+          avatarImg.toggleAttribute("playsinline", true);
+        }
+      } else {
+        img = this.author?.avatar;
+        nameText = this.author?.name ?? "";
+      }
+
+      img ??= CONST.DEFAULT_TOKEN;
+      Object.assign(avatarImg, { src: img, alt: nameText });
+      avatar.append(avatarImg);
+
+      const name = document.createElement("span");
+      name.classList.add("name-stacked");
+      const title = document.createElement("span");
+      title.classList.add("title");
+      title.append(nameText);
+      name.append(title);
+
+      const subtitle = document.createElement("span");
+      subtitle.classList.add("subtitle");
+      if ( this.whisper.length ) subtitle.innerText = html.querySelector(".whisper-to")?.innerText ?? "";
+      if ( (nameText !== this.author?.name) && !subtitle.innerText.length ) {
+        subtitle.innerText = this.author?.name ?? "";
+      }
+
+      name.appendChild(subtitle);
+      sender?.replaceChildren(avatar, name);
+      html.querySelector(".whisper-to")?.remove();
+    }
+
+    const target = avatar ?? sender;
+    if ( !target ) return;
+    if ( actor ) target.dataset.actorUuid = actor.uuid;
+    if ( token ) target.dataset.tokenUuid = token.uuid;
+    target.addEventListener("click", this._onTargetMouseDown.bind(this));
+    target.addEventListener("pointerover", this._onTargetHoverIn.bind(this));
+    target.addEventListener("pointerout", this._onTargetHoverOut.bind(this));
   }
 
   /* -------------------------------------------- */

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -911,7 +911,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
    */
   static _onChatCardToggleContent(event) {
     const header = event.target.closest(".collapsible");
-    if ( !event.target.closest(".collapsible-content.card-content") ) {
+    if ( !event.target.closest(".collapsible-content") ) {
       event.preventDefault();
       header.classList.toggle("collapsed");
 

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -1,3 +1,4 @@
+import ChatLog5e from "./applications/chat-log.mjs";
 import CompendiumBrowser from "./applications/compendium-browser.mjs";
 import BastionSettingsConfig from "./applications/settings/bastion-settings.mjs";
 import CalendarSettingsConfig from "./applications/settings/calendar-settings.mjs";
@@ -229,6 +230,25 @@ export function registerSystemSettings() {
       older: "SETTINGS.DND5E.COLLAPSETRAYS.Older",
       always: "SETTINGS.DND5E.COLLAPSETRAYS.Always"
     }
+  });
+
+  // Chat log theme
+  game.settings.register("dnd5e", "chatLogTheme", {
+    config: true,
+    hint: "SETTINGS.DND5E.CHATLOG.Hint",
+    name: "SETTINGS.DND5E.CHATLOG.Name",
+    onChange: () => ChatLog5e.applyTheme(),
+    scope: "client",
+    type: new foundry.data.fields.StringField({
+      blank: true,
+      choices: {
+        "": "SETTINGS.DND5E.CHATLOG.Options.blank",
+        dark: "SETTINGS.DND5E.CHATLOG.Options.dark",
+        light: "SETTINGS.DND5E.CHATLOG.Options.light"
+      },
+      initial: "",
+      required: true
+    })
   });
 
   // Allow Rests from Sheet

--- a/system.json
+++ b/system.json
@@ -107,7 +107,7 @@
           "item.img": ["IMAGE"],
           "targets.*.img": ["IMAGE", "VIDEO"]
         },
-        "htmlFields": ["description"]
+        "htmlFields": ["activity.chatFlavor", "description"]
       }
     },
     "Item": {

--- a/templates/chat/parts/card-face.hbs
+++ b/templates/chat/parts/card-face.hbs
@@ -1,40 +1,39 @@
 <div class="chat-card">
 
-    {{!-- Collapsible Description --}}
-    <section class="card-header description {{~#if description}} collapsible{{/if}}"
+    {{!-- Header --}}
+    <section class="card-header"{{#if description}} data-action="toggleDescription"{{/if}}
              {{~#if concealed}} data-concealed{{/if}}>
-        <header class="summary">
+        <div class="item-icon" data-action="showDocument" data-uuid="{{ item.uuid }}">
             <img class="gold-icon" src="{{ item.img }}" alt="{{ item.name }}">
-            <div class="name-stacked border">
-                <span class="title">{{ item.name }}</span>
-                {{#if subtitle}}
-                <span class="subtitle">{{{ subtitle }}}</span>
-                {{/if}}
-            </div>
-            {{#if description}}<i class="fa-solid fa-chevron-down fa-fw" inert></i>{{/if}}
-        </header>
+        </div>
+        {{#if activity.uuid}}
+        <div class="activity-icon">{{ dnd5e-icon activity.img alt=activity.name classes="gold-icon" }}</div>
+        {{/if}}
+        <div class="name-stacked">
+            <span class="title">{{ item.name }}</span>
+            {{#if subtitle}}
+            <span class="subtitle">{{{ subtitle }}}</span>
+            {{/if}}
+        </div>
         {{#if description}}
-        <section class="details collapsible-content card-content">
-            <div class="wrapper">{{{ description }}}</div>
-        </section>
+        <div class="chevron">
+            <i class="fa-solid fa-chevron-down" inert></i>
+        </div>
         {{/if}}
     </section>
 
-    {{!-- Buttons --}}
-    {{#if buttons.length}}
-    <div class="card-buttons">
-        {{#each buttons}}
-        <button type="button" data-action="{{ action }}" data-index="{{ index }}"{{#if hidden}} hidden{{/if}}>
-            {{ dnd5e-icon icon }}
-            {{#if label.hidden}}
-            <span class="visible-dc">{{ localize label.value }}</span>
-            <span class="hidden-dc">{{ localize label.hidden }}</span>
-            {{else}}
-            <span>{{ localize label.value }}</span>
-            {{/if}}
-        </button>
-        {{/each}}
-    </div>
+    {{!-- Flavor --}}
+    {{#if activity.chatFlavor}}
+    <section class="card-flavor">{{{ activity.chatFlavor }}}</section>
+    {{/if}}
+
+    {{!-- Collapsible Description --}}
+    {{#if description}}
+    <section class="card-description collapsible">
+        <div class="collapsible-content">
+            <div class="wrapper">{{{ description }}}</div>
+        </div>
+    </section>
     {{/if}}
 
     {{!-- Supplements --}}
@@ -42,14 +41,39 @@
     <p class="supplement"><strong>{{ localize label }}</strong> {{ detail }}</p>
     {{/each}}
 
-    {{!-- Properties --}}
-    {{#if properties.length}}
-    <ul class="card-footer pills unlist">
-        {{#each properties}}
-        <li class="pill transparent">
-            <span class="label">{{ this }}</span>
-        </li>
-        {{/each}}
-    </ul>
+    {{!-- Rows --}}
+    {{#each rows}}
+    {{#if entries.length}}
+    <section class="icon-row">
+        <i class="fa-fw {{ icon }}" inert></i>
+        <ul class="pills unlist">
+            {{#each entries}}
+            <li class="pill transparent">
+                <span class="label">{{ this }}</span>
+            </li>
+            {{/each}}
+        </ul>
+    </section>
+    {{/if}}
+    {{/each}}
+
+    {{!-- Buttons --}}
+    {{#if buttonGroups}}
+    <section class="icon-row">
+        <i class="fa-solid fa-fw fa-bolt" inert></i>
+        <ul class="unlist">
+            {{#each buttonGroups}}
+            {{#each entries}}
+            <li>
+                <button type="button" class="icon" data-tooltip aria-label="{{ localize label }}"
+                        {{#if (and canGroup (not singleton))}}data-group data-forward-action="{{ action }}"
+                        {{else}}data-action="{{ action }}" data-index="{{ index}}"{{/if}}>
+                    {{ dnd5e-icon icon }}
+                </button>
+            </li>
+            {{/each}}
+            {{/each}}
+        </ul>
+    </section>
     {{/if}}
 </div>

--- a/templates/chat/parts/card-face.hbs
+++ b/templates/chat/parts/card-face.hbs
@@ -45,7 +45,7 @@
     {{#each rows}}
     {{#if entries.length}}
     <section class="icon-row">
-        <i class="fa-fw {{ icon }}" inert></i>
+        <i class="fa-fw {{ icon }}" aria-label="{{ localize label }}"></i>
         <ul class="pills unlist">
             {{#each entries}}
             <li class="pill transparent">
@@ -60,7 +60,7 @@
     {{!-- Buttons --}}
     {{#if buttonGroups}}
     <section class="icon-row">
-        <i class="fa-solid fa-fw fa-bolt" inert></i>
+        <i class="fa-solid fa-fw fa-bolt" aria-label="{{ localize "DND5E.CHATMESSAGE.Row.Actions" }}"></i>
         <ul class="unlist">
             {{#each buttonGroups}}
             {{#each entries}}

--- a/templates/chat/usage-card.hbs
+++ b/templates/chat/usage-card.hbs
@@ -3,11 +3,3 @@
 {{else}}
 {{> "dnd5e.card-face" }}
 {{/if}}
-
-{{#if effects.length}}
-<effect-application class="dnd5e2">
-    {{#each effects}}
-    <option value="{{ uuid }}"></option>
-    {{/each}}
-</effect-application>
-{{/if}}


### PR DESCRIPTION
Sorry for large diff but 1/3 of it is CSS so hopefully not too arduous to review.

Summary of changes in this PR:
- Enable dark mode chat log.
- Add theming to v2 chat card styles.
- Include activity name, icon, & description in chat cards.
- New compact style for activity usage and item display chat cards.
- Collapses multiple `rollSave` and `rollCheck` into singular 'group' buttons that provide a drop-down of options on click.

<img width="400" height="1521" alt="image" src="https://github.com/user-attachments/assets/b031c5a4-778b-4bac-a4e4-071108e9283e" />

The following not attempted here but still TODO:
- Restyle effects tray (effects tray just entirely removed in this PR)
- Handling of progressive appending for additional cards spawned by the usage card