### PR TITLE
Update spells to take advantage of 6.0 features

### DIFF
--- a/packs/_source/actors24/companions/otherworldly-steeds/celestial-steed.yml
+++ b/packs/_source/actors24/companions/otherworldly-steeds/celestial-steed.yml
@@ -417,7 +417,7 @@ _id: phbostCelestial0
 img: ''
 prototypeToken:
   name: Otherworldly Steed
-  displayName: 0
+  displayName: 20
   actorLink: true
   appendNumber: false
   prependAdjective: false
@@ -436,7 +436,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 0
+  displayBars: 20
   bar1:
     attribute: attributes.hp
   bar2:
@@ -477,14 +477,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: true
+    enabled: false
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: modules/dnd-players-handbook/assets/subjects/horse-01.webp
+      texture: null
   flags: {}
   randomImg: false
   turnMarker:
@@ -506,6 +506,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -560,6 +561,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -693,8 +695,9 @@ items:
         chat: ''
       source:
         custom: ''
-        revision: 1
         rules: '2024'
+        license: CC-BY-4.0
+        revision: 1
       uses:
         max: '1'
         recovery:

--- a/packs/_source/actors24/companions/otherworldly-steeds/celestial-steed.yml
+++ b/packs/_source/actors24/companions/otherworldly-steeds/celestial-steed.yml
@@ -28,9 +28,6 @@ system:
       value: 18
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -45,9 +42,6 @@ system:
       value: 12
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -62,9 +56,6 @@ system:
       value: 14
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -79,9 +70,6 @@ system:
       value: 6
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -96,9 +84,6 @@ system:
       value: 12
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -113,9 +98,6 @@ system:
       value: 8
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -158,22 +140,6 @@ system:
     sp: 0
     cp: 0
   bonuses:
-    mwak:
-      attack: ''
-      damage: ''
-    rwak:
-      attack: ''
-      damage: ''
-    msak:
-      attack: ''
-      damage: ''
-    rsak:
-      attack: ''
-      damage: ''
-    abilities:
-      check: ''
-      save: ''
-      skill: ''
     spell:
       dc: ''
   skills:
@@ -185,7 +151,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ani:
       ability: wis
@@ -195,7 +160,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     arc:
       ability: int
@@ -205,7 +169,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ath:
       ability: str
@@ -215,7 +178,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     dec:
       ability: cha
@@ -225,7 +187,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     his:
       ability: int
@@ -235,7 +196,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ins:
       ability: wis
@@ -245,7 +205,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     itm:
       ability: cha
@@ -255,7 +214,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     inv:
       ability: int
@@ -265,7 +223,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     med:
       ability: wis
@@ -275,7 +232,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     nat:
       ability: int
@@ -285,7 +241,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prc:
       ability: wis
@@ -295,7 +250,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prf:
       ability: cha
@@ -305,7 +259,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     per:
       ability: cha
@@ -315,7 +268,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     rel:
       ability: int
@@ -325,7 +277,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     slt:
       ability: dex
@@ -335,7 +286,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ste:
       ability: dex
@@ -345,7 +295,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     sur:
       ability: wis
@@ -355,7 +304,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
   tools: {}
   spells:
@@ -396,12 +344,12 @@ system:
         min: null
         max: null
         mode: 0
-      bonus: ''
     movement:
-      walk: '60'
       units: null
       hover: false
       ignoredDifficultTerrain: []
+      speeds:
+        walk: '60'
     attunement:
       max: 3
     senses:
@@ -420,12 +368,13 @@ system:
         min: null
         max: null
         mode: 0
-      bonuses:
-        save: ''
       limit: 1
     ac:
       flat: 10
-      calc: natural
+      calcs:
+        - natural
+      formulas: []
+      override: null
     hd:
       spent: 0
     hp:
@@ -441,8 +390,6 @@ system:
         mode: 0
       success: 0
       failure: 0
-      bonuses:
-        save: ''
     spell:
       level: 0
     loyalty: {}
@@ -463,13 +410,14 @@ system:
   source:
     revision: 1
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
+    license: CC-BY-4.0
+  rolls: {}
 _id: phbostCelestial0
 img: ''
 prototypeToken:
   name: Otherworldly Steed
-  displayName: 20
+  displayName: 0
   actorLink: true
   appendNumber: false
   prependAdjective: false
@@ -488,7 +436,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 20
+  displayBars: 0
   bar1:
     attribute: attributes.hp
   bar2:
@@ -529,14 +477,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: false
+    enabled: true
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: null
+      texture: modules/dnd-players-handbook/assets/subjects/horse-01.webp
   flags: {}
   randomImg: false
   turnMarker:
@@ -558,8 +506,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -570,15 +516,14 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: You regain Hit Points from a spell
       activities: {}
       enchant: {}
       identifier: life-bond
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiLifeBond00
     type: feat
@@ -597,12 +542,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557541
+      modifiedTime: 1787693557541
     _key: '!actors.items!phbostCelestial0.phbaoiLifeBond00'
   - name: Otherworldly Slam
     system:
@@ -615,8 +560,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -627,8 +570,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: ''
       activities:
@@ -648,6 +591,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -669,6 +613,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -702,6 +647,7 @@ items:
                   mode: whole
                   number: null
                   formula: ''
+                modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -713,10 +659,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: otherworldly-slam
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiOtherworld
     type: feat
@@ -731,12 +677,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557541
+      modifiedTime: 1787693557541
     _key: '!actors.items!phbostCelestial0.phbaoiOtherworld'
   - name: Healing Touch
     system:
@@ -749,8 +695,6 @@ items:
         custom: ''
         revision: 1
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
       uses:
         max: '1'
         recovery:
@@ -762,8 +706,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: ''
       activities:
@@ -789,6 +733,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -810,6 +755,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: '1'
               type: creature
@@ -830,6 +776,7 @@ items:
               mode: whole
               number: null
               formula: ''
+            modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -841,10 +788,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: healing-touch
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiHealingTou
     type: feat
@@ -859,12 +806,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557541
+      modifiedTime: 1787693557541
     _key: '!actors.items!phbostCelestial0.phbaoiHealingTou'
 effects: []
 folder: l9ar6UzbvIRDyYmA
@@ -877,10 +824,10 @@ flags:
 _stats:
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 5.3.0
-  createdTime: 1771452721074
-  modifiedTime: 1771452721074
+  systemVersion: 6.0.0
+  createdTime: 1787693557540
+  modifiedTime: 1787693557540
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!phbostCelestial0'

--- a/packs/_source/actors24/companions/otherworldly-steeds/fey-steed.yml
+++ b/packs/_source/actors24/companions/otherworldly-steeds/fey-steed.yml
@@ -28,9 +28,6 @@ system:
       value: 18
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -45,9 +42,6 @@ system:
       value: 12
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -62,9 +56,6 @@ system:
       value: 14
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -79,9 +70,6 @@ system:
       value: 6
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -96,9 +84,6 @@ system:
       value: 12
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -113,9 +98,6 @@ system:
       value: 8
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -158,22 +140,6 @@ system:
     sp: 0
     cp: 0
   bonuses:
-    mwak:
-      attack: ''
-      damage: ''
-    rwak:
-      attack: ''
-      damage: ''
-    msak:
-      attack: ''
-      damage: ''
-    rsak:
-      attack: ''
-      damage: ''
-    abilities:
-      check: ''
-      save: ''
-      skill: ''
     spell:
       dc: ''
   skills:
@@ -185,7 +151,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ani:
       ability: wis
@@ -195,7 +160,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     arc:
       ability: int
@@ -205,7 +169,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ath:
       ability: str
@@ -215,7 +178,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     dec:
       ability: cha
@@ -225,7 +187,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     his:
       ability: int
@@ -235,7 +196,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ins:
       ability: wis
@@ -245,7 +205,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     itm:
       ability: cha
@@ -255,7 +214,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     inv:
       ability: int
@@ -265,7 +223,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     med:
       ability: wis
@@ -275,7 +232,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     nat:
       ability: int
@@ -285,7 +241,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prc:
       ability: wis
@@ -295,7 +250,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prf:
       ability: cha
@@ -305,7 +259,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     per:
       ability: cha
@@ -315,7 +268,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     rel:
       ability: int
@@ -325,7 +277,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     slt:
       ability: dex
@@ -335,7 +286,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ste:
       ability: dex
@@ -345,7 +295,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     sur:
       ability: wis
@@ -355,7 +304,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
   tools: {}
   spells:
@@ -396,12 +344,12 @@ system:
         min: null
         max: null
         mode: 0
-      bonus: ''
     movement:
-      walk: '60'
       units: null
       hover: false
       ignoredDifficultTerrain: []
+      speeds:
+        walk: '60'
     attunement:
       max: 3
     senses:
@@ -420,12 +368,13 @@ system:
         min: null
         max: null
         mode: 0
-      bonuses:
-        save: ''
       limit: 1
     ac:
       flat: 10
-      calc: natural
+      calcs:
+        - natural
+      formulas: []
+      override: null
     hd:
       spent: 0
     hp:
@@ -441,8 +390,6 @@ system:
         mode: 0
       success: 0
       failure: 0
-      bonuses:
-        save: ''
     spell:
       level: 0
     loyalty: {}
@@ -463,13 +410,14 @@ system:
   source:
     revision: 1
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
+    license: CC-BY-4.0
+  rolls: {}
 _id: phbostFey0000000
 img: ''
 prototypeToken:
   name: Otherworldly Steed
-  displayName: 20
+  displayName: 0
   actorLink: true
   appendNumber: false
   prependAdjective: false
@@ -488,7 +436,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 20
+  displayBars: 0
   bar1:
     attribute: attributes.hp
   bar2:
@@ -529,14 +477,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: false
+    enabled: true
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: null
+      texture: modules/dnd-players-handbook/assets/subjects/horse-01.webp
   flags: {}
   randomImg: false
   turnMarker:
@@ -558,8 +506,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -570,15 +516,14 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: You regain Hit Points from a spell
       activities: {}
       enchant: {}
       identifier: life-bond
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiLifeBond00
     type: feat
@@ -597,12 +542,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557542
+      modifiedTime: 1787693557542
     _key: '!actors.items!phbostFey0000000.phbaoiLifeBond00'
   - name: Otherworldly Slam
     system:
@@ -615,8 +560,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -627,8 +570,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: ''
       activities:
@@ -648,6 +591,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -669,6 +613,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -702,6 +647,7 @@ items:
                   mode: whole
                   number: null
                   formula: ''
+                modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -713,10 +659,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: otherworldly-slam
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiOtherworld
     type: feat
@@ -731,12 +677,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557542
+      modifiedTime: 1787693557542
     _key: '!actors.items!phbostFey0000000.phbaoiOtherworld'
   - name: Fey Step
     system:
@@ -749,8 +695,6 @@ items:
         custom: ''
         revision: 1
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
       uses:
         max: '1'
         recovery:
@@ -762,8 +706,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: ''
       activities:
@@ -787,6 +731,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -808,6 +753,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: '1'
               type: space
@@ -833,10 +779,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: fey-step
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiFeyStepFey
     type: feat
@@ -855,12 +801,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557542
+      modifiedTime: 1787693557542
     _key: '!actors.items!phbostFey0000000.phbaoiFeyStepFey'
 effects: []
 folder: l9ar6UzbvIRDyYmA
@@ -873,10 +819,10 @@ flags:
 _stats:
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 5.3.0
-  createdTime: 1771452721143
-  modifiedTime: 1771452721143
+  systemVersion: 6.0.0
+  createdTime: 1787693557542
+  modifiedTime: 1787693557542
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!phbostFey0000000'

--- a/packs/_source/actors24/companions/otherworldly-steeds/fey-steed.yml
+++ b/packs/_source/actors24/companions/otherworldly-steeds/fey-steed.yml
@@ -417,7 +417,7 @@ _id: phbostFey0000000
 img: ''
 prototypeToken:
   name: Otherworldly Steed
-  displayName: 0
+  displayName: 20
   actorLink: true
   appendNumber: false
   prependAdjective: false
@@ -436,7 +436,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 0
+  displayBars: 20
   bar1:
     attribute: attributes.hp
   bar2:
@@ -477,14 +477,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: true
+    enabled: false
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: modules/dnd-players-handbook/assets/subjects/horse-01.webp
+      texture: null
   flags: {}
   randomImg: false
   turnMarker:
@@ -506,6 +506,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -560,6 +561,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -693,8 +695,9 @@ items:
         chat: ''
       source:
         custom: ''
-        revision: 1
         rules: '2024'
+        license: CC-BY-4.0
+        revision: 1
       uses:
         max: '1'
         recovery:

--- a/packs/_source/actors24/companions/otherworldly-steeds/fiend-steed.yml
+++ b/packs/_source/actors24/companions/otherworldly-steeds/fiend-steed.yml
@@ -417,7 +417,7 @@ _id: phbostFiend00000
 img: ''
 prototypeToken:
   name: Otherworldly Steed
-  displayName: 0
+  displayName: 20
   actorLink: true
   appendNumber: false
   prependAdjective: false
@@ -436,7 +436,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 0
+  displayBars: 20
   bar1:
     attribute: attributes.hp
   bar2:
@@ -477,14 +477,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: true
+    enabled: false
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: modules/dnd-players-handbook/assets/subjects/horse-01.webp
+      texture: null
   flags: {}
   randomImg: false
   turnMarker:
@@ -506,6 +506,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -560,6 +561,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -699,8 +701,9 @@ items:
         chat: ''
       source:
         custom: ''
-        revision: 2
         rules: '2024'
+        license: CC-BY-4.0
+        revision: 2
       uses:
         max: '1'
         recovery:

--- a/packs/_source/actors24/companions/otherworldly-steeds/fiend-steed.yml
+++ b/packs/_source/actors24/companions/otherworldly-steeds/fiend-steed.yml
@@ -28,9 +28,6 @@ system:
       value: 18
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -45,9 +42,6 @@ system:
       value: 12
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -62,9 +56,6 @@ system:
       value: 14
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -79,9 +70,6 @@ system:
       value: 6
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -96,9 +84,6 @@ system:
       value: 12
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -113,9 +98,6 @@ system:
       value: 8
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -158,22 +140,6 @@ system:
     sp: 0
     cp: 0
   bonuses:
-    mwak:
-      attack: ''
-      damage: ''
-    rwak:
-      attack: ''
-      damage: ''
-    msak:
-      attack: ''
-      damage: ''
-    rsak:
-      attack: ''
-      damage: ''
-    abilities:
-      check: ''
-      save: ''
-      skill: ''
     spell:
       dc: ''
   skills:
@@ -185,7 +151,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ani:
       ability: wis
@@ -195,7 +160,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     arc:
       ability: int
@@ -205,7 +169,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ath:
       ability: str
@@ -215,7 +178,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     dec:
       ability: cha
@@ -225,7 +187,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     his:
       ability: int
@@ -235,7 +196,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ins:
       ability: wis
@@ -245,7 +205,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     itm:
       ability: cha
@@ -255,7 +214,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     inv:
       ability: int
@@ -265,7 +223,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     med:
       ability: wis
@@ -275,7 +232,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     nat:
       ability: int
@@ -285,7 +241,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prc:
       ability: wis
@@ -295,7 +250,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prf:
       ability: cha
@@ -305,7 +259,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     per:
       ability: cha
@@ -315,7 +268,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     rel:
       ability: int
@@ -325,7 +277,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     slt:
       ability: dex
@@ -335,7 +286,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ste:
       ability: dex
@@ -345,7 +295,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     sur:
       ability: wis
@@ -355,7 +304,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
   tools: {}
   spells:
@@ -396,12 +344,12 @@ system:
         min: null
         max: null
         mode: 0
-      bonus: ''
     movement:
-      walk: '60'
       units: null
       hover: false
       ignoredDifficultTerrain: []
+      speeds:
+        walk: '60'
     attunement:
       max: 3
     senses:
@@ -420,12 +368,13 @@ system:
         min: null
         max: null
         mode: 0
-      bonuses:
-        save: ''
       limit: 1
     ac:
       flat: 10
-      calc: natural
+      calcs:
+        - natural
+      formulas: []
+      override: null
     hd:
       spent: 0
     hp:
@@ -441,8 +390,6 @@ system:
         mode: 0
       success: 0
       failure: 0
-      bonuses:
-        save: ''
     spell:
       level: 0
     loyalty: {}
@@ -463,13 +410,14 @@ system:
   source:
     revision: 1
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
+    license: CC-BY-4.0
+  rolls: {}
 _id: phbostFiend00000
 img: ''
 prototypeToken:
   name: Otherworldly Steed
-  displayName: 20
+  displayName: 0
   actorLink: true
   appendNumber: false
   prependAdjective: false
@@ -488,7 +436,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 20
+  displayBars: 0
   bar1:
     attribute: attributes.hp
   bar2:
@@ -529,14 +477,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: false
+    enabled: true
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: null
+      texture: modules/dnd-players-handbook/assets/subjects/horse-01.webp
   flags: {}
   randomImg: false
   turnMarker:
@@ -558,8 +506,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -570,15 +516,14 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: You regain Hit Points from a spell
       activities: {}
       enchant: {}
       identifier: life-bond
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiLifeBond00
     type: feat
@@ -597,12 +542,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557543
+      modifiedTime: 1787693557543
     _key: '!actors.items!phbostFiend00000.phbaoiLifeBond00'
   - name: Otherworldly Slam
     system:
@@ -615,8 +560,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -627,8 +570,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: ''
       activities:
@@ -648,6 +591,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -669,6 +613,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -700,6 +645,7 @@ items:
                   - necrotic
                 scaling:
                   number: 1
+                modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -713,10 +659,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: otherworldly-slam
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiOtherworld
     type: feat
@@ -735,12 +681,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557543
+      modifiedTime: 1787693557543
     _key: '!actors.items!phbostFiend00000.phbaoiOtherworld'
   - name: Fell Glare
     system:
@@ -753,10 +699,8 @@ items:
         chat: ''
       source:
         custom: ''
-        revision: 1
+        revision: 2
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
       uses:
         max: '1'
         recovery:
@@ -768,8 +712,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: ''
       activities:
@@ -792,6 +736,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -802,6 +747,7 @@ items:
             - _id: TMhI7D143iHjrZgb
               onSave: false
               level: {}
+              uuid: null
           range:
             value: '60'
             units: ft
@@ -816,6 +762,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: '1'
               type: creature
@@ -832,6 +779,7 @@ items:
             dc:
               calculation: spellcasting
               formula: ''
+            visible: true
           uses:
             spent: 0
             recovery: []
@@ -846,10 +794,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: fell-glare
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiFellGlareF
     type: feat
@@ -863,11 +811,15 @@ items:
         type: base
         system:
           changes: []
+          conditions: '{}'
+          magical: false
+          rider:
+            statuses: []
         disabled: false
         duration:
-          value: 1
+          value: null
           units: rounds
-          expiry: turnStart
+          expiry: sourceEnd
           expired: false
         description: ''
         tint: '#ffffff'
@@ -876,16 +828,15 @@ items:
         sort: 0
         flags: {}
         _stats:
-          compendiumSource: >-
-            Compendium.dnd5e.actors24.Actor.phbmobOtherworld.Item.phbaoiFellGlareF.ActiveEffect.mvCvu3ezA2FV5IeR
+          compendiumSource: null
           duplicateSource: null
           exportSource: null
-          coreVersion: '14.364'
+          coreVersion: '14.367'
           systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-          createdTime: null
-          modifiedTime: null
+          systemVersion: 6.0.0
+          lastModifiedBy: dnd5ebuilder0000
+          createdTime: 1787693557544
+          modifiedTime: 1787693557544
         showIcon: 2
         start: null
         folder: null
@@ -904,12 +855,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557543
+      modifiedTime: 1787693557543
     _key: '!actors.items!phbostFiend00000.phbaoiFellGlareF'
 effects: []
 folder: l9ar6UzbvIRDyYmA
@@ -922,10 +873,10 @@ flags:
 _stats:
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 5.3.0
-  createdTime: 1771452721213
-  modifiedTime: 1771452721213
+  systemVersion: 6.0.0
+  createdTime: 1787693557543
+  modifiedTime: 1787693557543
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!phbostFiend00000'

--- a/packs/_source/actors24/companions/otherworldly-steeds/otherworldly-steed.yml
+++ b/packs/_source/actors24/companions/otherworldly-steeds/otherworldly-steed.yml
@@ -417,7 +417,7 @@ _id: phbmobOtherworld
 img: ''
 prototypeToken:
   name: Otherworldly Steed
-  displayName: 0
+  displayName: 20
   actorLink: true
   appendNumber: false
   prependAdjective: false
@@ -436,7 +436,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 0
+  displayBars: 20
   bar1:
     attribute: attributes.hp
   bar2:
@@ -477,14 +477,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: true
+    enabled: false
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: modules/dnd-players-handbook/assets/subjects/horse-01.webp
+      texture: null
   flags: {}
   randomImg: false
   turnMarker:
@@ -506,6 +506,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -560,6 +561,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -701,8 +703,9 @@ items:
         chat: ''
       source:
         custom: ''
-        revision: 2
         rules: '2024'
+        license: CC-BY-4.0
+        revision: 2
       uses:
         max: '1'
         recovery:

--- a/packs/_source/actors24/companions/otherworldly-steeds/otherworldly-steed.yml
+++ b/packs/_source/actors24/companions/otherworldly-steeds/otherworldly-steed.yml
@@ -28,9 +28,6 @@ system:
       value: 18
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -45,9 +42,6 @@ system:
       value: 12
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -62,9 +56,6 @@ system:
       value: 14
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -79,9 +70,6 @@ system:
       value: 6
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -96,9 +84,6 @@ system:
       value: 12
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -113,9 +98,6 @@ system:
       value: 8
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -158,22 +140,6 @@ system:
     sp: 0
     cp: 0
   bonuses:
-    mwak:
-      attack: ''
-      damage: ''
-    rwak:
-      attack: ''
-      damage: ''
-    msak:
-      attack: ''
-      damage: ''
-    rsak:
-      attack: ''
-      damage: ''
-    abilities:
-      check: ''
-      save: ''
-      skill: ''
     spell:
       dc: ''
   skills:
@@ -185,7 +151,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ani:
       ability: wis
@@ -195,7 +160,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     arc:
       ability: int
@@ -205,7 +169,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ath:
       ability: str
@@ -215,7 +178,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     dec:
       ability: cha
@@ -225,7 +187,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     his:
       ability: int
@@ -235,7 +196,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ins:
       ability: wis
@@ -245,7 +205,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     itm:
       ability: cha
@@ -255,7 +214,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     inv:
       ability: int
@@ -265,7 +223,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     med:
       ability: wis
@@ -275,7 +232,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     nat:
       ability: int
@@ -285,7 +241,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prc:
       ability: wis
@@ -295,7 +250,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prf:
       ability: cha
@@ -305,7 +259,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     per:
       ability: cha
@@ -315,7 +268,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     rel:
       ability: int
@@ -325,7 +277,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     slt:
       ability: dex
@@ -335,7 +286,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ste:
       ability: dex
@@ -345,7 +295,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     sur:
       ability: wis
@@ -355,7 +304,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
   tools: {}
   spells:
@@ -396,12 +344,12 @@ system:
         min: null
         max: null
         mode: 0
-      bonus: ''
     movement:
-      walk: '60'
       units: null
       hover: false
       ignoredDifficultTerrain: []
+      speeds:
+        walk: '60'
     attunement:
       max: 3
     senses:
@@ -420,12 +368,13 @@ system:
         min: null
         max: null
         mode: 0
-      bonuses:
-        save: ''
       limit: 1
     ac:
       flat: 10
-      calc: natural
+      calcs:
+        - natural
+      formulas: []
+      override: null
     hd:
       spent: 0
     hp:
@@ -441,8 +390,6 @@ system:
         mode: 0
       success: 0
       failure: 0
-      bonuses:
-        save: ''
     spell:
       level: 0
     loyalty: {}
@@ -463,13 +410,14 @@ system:
   source:
     revision: 1
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
+    license: CC-BY-4.0
+  rolls: {}
 _id: phbmobOtherworld
 img: ''
 prototypeToken:
   name: Otherworldly Steed
-  displayName: 20
+  displayName: 0
   actorLink: true
   appendNumber: false
   prependAdjective: false
@@ -488,7 +436,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 20
+  displayBars: 0
   bar1:
     attribute: attributes.hp
   bar2:
@@ -529,14 +477,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: false
+    enabled: true
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: null
+      texture: modules/dnd-players-handbook/assets/subjects/horse-01.webp
   flags: {}
   randomImg: false
   turnMarker:
@@ -558,8 +506,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -570,15 +516,14 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: you regain Hit Points from a spell
       activities: {}
       enchant: {}
       identifier: life-bond
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiLifeBond00
     type: feat
@@ -597,12 +542,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557545
+      modifiedTime: 1787693557545
     _key: '!actors.items!phbmobOtherworld.phbaoiLifeBond00'
   - name: Otherworldly Slam
     system:
@@ -615,8 +560,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -627,8 +570,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: ''
       activities:
@@ -648,6 +591,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -669,6 +613,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -702,6 +647,7 @@ items:
                   - necrotic
                 scaling:
                   number: 1
+                modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -715,10 +661,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: otherworldly-slam
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiOtherworld
     type: feat
@@ -737,12 +683,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557545
+      modifiedTime: 1787693557545
     _key: '!actors.items!phbmobOtherworld.phbaoiOtherworld'
   - name: Fell Glare
     system:
@@ -755,10 +701,8 @@ items:
         chat: ''
       source:
         custom: ''
-        revision: 1
+        revision: 2
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
       uses:
         max: '1'
         recovery:
@@ -770,8 +714,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: Fiend Only
       activities:
@@ -797,6 +741,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -807,6 +752,7 @@ items:
             - _id: mvCvu3ezA2FV5IeR
               onSave: false
               level: {}
+              uuid: null
           range:
             value: '60'
             units: ft
@@ -821,6 +767,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: '1'
               type: creature
@@ -837,6 +784,7 @@ items:
             dc:
               calculation: spellcasting
               formula: ''
+            visible: true
           uses:
             spent: 0
             recovery: []
@@ -848,10 +796,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: fell-glare
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiFellGlareF
     type: feat
@@ -865,11 +813,15 @@ items:
         type: base
         system:
           changes: []
+          conditions: '{}'
+          magical: false
+          rider:
+            statuses: []
         disabled: false
         duration:
-          value: 1
+          value: null
           units: rounds
-          expiry: turnStart
+          expiry: sourceEnd
           expired: false
         description: ''
         tint: '#ffffff'
@@ -881,12 +833,12 @@ items:
           compendiumSource: null
           duplicateSource: null
           exportSource: null
-          coreVersion: '14.364'
+          coreVersion: '14.367'
           systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-          createdTime: null
-          modifiedTime: null
+          systemVersion: 6.0.0
+          lastModifiedBy: dnd5ebuilder0000
+          createdTime: 1787693557545
+          modifiedTime: 1787693557545
         showIcon: 2
         start: null
         folder: null
@@ -905,12 +857,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557545
+      modifiedTime: 1787693557545
     _key: '!actors.items!phbmobOtherworld.phbaoiFellGlareF'
   - name: Fey Step
     system:
@@ -923,8 +875,6 @@ items:
         custom: ''
         revision: 1
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
       uses:
         max: '1'
         recovery:
@@ -936,8 +886,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: Fey Only
       activities:
@@ -961,6 +911,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -982,6 +933,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: '1'
               type: space
@@ -1007,10 +959,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: fey-step
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiFeyStepFey
     type: feat
@@ -1029,12 +981,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557545
+      modifiedTime: 1787693557545
     _key: '!actors.items!phbmobOtherworld.phbaoiFeyStepFey'
   - name: Healing Touch
     system:
@@ -1047,8 +999,6 @@ items:
         custom: ''
         revision: 1
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
       uses:
         max: '1'
         recovery:
@@ -1060,8 +1010,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: Celestial Only
       activities:
@@ -1087,6 +1037,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -1108,6 +1059,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: '1'
               type: creature
@@ -1128,6 +1080,7 @@ items:
               mode: whole
               number: null
               formula: ''
+            modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -1139,10 +1092,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: healing-touch
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiHealingTou
     type: feat
@@ -1157,12 +1110,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693557546
+      modifiedTime: 1787693557546
     _key: '!actors.items!phbmobOtherworld.phbaoiHealingTou'
 effects: []
 folder: l9ar6UzbvIRDyYmA
@@ -1175,10 +1128,10 @@ flags:
 _stats:
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 5.3.0
-  createdTime: 1771452720797
-  modifiedTime: 1771452720797
+  systemVersion: 6.0.0
+  createdTime: 1787693557544
+  modifiedTime: 1787693557544
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!phbmobOtherworld'

--- a/packs/_source/actors24/conjurations/conjured-fey.yml
+++ b/packs/_source/actors24/conjurations/conjured-fey.yml
@@ -417,7 +417,7 @@ system:
   rolls: {}
 prototypeToken:
   name: Conjured Fey
-  displayName: 0
+  displayName: 20
   actorLink: false
   appendNumber: false
   prependAdjective: false
@@ -436,7 +436,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: -2
-  displayBars: 0
+  displayBars: 20
   bar1:
     attribute: attributes.hp
   bar2:
@@ -477,14 +477,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: true
+    enabled: false
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: modules/dnd-players-handbook/assets/subjects/fey-spirit.webp
+      texture: null
   flags: {}
   randomImg: false
   turnMarker:
@@ -673,6 +673,7 @@ items:
         max: ''
       source:
         rules: '2024'
+        license: CC-BY-4.0
         revision: 2
       enchant: {}
       type:

--- a/packs/_source/actors24/conjurations/conjured-fey.yml
+++ b/packs/_source/actors24/conjurations/conjured-fey.yml
@@ -14,9 +14,6 @@ system:
       value: 0
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -31,9 +28,6 @@ system:
       value: 0
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -48,9 +42,6 @@ system:
       value: 0
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -65,9 +56,6 @@ system:
       value: 0
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -82,9 +70,6 @@ system:
       value: 0
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -99,9 +84,6 @@ system:
       value: 0
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -113,22 +95,6 @@ system:
           max: null
           mode: 0
   bonuses:
-    mwak:
-      attack: ''
-      damage: ''
-    rwak:
-      attack: ''
-      damage: ''
-    msak:
-      attack: ''
-      damage: ''
-    rsak:
-      attack: ''
-      damage: ''
-    abilities:
-      check: ''
-      save: ''
-      skill: ''
     spell:
       dc: ''
   skills:
@@ -140,7 +106,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ani:
       ability: wis
@@ -150,7 +115,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     arc:
       ability: int
@@ -160,7 +124,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ath:
       ability: str
@@ -170,7 +133,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     dec:
       ability: cha
@@ -180,7 +142,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     his:
       ability: int
@@ -190,7 +151,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ins:
       ability: wis
@@ -200,7 +160,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     itm:
       ability: cha
@@ -210,7 +169,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     inv:
       ability: int
@@ -220,7 +178,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     med:
       ability: wis
@@ -230,7 +187,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     nat:
       ability: int
@@ -240,7 +196,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prc:
       ability: wis
@@ -250,7 +205,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prf:
       ability: cha
@@ -260,7 +214,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     per:
       ability: cha
@@ -270,7 +223,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     rel:
       ability: int
@@ -280,7 +232,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     slt:
       ability: dex
@@ -290,7 +241,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ste:
       ability: dex
@@ -300,7 +250,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     sur:
       ability: wis
@@ -310,7 +259,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
   tools: {}
   spells:
@@ -351,11 +299,11 @@ system:
         min: null
         max: null
         mode: 0
-      bonus: ''
     movement:
       units: null
       hover: false
       ignoredDifficultTerrain: []
+      speeds: {}
     attunement:
       max: 3
     senses:
@@ -374,12 +322,14 @@ system:
         min: null
         max: null
         mode: 0
-      bonuses:
-        save: ''
       limit: 1
     ac:
       flat: 0
-      calc: flat
+      override: 0
+      calcs:
+        - unarmored
+        - armored
+      formulas: []
     hd:
       spent: 0
     hp:
@@ -395,8 +345,6 @@ system:
         mode: 0
       success: 0
       failure: 0
-      bonuses:
-        save: ''
     spell:
       level: 0
     loyalty: {}
@@ -463,12 +411,13 @@ system:
     important: false
   source:
     rules: '2024'
-    license: CC-BY-4.0
-    book: ''
     revision: 1
+    book: ''
+    license: CC-BY-4.0
+  rolls: {}
 prototypeToken:
   name: Conjured Fey
-  displayName: 20
+  displayName: 0
   actorLink: false
   appendNumber: false
   prependAdjective: false
@@ -487,7 +436,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: -2
-  displayBars: 20
+  displayBars: 0
   bar1:
     attribute: attributes.hp
   bar2:
@@ -528,14 +477,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: false
+    enabled: true
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: null
+      texture: modules/dnd-players-handbook/assets/subjects/fey-spirit.webp
   flags: {}
   randomImg: false
   turnMarker:
@@ -570,6 +519,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             units: inst
             concentration: false
@@ -577,6 +527,7 @@ items:
           effects:
             - _id: sEpCnDgBAYjTuRgI
               level: {}
+              uuid: null
           range:
             override: false
             value: '5'
@@ -587,6 +538,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -623,6 +575,7 @@ items:
                   - psychic
                 scaling:
                   number: 1
+                modifiers: []
           name: ''
           img: ''
           flags: {}
@@ -631,6 +584,7 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
         ooHKOg5gGPyp0Jzy:
           type: attack
           activation:
@@ -646,6 +600,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             units: inst
             concentration: false
@@ -653,6 +608,7 @@ items:
           effects:
             - _id: sEpCnDgBAYjTuRgI
               level: {}
+              uuid: null
           range:
             override: false
             value: '35'
@@ -663,6 +619,7 @@ items:
               contiguous: false
               units: ft
               type: ''
+              stationary: false
             affects:
               choice: false
               count: '1'
@@ -699,6 +656,7 @@ items:
                   - psychic
                 scaling:
                   number: 1
+                modifiers: []
           name: Teleport and Attack
           _id: ooHKOg5gGPyp0Jzy
           img: ''
@@ -708,28 +666,26 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       uses:
         spent: 0
         recovery: []
         max: ''
       source:
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
-        revision: 1
+        revision: 2
       enchant: {}
       type:
         value: monster
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: ''
       identifier: command
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiAttackAtta
     type: feat
@@ -743,11 +699,15 @@ items:
         type: base
         system:
           changes: []
+          conditions: '{}'
+          magical: false
+          rider:
+            statuses: []
         disabled: false
         duration:
-          value: 1
-          units: rounds
-          expiry: turnStart
+          value: null
+          units: seconds
+          expiry: sourceStart
           expired: false
         description: >-
           <p>The target has the &amp;Reference[Frightened apply=false] condition
@@ -762,12 +722,12 @@ items:
           compendiumSource: null
           duplicateSource: null
           exportSource: null
-          coreVersion: '14.364'
+          coreVersion: '14.367'
           systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-          createdTime: null
-          modifiedTime: null
+          systemVersion: 6.0.0
+          lastModifiedBy: dnd5ebuilder0000
+          createdTime: 1787693535144
+          modifiedTime: 1787693535144
         showIcon: 2
         start: null
         folder: null
@@ -783,15 +743,15 @@ items:
           activity: []
           effect: []
     _stats:
-      compendiumSource: Compendium.dnd5e.actors24.Actor.phbsplConjuredFe.Item.phbaoiAttackAtta
+      compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693535144
+      modifiedTime: 1787693535144
     _key: '!actors.items!phbsplConjuredFe.phbaoiAttackAtta'
 effects: []
 folder: 9mmdDqYZFLIJBacj
@@ -801,11 +761,11 @@ flags:
 _stats:
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 5.3.0
-  createdTime: 1771452721552
-  modifiedTime: 1771452721552
+  systemVersion: 6.0.0
+  createdTime: 1787693535144
+  modifiedTime: 1787693535144
   lastModifiedBy: dnd5ebuilder0000
 sort: 1200000
 ownership:

--- a/packs/_source/actors24/summons/giant-insects/giant-centipede.yml
+++ b/packs/_source/actors24/summons/giant-insects/giant-centipede.yml
@@ -414,14 +414,14 @@ _id: phbginGiantCenti
 img: null
 prototypeToken:
   name: Giant Insect
-  displayName: 0
+  displayName: 20
   actorLink: false
   appendNumber: false
   prependAdjective: false
   width: 2
   height: 2
   texture:
-    src: modules/dnd-players-handbook/assets/tokens/giant-centipede.webp
+    src: null
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -433,7 +433,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 0
+  displayBars: 20
   bar1:
     attribute: attributes.hp
   bar2:
@@ -477,14 +477,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: true
+    enabled: false
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: modules/dnd-players-handbook/assets/subjects/giant-centipede.webp
+      texture: null
   flags: {}
   randomImg: false
   turnMarker:
@@ -505,6 +505,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -556,6 +557,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -674,6 +676,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -825,6 +828,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 2
       uses:
         max: ''

--- a/packs/_source/actors24/summons/giant-insects/giant-centipede.yml
+++ b/packs/_source/actors24/summons/giant-insects/giant-centipede.yml
@@ -25,9 +25,6 @@ system:
       value: 17
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -42,9 +39,6 @@ system:
       value: 13
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -59,9 +53,6 @@ system:
       value: 15
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -76,9 +67,6 @@ system:
       value: 4
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -93,9 +81,6 @@ system:
       value: 14
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -110,9 +95,6 @@ system:
       value: 3
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -155,22 +137,6 @@ system:
     sp: 0
     cp: 0
   bonuses:
-    mwak:
-      attack: ''
-      damage: ''
-    rwak:
-      attack: ''
-      damage: ''
-    msak:
-      attack: ''
-      damage: ''
-    rsak:
-      attack: ''
-      damage: ''
-    abilities:
-      check: ''
-      save: ''
-      skill: ''
     spell:
       dc: ''
   skills:
@@ -182,7 +148,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ani:
       ability: wis
@@ -192,7 +157,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     arc:
       ability: int
@@ -202,7 +166,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ath:
       ability: str
@@ -212,7 +175,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     dec:
       ability: cha
@@ -222,7 +184,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     his:
       ability: int
@@ -232,7 +193,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ins:
       ability: wis
@@ -242,7 +202,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     itm:
       ability: cha
@@ -252,7 +211,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     inv:
       ability: int
@@ -262,7 +220,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     med:
       ability: wis
@@ -272,7 +229,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     nat:
       ability: int
@@ -282,7 +238,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prc:
       ability: wis
@@ -292,7 +247,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prf:
       ability: cha
@@ -302,7 +256,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     per:
       ability: cha
@@ -312,7 +265,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     rel:
       ability: int
@@ -322,7 +274,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     slt:
       ability: dex
@@ -332,7 +283,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ste:
       ability: dex
@@ -342,7 +292,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     sur:
       ability: wis
@@ -352,7 +301,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
   tools: {}
   spells:
@@ -393,13 +341,13 @@ system:
         min: null
         max: null
         mode: 0
-      bonus: ''
     movement:
-      climb: '40'
-      walk: '40'
       units: null
       hover: false
       ignoredDifficultTerrain: []
+      speeds:
+        walk: '40'
+        climb: '40'
     attunement:
       max: 3
     senses:
@@ -418,12 +366,13 @@ system:
         min: null
         max: null
         mode: 0
-      bonuses:
-        save: ''
       limit: 1
     ac:
       flat: 11
-      calc: natural
+      calcs:
+        - natural
+      formulas: []
+      override: null
     hd:
       spent: 0
     hp:
@@ -439,8 +388,6 @@ system:
         mode: 0
       success: 0
       failure: 0
-      bonuses:
-        save: ''
     spell:
       level: 0
     loyalty: {}
@@ -462,18 +409,19 @@ system:
     rules: '2024'
     custom: ''
     revision: 1
+  rolls: {}
 _id: phbginGiantCenti
 img: null
 prototypeToken:
   name: Giant Insect
-  displayName: 20
+  displayName: 0
   actorLink: false
   appendNumber: false
   prependAdjective: false
   width: 2
   height: 2
   texture:
-    src: null
+    src: modules/dnd-players-handbook/assets/tokens/giant-centipede.webp
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -485,7 +433,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 20
+  displayBars: 0
   bar1:
     attribute: attributes.hp
   bar2:
@@ -536,7 +484,7 @@ prototypeToken:
     effects: 1
     subject:
       scale: 1
-      texture: null
+      texture: modules/dnd-players-handbook/assets/subjects/giant-centipede.webp
   flags: {}
   randomImg: false
   turnMarker:
@@ -569,7 +517,8 @@ items:
         level: null
         items: []
         repeatable: false
-      properties: []
+      properties:
+        - trait
       requirements: ''
       activities: {}
       enchant: {}
@@ -589,12 +538,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573239
+      modifiedTime: 1787693573239
     _key: '!actors.items!phbginGiantCenti.phbaoiSpiderClim'
   - name: Multiattack
     system:
@@ -638,6 +587,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -658,6 +608,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -683,6 +634,7 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: multiattack
       advancement: {}
@@ -704,12 +656,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573239
+      modifiedTime: 1787693573239
     _key: '!actors.items!phbginGiantCenti.phbaoiMultiattac'
   - name: Poison Jab
     system:
@@ -753,6 +705,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -774,6 +727,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -805,6 +759,7 @@ items:
                   - piercing
                 scaling:
                   number: 1
+                modifiers: []
               - custom:
                   enabled: false
                   formula: ''
@@ -815,6 +770,7 @@ items:
                   - poison
                 scaling:
                   number: 1
+                modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -828,6 +784,7 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: poison-jab
       advancement: {}
@@ -849,12 +806,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573239
+      modifiedTime: 1787693573239
     _key: '!actors.items!phbginGiantCenti.phbaoiPoisonJab0'
   - name: Venomous Spew
     system:
@@ -868,7 +825,7 @@ items:
       source:
         custom: ''
         rules: '2024'
-        revision: 1
+        revision: 2
       uses:
         max: ''
         recovery: []
@@ -899,6 +856,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: '1'
             units: round
@@ -909,6 +867,7 @@ items:
             - _id: uUvxWKSj8qQRIbTK
               onSave: false
               level: {}
+              uuid: null
           range:
             value: '10'
             units: ft
@@ -923,6 +882,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: '1'
               type: creature
@@ -939,6 +899,7 @@ items:
             dc:
               calculation: spellcasting
               formula: ''
+            visible: true
           uses:
             spent: 0
             recovery: []
@@ -950,6 +911,7 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: venomous-spew
       advancement: {}
@@ -966,11 +928,15 @@ items:
         type: base
         system:
           changes: []
+          conditions: '{}'
+          magical: false
+          rider:
+            statuses: []
         disabled: false
         duration:
-          value: 1
-          units: rounds
-          expiry: turnStart
+          value: null
+          units: seconds
+          expiry: sourceStart
           expired: false
         description: >-
           <p>The target has the &amp;Reference[Poisoned apply=false] condition
@@ -984,12 +950,12 @@ items:
           compendiumSource: null
           duplicateSource: null
           exportSource: null
-          coreVersion: '14.364'
+          coreVersion: '14.367'
           systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-          createdTime: null
-          modifiedTime: null
+          systemVersion: 6.0.0
+          lastModifiedBy: dnd5ebuilder0000
+          createdTime: 1787693573239
+          modifiedTime: 1787693573239
         showIcon: 2
         start: null
         folder: null
@@ -1008,12 +974,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573239
+      modifiedTime: 1787693573239
     _key: '!actors.items!phbginGiantCenti.phbaoiVenomousSp'
 effects: []
 folder: beGRXWKaYfeeR1Iz
@@ -1026,10 +992,10 @@ flags:
 _stats:
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 5.3.0
-  createdTime: 1771452719847
-  modifiedTime: 1771452719847
+  systemVersion: 6.0.0
+  createdTime: 1787693573238
+  modifiedTime: 1787693573238
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!phbginGiantCenti'

--- a/packs/_source/actors24/summons/giant-insects/giant-spider.yml
+++ b/packs/_source/actors24/summons/giant-insects/giant-spider.yml
@@ -414,14 +414,14 @@ _id: phbginGiantSpide
 img: null
 prototypeToken:
   name: Giant Insect
-  displayName: 0
+  displayName: 20
   actorLink: false
   appendNumber: false
   prependAdjective: false
   width: 2
   height: 2
   texture:
-    src: modules/dnd-players-handbook/assets/tokens/giant-spider-*.webp
+    src: null
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -433,7 +433,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 0
+  displayBars: 20
   bar1:
     attribute: attributes.hp
   bar2:
@@ -477,13 +477,13 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: true
+    enabled: false
     colors:
       ring: null
       background: null
     effects: 1
     subject:
-      scale: 2
+      scale: 1
       texture: null
   flags: {}
   randomImg: true
@@ -505,6 +505,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -556,6 +557,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -674,6 +676,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -825,6 +828,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''

--- a/packs/_source/actors24/summons/giant-insects/giant-spider.yml
+++ b/packs/_source/actors24/summons/giant-insects/giant-spider.yml
@@ -25,9 +25,6 @@ system:
       value: 17
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -42,9 +39,6 @@ system:
       value: 13
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -59,9 +53,6 @@ system:
       value: 15
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -76,9 +67,6 @@ system:
       value: 4
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -93,9 +81,6 @@ system:
       value: 14
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -110,9 +95,6 @@ system:
       value: 3
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -155,22 +137,6 @@ system:
     sp: 0
     cp: 0
   bonuses:
-    mwak:
-      attack: ''
-      damage: ''
-    rwak:
-      attack: ''
-      damage: ''
-    msak:
-      attack: ''
-      damage: ''
-    rsak:
-      attack: ''
-      damage: ''
-    abilities:
-      check: ''
-      save: ''
-      skill: ''
     spell:
       dc: ''
   skills:
@@ -182,7 +148,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ani:
       ability: wis
@@ -192,7 +157,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     arc:
       ability: int
@@ -202,7 +166,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ath:
       ability: str
@@ -212,7 +175,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     dec:
       ability: cha
@@ -222,7 +184,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     his:
       ability: int
@@ -232,7 +193,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ins:
       ability: wis
@@ -242,7 +202,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     itm:
       ability: cha
@@ -252,7 +211,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     inv:
       ability: int
@@ -262,7 +220,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     med:
       ability: wis
@@ -272,7 +229,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     nat:
       ability: int
@@ -282,7 +238,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prc:
       ability: wis
@@ -292,7 +247,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prf:
       ability: cha
@@ -302,7 +256,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     per:
       ability: cha
@@ -312,7 +265,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     rel:
       ability: int
@@ -322,7 +274,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     slt:
       ability: dex
@@ -332,7 +283,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ste:
       ability: dex
@@ -342,7 +292,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     sur:
       ability: wis
@@ -352,7 +301,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
   tools: {}
   spells:
@@ -393,13 +341,13 @@ system:
         min: null
         max: null
         mode: 0
-      bonus: ''
     movement:
-      climb: '40'
-      walk: '40'
       units: null
       hover: false
       ignoredDifficultTerrain: []
+      speeds:
+        walk: '40'
+        climb: '40'
     attunement:
       max: 3
     senses:
@@ -418,12 +366,13 @@ system:
         min: null
         max: null
         mode: 0
-      bonuses:
-        save: ''
       limit: 1
     ac:
       flat: 11
-      calc: natural
+      calcs:
+        - natural
+      formulas: []
+      override: null
     hd:
       spent: 0
     hp:
@@ -439,8 +388,6 @@ system:
         mode: 0
       success: 0
       failure: 0
-      bonuses:
-        save: ''
     spell:
       level: 0
     loyalty: {}
@@ -462,18 +409,19 @@ system:
     rules: '2024'
     custom: ''
     revision: 1
+  rolls: {}
 _id: phbginGiantSpide
 img: null
 prototypeToken:
   name: Giant Insect
-  displayName: 20
+  displayName: 0
   actorLink: false
   appendNumber: false
   prependAdjective: false
   width: 2
   height: 2
   texture:
-    src: null
+    src: modules/dnd-players-handbook/assets/tokens/giant-spider-*.webp
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -485,7 +433,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 20
+  displayBars: 0
   bar1:
     attribute: attributes.hp
   bar2:
@@ -569,7 +517,8 @@ items:
         level: null
         items: []
         repeatable: false
-      properties: []
+      properties:
+        - trait
       requirements: ''
       activities: {}
       enchant: {}
@@ -589,12 +538,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573240
+      modifiedTime: 1787693573240
     _key: '!actors.items!phbginGiantSpide.phbaoiSpiderClim'
   - name: Multiattack
     system:
@@ -638,6 +587,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -658,6 +608,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -683,6 +634,7 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: multiattack
       advancement: {}
@@ -704,12 +656,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573240
+      modifiedTime: 1787693573240
     _key: '!actors.items!phbginGiantSpide.phbaoiMultiattac'
   - name: Poison Jab
     system:
@@ -753,6 +705,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -774,6 +727,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -805,6 +759,7 @@ items:
                   - piercing
                 scaling:
                   number: 1
+                modifiers: []
               - custom:
                   enabled: false
                   formula: ''
@@ -815,6 +770,7 @@ items:
                   - poison
                 scaling:
                   number: 1
+                modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -828,6 +784,7 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: poison-jab
       advancement: {}
@@ -849,12 +806,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573241
+      modifiedTime: 1787693573241
     _key: '!actors.items!phbginGiantSpide.phbaoiPoisonJab0'
   - name: Web Bolt
     system:
@@ -899,6 +856,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -908,6 +866,7 @@ items:
           effects:
             - _id: Gvwt9wpCcJgC0yMl
               level: {}
+              uuid: null
           range:
             value: '60'
             units: ft
@@ -922,6 +881,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -955,6 +915,7 @@ items:
                   mode: whole
                   number: null
                   formula: ''
+                modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -966,6 +927,7 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: web-bolt
       advancement: {}
@@ -993,34 +955,43 @@ items:
               priority: null
               type: downgrade
               phase: initial
-              _id: n4iffgs0cx6q7wNM
+              _id: 2ed3oasE3lTlQHuL
+              conditions: '{}'
             - key: system.attributes.movement.burrow
               value: 0
               priority: null
               type: downgrade
               phase: initial
-              _id: zdFhF36YsF6UmKHe
+              _id: VYSprXRgd3LRxyV4
+              conditions: '{}'
             - key: system.attributes.movement.climb
               value: 0
               priority: null
               type: downgrade
               phase: initial
-              _id: kSF2xMYHHOViMNby
+              _id: F6Qr2zoofx3XsFtE
+              conditions: '{}'
             - key: system.attributes.movement.fly
               value: 0
               priority: null
               type: downgrade
               phase: initial
-              _id: ZfiUPsdFcYnaPkJA
+              _id: sqDPIIKWsn6XzGSL
+              conditions: '{}'
             - key: system.attributes.movement.swim
               value: 0
               priority: null
               type: downgrade
               phase: initial
-              _id: DIgWHuCQJlsf5dP2
+              _id: HTdBohYXtOZsJ6vU
+              conditions: '{}'
+          conditions: '{}'
+          magical: false
+          rider:
+            statuses: []
         description: >-
-          <p><span style="font-family:Signika, sans-serif">The target’s Speed is
-          reduced to 0 until the start of the insect’s next turn.</span></p>
+          <p>The target’s Speed is reduced to 0 until the start of the insect’s
+          next turn.</p>
         tint: '#ffffff'
         transfer: false
         statuses: []
@@ -1029,12 +1000,12 @@ items:
           compendiumSource: null
           duplicateSource: null
           exportSource: null
-          coreVersion: '14.364'
+          coreVersion: '14.367'
           systemId: dnd5e
           systemVersion: 6.0.0
           lastModifiedBy: dnd5ebuilder0000
-          createdTime: 1783544184547
-          modifiedTime: 1783544184547
+          createdTime: 1787693573241
+          modifiedTime: 1787693573241
         start: null
         showIcon: 1
         folder: null
@@ -1049,12 +1020,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
+      systemVersion: 6.0.0
       lastModifiedBy: dnd5ebuilder0000
-      createdTime: 1783544184547
-      modifiedTime: 1783544184547
+      createdTime: 1787693573241
+      modifiedTime: 1787693573241
     _key: '!actors.items!phbginGiantSpide.phbaoiWebBoltSpi'
 effects: []
 folder: beGRXWKaYfeeR1Iz
@@ -1067,10 +1038,10 @@ flags:
 _stats:
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
   systemVersion: 6.0.0
-  createdTime: 1783544184546
-  modifiedTime: 1783544184546
+  createdTime: 1787693573240
+  modifiedTime: 1787693573240
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!phbginGiantSpide'

--- a/packs/_source/actors24/summons/giant-insects/giant-wasp.yml
+++ b/packs/_source/actors24/summons/giant-insects/giant-wasp.yml
@@ -25,9 +25,6 @@ system:
       value: 17
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -42,9 +39,6 @@ system:
       value: 13
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -59,9 +53,6 @@ system:
       value: 15
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -76,9 +67,6 @@ system:
       value: 4
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -93,9 +81,6 @@ system:
       value: 14
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -110,9 +95,6 @@ system:
       value: 3
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -155,22 +137,6 @@ system:
     sp: 0
     cp: 0
   bonuses:
-    mwak:
-      attack: ''
-      damage: ''
-    rwak:
-      attack: ''
-      damage: ''
-    msak:
-      attack: ''
-      damage: ''
-    rsak:
-      attack: ''
-      damage: ''
-    abilities:
-      check: ''
-      save: ''
-      skill: ''
     spell:
       dc: ''
   skills:
@@ -182,7 +148,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ani:
       ability: wis
@@ -192,7 +157,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     arc:
       ability: int
@@ -202,7 +166,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ath:
       ability: str
@@ -212,7 +175,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     dec:
       ability: cha
@@ -222,7 +184,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     his:
       ability: int
@@ -232,7 +193,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ins:
       ability: wis
@@ -242,7 +202,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     itm:
       ability: cha
@@ -252,7 +211,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     inv:
       ability: int
@@ -262,7 +220,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     med:
       ability: wis
@@ -272,7 +229,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     nat:
       ability: int
@@ -282,7 +238,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prc:
       ability: wis
@@ -292,7 +247,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prf:
       ability: cha
@@ -302,7 +256,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     per:
       ability: cha
@@ -312,7 +265,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     rel:
       ability: int
@@ -322,7 +274,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     slt:
       ability: dex
@@ -332,7 +283,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ste:
       ability: dex
@@ -342,7 +292,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     sur:
       ability: wis
@@ -352,7 +301,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
   tools: {}
   spells:
@@ -393,14 +341,14 @@ system:
         min: null
         max: null
         mode: 0
-      bonus: ''
     movement:
-      climb: '40'
-      fly: '40'
-      walk: '40'
       units: null
       hover: false
       ignoredDifficultTerrain: []
+      speeds:
+        walk: '40'
+        climb: '40'
+        fly: '40'
     attunement:
       max: 3
     senses:
@@ -419,12 +367,13 @@ system:
         min: null
         max: null
         mode: 0
-      bonuses:
-        save: ''
       limit: 1
     ac:
       flat: 11
-      calc: natural
+      calcs:
+        - natural
+      formulas: []
+      override: null
     hd:
       spent: 0
     hp:
@@ -440,8 +389,6 @@ system:
         mode: 0
       success: 0
       failure: 0
-      bonuses:
-        save: ''
     spell:
       level: 0
     loyalty: {}
@@ -463,18 +410,19 @@ system:
     rules: '2024'
     custom: ''
     revision: 1
+  rolls: {}
 _id: phbginGiantWasp0
 img: null
 prototypeToken:
   name: Giant Insect
-  displayName: 20
+  displayName: 0
   actorLink: false
   appendNumber: false
   prependAdjective: false
   width: 2
   height: 2
   texture:
-    src: null
+    src: modules/dnd-players-handbook/assets/tokens/giant-wasp.webp
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -486,7 +434,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 20
+  displayBars: 0
   bar1:
     attribute: attributes.hp
   bar2:
@@ -537,7 +485,7 @@ prototypeToken:
     effects: 1
     subject:
       scale: 1
-      texture: null
+      texture: modules/dnd-players-handbook/assets/subjects/giant-wasp.webp
   flags: {}
   randomImg: false
   turnMarker:
@@ -570,7 +518,8 @@ items:
         level: null
         items: []
         repeatable: false
-      properties: []
+      properties:
+        - trait
       requirements: ''
       activities: {}
       enchant: {}
@@ -590,12 +539,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573238
+      modifiedTime: 1787693573238
     _key: '!actors.items!phbginGiantWasp0.phbaoiSpiderClim'
   - name: Multiattack
     system:
@@ -639,6 +588,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -659,6 +609,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -684,6 +635,7 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: multiattack
       advancement: {}
@@ -705,12 +657,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573238
+      modifiedTime: 1787693573238
     _key: '!actors.items!phbginGiantWasp0.phbaoiMultiattac'
   - name: Poison Jab
     system:
@@ -754,6 +706,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -775,6 +728,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -806,6 +760,7 @@ items:
                   - piercing
                 scaling:
                   number: 1
+                modifiers: []
               - custom:
                   enabled: false
                   formula: ''
@@ -816,6 +771,7 @@ items:
                   - poison
                 scaling:
                   number: 1
+                modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -829,6 +785,7 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: poison-jab
       advancement: {}
@@ -850,12 +807,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573238
+      modifiedTime: 1787693573238
     _key: '!actors.items!phbginGiantWasp0.phbaoiPoisonJab0'
 effects: []
 folder: beGRXWKaYfeeR1Iz
@@ -866,10 +823,10 @@ flags: {}
 _stats:
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 5.3.0
-  createdTime: 1771452719984
-  modifiedTime: 1771452719984
+  systemVersion: 6.0.0
+  createdTime: 1787693573237
+  modifiedTime: 1787693573237
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!phbginGiantWasp0'

--- a/packs/_source/actors24/summons/giant-insects/giant-wasp.yml
+++ b/packs/_source/actors24/summons/giant-insects/giant-wasp.yml
@@ -415,14 +415,14 @@ _id: phbginGiantWasp0
 img: null
 prototypeToken:
   name: Giant Insect
-  displayName: 0
+  displayName: 20
   actorLink: false
   appendNumber: false
   prependAdjective: false
   width: 2
   height: 2
   texture:
-    src: modules/dnd-players-handbook/assets/tokens/giant-wasp.webp
+    src: null
     anchorX: 0.5
     anchorY: 0.5
     fit: contain
@@ -434,7 +434,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 0
+  displayBars: 20
   bar1:
     attribute: attributes.hp
   bar2:
@@ -478,14 +478,14 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: true
+    enabled: false
     colors:
       ring: null
       background: null
     effects: 1
     subject:
       scale: 1
-      texture: modules/dnd-players-handbook/assets/subjects/giant-wasp.webp
+      texture: null
   flags: {}
   randomImg: false
   turnMarker:
@@ -506,6 +506,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -557,6 +558,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -675,6 +677,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''

--- a/packs/_source/actors24/summons/summon-templates/giant-insect.yml
+++ b/packs/_source/actors24/summons/summon-templates/giant-insect.yml
@@ -25,9 +25,6 @@ system:
       value: 17
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -42,9 +39,6 @@ system:
       value: 13
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -59,9 +53,6 @@ system:
       value: 15
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -76,9 +67,6 @@ system:
       value: 4
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -93,9 +81,6 @@ system:
       value: 14
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -110,9 +95,6 @@ system:
       value: 3
       proficient: 0
       max: null
-      bonuses:
-        check: ''
-        save: ''
       check:
         roll:
           min: null
@@ -155,22 +137,6 @@ system:
     sp: 0
     cp: 0
   bonuses:
-    mwak:
-      attack: ''
-      damage: ''
-    rwak:
-      attack: ''
-      damage: ''
-    msak:
-      attack: ''
-      damage: ''
-    rsak:
-      attack: ''
-      damage: ''
-    abilities:
-      check: ''
-      save: ''
-      skill: ''
     spell:
       dc: ''
   skills:
@@ -182,7 +148,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ani:
       ability: wis
@@ -192,7 +157,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     arc:
       ability: int
@@ -202,7 +166,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ath:
       ability: str
@@ -212,7 +175,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     dec:
       ability: cha
@@ -222,7 +184,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     his:
       ability: int
@@ -232,7 +193,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ins:
       ability: wis
@@ -242,7 +202,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     itm:
       ability: cha
@@ -252,7 +211,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     inv:
       ability: int
@@ -262,7 +220,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     med:
       ability: wis
@@ -272,7 +229,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     nat:
       ability: int
@@ -282,7 +238,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prc:
       ability: wis
@@ -292,7 +247,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     prf:
       ability: cha
@@ -302,7 +256,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     per:
       ability: cha
@@ -312,7 +265,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     rel:
       ability: int
@@ -322,7 +274,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     slt:
       ability: dex
@@ -332,7 +283,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     ste:
       ability: dex
@@ -342,7 +292,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
     sur:
       ability: wis
@@ -352,7 +301,6 @@ system:
         mode: 0
       value: 0
       bonuses:
-        check: ''
         passive: ''
   tools: {}
   spells:
@@ -393,13 +341,13 @@ system:
         min: null
         max: null
         mode: 0
-      bonus: ''
     movement:
-      climb: '40'
-      walk: '40'
       units: null
       hover: false
       ignoredDifficultTerrain: []
+      speeds:
+        walk: '40'
+        climb: '40'
     attunement:
       max: 3
     senses:
@@ -418,12 +366,13 @@ system:
         min: null
         max: null
         mode: 0
-      bonuses:
-        save: ''
       limit: 1
     ac:
       flat: 11
-      calc: natural
+      calcs:
+        - natural
+      formulas: []
+      override: null
     hd:
       spent: 0
     hp:
@@ -439,8 +388,6 @@ system:
         mode: 0
       success: 0
       failure: 0
-      bonuses:
-        save: ''
     spell:
       level: 0
     loyalty: {}
@@ -460,15 +407,16 @@ system:
       inside: false
   source:
     rules: '2024'
-    license: CC-BY-4.0
-    book: ''
     custom: ''
     revision: 1
+    book: ''
+    license: CC-BY-4.0
+  rolls: {}
 _id: phbmobGiantInsec
 img: ''
 prototypeToken:
   name: Giant Insect
-  displayName: 20
+  displayName: 0
   actorLink: false
   appendNumber: false
   prependAdjective: false
@@ -487,7 +435,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 20
+  displayBars: 0
   bar1:
     attribute: attributes.hp
   bar2:
@@ -528,7 +476,7 @@ prototypeToken:
   occludable:
     radius: 0
   ring:
-    enabled: false
+    enabled: true
     colors:
       ring: null
       background: null
@@ -556,8 +504,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -568,15 +514,15 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
-      properties: []
+        repeatable: false
+      properties:
+        - trait
       requirements: ''
       activities: {}
       enchant: {}
       identifier: spider-climb
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiSpiderClim
     type: feat
@@ -591,26 +537,25 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573243
+      modifiedTime: 1787693573243
     _key: '!actors.items!phbmobGiantInsec.phbaoiSpiderClim'
   - name: Multiattack
     system:
       description:
         value: >-
           <p>The insect makes a number of attacks equal to half this spell's
-          level (round down).</p><p>[[floor(@flags.dnd5e.summon.level /
-          2)]]{Number of attacks}</p>
+          level (round down).</p><p
+          class="hide-in-embed">[[floor(@flags.dnd5e.summon.level / 2)]]{Number
+          of attacks}</p>
         chat: ''
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -621,8 +566,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: ''
       activities:
@@ -642,6 +587,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -662,6 +608,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -687,10 +634,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: multiattack
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiMultiattac
     type: feat
@@ -709,12 +656,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573243
+      modifiedTime: 1787693573243
     _key: '!actors.items!phbmobGiantInsec.phbaoiMultiattac'
   - name: Poison Jab
     system:
@@ -727,8 +674,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -739,8 +684,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: ''
       activities:
@@ -760,6 +705,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -781,6 +727,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -812,6 +759,7 @@ items:
                   - piercing
                 scaling:
                   number: 1
+                modifiers: []
               - custom:
                   enabled: false
                   formula: ''
@@ -822,6 +770,7 @@ items:
                   - poison
                 scaling:
                   number: 1
+                modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -835,10 +784,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: poison-jab
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiPoisonJab0
     type: feat
@@ -857,14 +806,14 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573243
+      modifiedTime: 1787693573243
     _key: '!actors.items!phbmobGiantInsec.phbaoiPoisonJab0'
-  - name: Web Bolt
+  - name: Web Bolt (Spider Only)
     system:
       description:
         value: >-
@@ -876,8 +825,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -888,8 +835,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: Spider Only
       activities:
@@ -909,6 +856,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: ''
             units: inst
@@ -918,6 +866,7 @@ items:
           effects:
             - _id: Gvwt9wpCcJgC0yMl
               level: {}
+              uuid: null
           range:
             value: '60'
             units: ft
@@ -932,6 +881,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: ''
               type: ''
@@ -965,6 +915,7 @@ items:
                   mode: whole
                   number: null
                   formula: ''
+                modifiers: []
           uses:
             spent: 0
             recovery: []
@@ -976,10 +927,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: web-bolt
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiWebBoltSpi
     type: feat
@@ -1004,34 +955,43 @@ items:
               priority: null
               type: downgrade
               phase: initial
-              _id: IKiZkNTKBtDTIm4O
+              _id: bP6IQDuphvqfK1P4
+              conditions: '{}'
             - key: system.attributes.movement.burrow
               value: 0
               priority: null
               type: downgrade
               phase: initial
-              _id: ajDUNdNYiGRTE0ZA
+              _id: iIun4xJlkzVnjuTa
+              conditions: '{}'
             - key: system.attributes.movement.climb
               value: 0
               priority: null
               type: downgrade
               phase: initial
-              _id: 9yKtj289ZloJ5XXq
+              _id: bs7PgySrkZ0oyyxX
+              conditions: '{}'
             - key: system.attributes.movement.fly
               value: 0
               priority: null
               type: downgrade
               phase: initial
-              _id: UTHrRE7UHLcJ0wL2
+              _id: qyXk7fqKpH15VRgo
+              conditions: '{}'
             - key: system.attributes.movement.swim
               value: 0
               priority: null
               type: downgrade
               phase: initial
-              _id: b6f4ZiB88KetfuDn
+              _id: AObMCYFsY6zKOXbS
+              conditions: '{}'
+          conditions: '{}'
+          magical: false
+          rider:
+            statuses: []
         description: >-
-          <p><span style="font-family:Signika, sans-serif">The target’s Speed is
-          reduced to 0 until the start of the insect’s next turn.</span></p>
+          <p>The target’s Speed is reduced to 0 until the start of the insect’s
+          next turn.</p>
         tint: '#ffffff'
         transfer: false
         statuses: []
@@ -1040,12 +1000,12 @@ items:
           compendiumSource: null
           duplicateSource: null
           exportSource: null
-          coreVersion: '14.364'
+          coreVersion: '14.367'
           systemId: dnd5e
           systemVersion: 6.0.0
           lastModifiedBy: dnd5ebuilder0000
-          createdTime: 1783544184759
-          modifiedTime: 1783544184759
+          createdTime: 1787693573243
+          modifiedTime: 1787693573243
         start: null
         showIcon: 1
         folder: null
@@ -1060,14 +1020,14 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
+      systemVersion: 6.0.0
       lastModifiedBy: dnd5ebuilder0000
-      createdTime: 1783544184759
-      modifiedTime: 1783544184759
+      createdTime: 1787693573243
+      modifiedTime: 1787693573243
     _key: '!actors.items!phbmobGiantInsec.phbaoiWebBoltSpi'
-  - name: Venomous Spew
+  - name: Venomous Spew (Centipede Only)
     system:
       description:
         value: >-
@@ -1079,8 +1039,6 @@ items:
       source:
         custom: ''
         rules: '2024'
-        book: ''
-        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -1091,8 +1049,8 @@ items:
         subtype: ''
       prerequisites:
         level: null
-        repeatable: false
         items: []
+        repeatable: false
       properties: []
       requirements: Centipede Only
       activities:
@@ -1112,6 +1070,7 @@ items:
             spellSlot: true
           description:
             chatFlavor: ''
+            value: ''
           duration:
             value: '1'
             units: round
@@ -1122,6 +1081,7 @@ items:
             - _id: jVWtHTrlPNi4dpDi
               onSave: false
               level: {}
+              uuid: null
           range:
             value: '10'
             units: ft
@@ -1136,6 +1096,7 @@ items:
               width: ''
               height: ''
               units: ft
+              stationary: false
             affects:
               count: '1'
               type: creature
@@ -1152,6 +1113,7 @@ items:
             dc:
               calculation: spellcasting
               formula: ''
+            visible: true
           uses:
             spent: 0
             recovery: []
@@ -1165,10 +1127,10 @@ items:
             requireAttunement: false
             requireIdentification: false
             requireMagic: false
+          behaviors: []
       enchant: {}
       identifier: venomous-spew
       advancement: {}
-      cover: null
       crewed: false
     _id: phbaoiVenomousSp
     type: feat
@@ -1182,11 +1144,15 @@ items:
         type: base
         system:
           changes: []
+          conditions: '{}'
+          magical: false
+          rider:
+            statuses: []
         disabled: false
         duration:
-          value: 1
-          units: rounds
-          expiry: turnStart
+          value: null
+          units: seconds
+          expiry: sourceStart
           expired: false
         description: >-
           <p>The target has the &amp;Reference[Poisoned apply=false] condition
@@ -1197,16 +1163,15 @@ items:
         sort: 0
         flags: {}
         _stats:
-          compendiumSource: >-
-            Compendium.dnd5e.actors24.Actor.phbginGiantCenti.Item.phbaoiVenomousSp.ActiveEffect.uUvxWKSj8qQRIbTK
+          compendiumSource: null
           duplicateSource: null
           exportSource: null
-          coreVersion: '14.364'
+          coreVersion: '14.367'
           systemId: dnd5e
-          systemVersion: 5.3.0
-          lastModifiedBy: null
-          createdTime: null
-          modifiedTime: null
+          systemVersion: 6.0.0
+          lastModifiedBy: dnd5ebuilder0000
+          createdTime: 1787693573244
+          modifiedTime: 1787693573244
         showIcon: 2
         start: null
         folder: null
@@ -1225,12 +1190,12 @@ items:
       compendiumSource: null
       duplicateSource: null
       exportSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
-      systemVersion: 5.3.0
-      lastModifiedBy: null
-      createdTime: null
-      modifiedTime: null
+      systemVersion: 6.0.0
+      lastModifiedBy: dnd5ebuilder0000
+      createdTime: 1787693573244
+      modifiedTime: 1787693573244
     _key: '!actors.items!phbmobGiantInsec.phbaoiVenomousSp'
 effects: []
 folder: 4Lxoa4gitE28qJLk
@@ -1240,13 +1205,18 @@ ownership:
 flags:
   dnd5e:
     showTokenPortrait: false
+    statBlockOverride:
+      ac: 11 + the spell’s level
+      hp: 30 + 10 for each spell level above 4
+      pb: equals your Proficiency Bonus
+      speed: 40 ft., Climb 40 ft., Fly 40 ft. (Wasp only)
 _stats:
   duplicateSource: null
   exportSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
   systemVersion: 6.0.0
-  createdTime: 1783544184758
-  modifiedTime: 1783544184758
+  createdTime: 1787693573242
+  modifiedTime: 1787693573242
   lastModifiedBy: dnd5ebuilder0000
 _key: '!actors!phbmobGiantInsec'

--- a/packs/_source/actors24/summons/summon-templates/giant-insect.yml
+++ b/packs/_source/actors24/summons/summon-templates/giant-insect.yml
@@ -416,7 +416,7 @@ _id: phbmobGiantInsec
 img: ''
 prototypeToken:
   name: Giant Insect
-  displayName: 0
+  displayName: 20
   actorLink: false
   appendNumber: false
   prependAdjective: false
@@ -435,7 +435,7 @@ prototypeToken:
   rotation: 0
   alpha: 1
   disposition: 1
-  displayBars: 0
+  displayBars: 20
   bar1:
     attribute: attributes.hp
   bar2:
@@ -504,6 +504,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -556,6 +557,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -674,6 +676,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -825,6 +828,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''
@@ -1039,6 +1043,7 @@ items:
       source:
         custom: ''
         rules: '2024'
+        license: CC-BY-4.0
         revision: 1
       uses:
         max: ''

--- a/packs/_source/effects/spells/_folder.yml
+++ b/packs/_source/effects/spells/_folder.yml
@@ -1,0 +1,19 @@
+type: ActiveEffect
+folder: null
+name: Spells
+color: null
+sorting: a
+_id: xOsCK7cF2ShkrOva
+description: ''
+sort: 0
+flags: {}
+_stats:
+  coreVersion: '14.365'
+  systemId: dnd5e
+  systemVersion: 6.0.0
+  createdTime: 1786472504966
+  modifiedTime: 1786472504966
+  lastModifiedBy: dnd5ebuilder0000
+  duplicateSource: null
+  exportSource: null
+_key: '!folders!xOsCK7cF2ShkrOva'

--- a/packs/_source/effects/spells/aura-of-life.yml
+++ b/packs/_source/effects/spells/aura-of-life.yml
@@ -1,0 +1,47 @@
+name: Aura of Life
+origin: null
+duration:
+  value: null
+  units: minutes
+  expiry: null
+  expired: false
+disabled: false
+flags: {}
+img: icons/magic/life/ankh-gold-blue.webp
+_id: phbeffAuraLife00
+type: base
+system:
+  changes:
+    - key: system.traits.dr.value
+      value: necrotic
+      priority: null
+      type: add
+      phase: initial
+      _id: BFfQCpqoUoA9soAX
+      conditions: '{}'
+  magical: true
+  rider:
+    statuses: []
+  conditions: '{}'
+description: >-
+  <p>While in the aura, you and your allies have Resistance to Necrotic damage,
+  and your Hit Point maximums can’t be reduced. If an ally with 0 Hit Points
+  starts its turn in the aura, that ally regains [[/healing 1 type=healing]]{1
+  Hit Point}.</p>
+tint: '#ffffff'
+transfer: false
+statuses: []
+_stats:
+  coreVersion: '14.365'
+  systemId: dnd5e
+  systemVersion: 6.0.0
+  createdTime: 1786472007764
+  modifiedTime: 1786472507248
+  lastModifiedBy: dnd5ebuilder0000
+  duplicateSource: null
+  exportSource: null
+start: null
+showIcon: 1
+folder: xOsCK7cF2ShkrOva
+sort: 100000
+_key: '!effects!phbeffAuraLife00'

--- a/packs/_source/effects/spells/silenced.yml
+++ b/packs/_source/effects/spells/silenced.yml
@@ -1,0 +1,48 @@
+name: Silenced
+_id: phbeffSilenced00
+img: icons/magic/control/encase-creature-humanoid-hold.webp
+type: base
+system:
+  changes:
+    - key: system.traits.di.value
+      type: add
+      value: thunder
+      phase: initial
+      _id: ngm6hLRTOqg1czSH
+      priority: null
+      conditions: '{}'
+  magical: true
+  rider:
+    statuses: []
+  conditions: '{}'
+disabled: false
+start: null
+duration:
+  value: null
+  units: minutes
+  expiry: null
+  expired: false
+description: >-
+  <p>Any creature or object entirely inside the Sphere has Immunity to Thunder
+  damage, and creatures have the Deafened condition while entirely inside it.
+  Casting a spell that includes a Verbal component is impossible there.</p>
+origin: null
+tint: '#ffffff'
+transfer: false
+statuses:
+  - deafened
+  - silenced
+showIcon: 1
+folder: xOsCK7cF2ShkrOva
+sort: 0
+flags: {}
+_stats:
+  coreVersion: '14.365'
+  systemId: dnd5e
+  systemVersion: 6.0.0
+  createdTime: 1786472101980
+  modifiedTime: 1786472508027
+  lastModifiedBy: dnd5ebuilder0000
+  duplicateSource: null
+  exportSource: null
+_key: '!effects!phbeffSilenced00'

--- a/packs/_source/spells24/1st-level/color-spray.yml
+++ b/packs/_source/spells24/1st-level/color-spray.yml
@@ -10,8 +10,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -31,6 +33,7 @@ system:
       size: '15'
       contiguous: false
       count: ''
+      stationary: false
   range:
     units: self
     special: ''
@@ -49,9 +52,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -65,20 +65,28 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: DKl58EVNaSX976co
+          uuid: null
+          level: {}
+          onSave: false
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -86,15 +94,27 @@ system:
         onSave: half
         parts: []
       save:
-        ability: con
+        ability:
+          - con
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
       sort: 0
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: color-spray
+  method: spell
+  prepared: 0
 _id: phbsplColorSpray
 type: spell
 img: icons/magic/light/hand-sparks-smoke-green.webp
@@ -108,47 +128,49 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
-      value: 1
-      units: rounds
-      expiry: turnStart
+      value: null
+      units: turns
+      expiry: sourceEnd
       expired: false
     description: ''
     tint: '#ffffff'
-    statuses: []
+    statuses:
+      - blinded
     sort: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725046777685
-      modifiedTime: 1783543974386
+      createdTime: 1787693525856
+      modifiedTime: 1787693525856
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
-    showIcon: 1
+    showIcon: 2
     folder: null
     _key: '!items.effects!phbsplColorSpray.DKl58EVNaSX976co'
 folder: pBaAAtXBCq9FVEnL
 sort: 4800000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425945486
-  modifiedTime: 1783543974386
+  systemVersion: 6.0.0
+  createdTime: 1787693525856
+  modifiedTime: 1787693525856
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplColorSpray'

--- a/packs/_source/spells24/1st-level/entangle.yml
+++ b/packs/_source/spells24/1st-level/entangle.yml
@@ -16,9 +16,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
-    revision: 2
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -36,6 +37,7 @@ system:
       size: '20'
       contiguous: false
       count: ''
+      stationary: false
   range:
     value: '90'
     units: ft
@@ -55,9 +57,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -71,21 +70,30 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: wn7K2m4XhXhItgPT
+          uuid: null
           onSave: false
+          level:
+            min: null
+            max: null
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -93,15 +101,41 @@ system:
         onSave: half
         parts: []
       save:
-        ability: str
+        ability:
+          - str
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
+        max: ''
       sort: 0
+      img: ''
+      behaviors:
+        - name: ''
+          _id: B2ZFUM5G3wW3feMi
+          type: difficultTerrain
+          config:
+            types:
+              - plants
+          level:
+            min: null
+            max: null
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      name: ''
   identifier: entangle
+  method: spell
+  prepared: 0
 _id: phbsplEntangle00
 type: spell
 img: icons/magic/nature/root-vine-entangle-foot-green.webp
@@ -121,6 +155,9 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
       <p>A Restrained creature can take an action to make a [[/check ability=str
       skill=ath]] check against your spell save DC. On a success, it frees
@@ -133,11 +170,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543974956
-      modifiedTime: 1783543974956
+      createdTime: 1786472051192
+      modifiedTime: 1786472051192
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -148,18 +185,14 @@ folder: pBaAAtXBCq9FVEnL
 sort: 3400000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425952240
-  modifiedTime: 1783543974956
+  systemVersion: 6.0.0
+  createdTime: 1786472051192
+  modifiedTime: 1786472051192
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplEntangle00'

--- a/packs/_source/spells24/1st-level/guiding-bolt.yml
+++ b/packs/_source/spells24/1st-level/guiding-bolt.yml
@@ -11,8 +11,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
+    page: ''
+    license: CC-BY-4.0
+    revision: 2
   activation:
     type: action
     condition: ''
@@ -27,9 +29,10 @@ system:
       choice: false
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     value: '120'
     units: ft
@@ -48,9 +51,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -64,20 +64,27 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: rHzZCeXfdeTcYyk8
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -107,11 +114,22 @@ system:
               mode: whole
               number: 1
               formula: ''
+            modifiers: []
       uses:
         spent: 0
         recovery: []
       sort: 0
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: guiding-bolt
+  method: spell
+  prepared: 0
 _id: phbsplGuidingBol
 type: spell
 img: icons/magic/light/projectile-flare-blue.webp
@@ -119,22 +137,26 @@ effects:
   - name: Guiding Bolt
     origin: Compendium.dnd5e.spells24.Item.phbsplGuidingBol
     duration:
-      value: 1
-      units: rounds
-      expiry: turnStart
+      value: null
+      units: seconds
+      expiry: sourceEnd
       expired: false
     disabled: false
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     img: icons/skills/targeting/target-strike-triple-blue.webp
     _id: rHzZCeXfdeTcYyk8
     type: base
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
-      <p><span style="font-family:Signika, sans-serif">The next attack roll made
-      against the target before the end of your next turn has
-      Advantage.</span></p>
+      <p>The next attack roll made against the target before the end of your
+      next turn has Advantage.</p>
     tint: '#ffffff'
     transfer: false
     statuses:
@@ -143,11 +165,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543975409
-      modifiedTime: 1783543975409
+      createdTime: 1787693578383
+      modifiedTime: 1787693578383
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -158,18 +180,14 @@ folder: pBaAAtXBCq9FVEnL
 sort: 2500000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425957500
-  modifiedTime: 1783543975409
+  systemVersion: 6.0.0
+  createdTime: 1787693578383
+  modifiedTime: 1787693578383
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplGuidingBol'

--- a/packs/_source/spells24/1st-level/ray-of-sickness.yml
+++ b/packs/_source/spells24/1st-level/ray-of-sickness.yml
@@ -4,33 +4,39 @@ system:
     value: >-
       <p>You shoot a greenish ray at a creature within range. Make a ranged
       spell attack against the target. On a hit, the target takes 2d8 Poison
-      damage and has the &amp;Reference[poisoned] condition until the end of
-      your next turn.</p><p><strong>Using a Higher-Level Spell Slot.</strong>
-      The damage increases by 1d8 for each spell slot level above 1.</p>
+      damage and has the &amp;Reference[poisoned apply=false] condition until
+      the end of your next turn.</p><p><strong>Using a Higher-Level Spell
+      Slot.</strong> The damage increases by 1d8 for each spell slot level above
+      1.</p>
     chat: ''
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
     value: null
   duration:
-    value: ''
+    value: '1'
     units: inst
   target:
     affects:
       type: creature
       count: '1'
       choice: false
+      special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
+      type: ''
+      stationary: false
   range:
     value: '60'
     units: ft
+    special: ''
   uses:
     max: ''
     recovery: []
@@ -45,9 +51,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -61,19 +64,27 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
-      effects: []
+        concentration: false
+      effects:
+        - _id: twUSPBjcoiuiu1mJ
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -103,31 +114,82 @@ system:
               mode: whole
               number: 1
               formula: ''
+            modifiers: []
       uses:
         spent: 0
         recovery: []
+        max: ''
       sort: 0
+      name: ''
+      img: ''
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      behaviors: []
+      flags: {}
   identifier: ray-of-sickness
+  method: spell
+  prepared: 0
 _id: phbsplRayofSickn
 type: spell
 img: icons/magic/unholy/beam-impact-green.webp
-effects: []
+effects:
+  - name: Poisoned
+    img: systems/dnd5e/icons/svg/statuses/poisoned.svg
+    origin: Compendium.dnd5e.spells24.Item.phbsplRayofSickn
+    type: base
+    _id: twUSPBjcoiuiu1mJ
+    system:
+      changes: []
+      magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
+    disabled: false
+    duration:
+      value: null
+      units: turns
+      expiry: sourceEnd
+      expired: false
+    description: ''
+    tint: '#ffffff'
+    transfer: false
+    statuses:
+      - poisoned
+    sort: 0
+    flags:
+      dnd5e:
+        riders: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '14.367'
+      systemId: dnd5e
+      systemVersion: 6.0.0
+      createdTime: 1787693621452
+      modifiedTime: 1787693621452
+      lastModifiedBy: dnd5ebuilder0000
+    showIcon: 2
+    start: null
+    folder: null
+    _key: '!items.effects!phbsplRayofSickn.twUSPBjcoiuiu1mJ'
 folder: pBaAAtXBCq9FVEnL
 sort: 900000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425968661
-  modifiedTime: 1745256797477
+  systemVersion: 6.0.0
+  createdTime: 1787693621452
+  modifiedTime: 1787693621452
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplRayofSickn'

--- a/packs/_source/spells24/1st-level/shield.yml
+++ b/packs/_source/spells24/1st-level/shield.yml
@@ -5,14 +5,15 @@ system:
       <p>An imperceptible barrier of magical force protects you. Until the start
       of your next turn, you have a +5 bonus to AC, including against the
       triggering attack, and you take no damage from
-      <em>@UUID[Compendium.dnd5e.spells24.Item.phbsplMagicMissi]{Magic
+      <em>@UUID[Compendium.dnd-players-handbook.spells.Item.phbsplMagicMissi]{Magic
       Missile}</em>.</p>
     chat: ''
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    license: CC-BY-4.0
   activation:
     type: reaction
     condition: when you are hit by an attack roll or targeted by the Magic Missile spell
@@ -27,9 +28,10 @@ system:
       type: self
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: self
     special: ''
@@ -47,9 +49,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -63,20 +62,27 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: Bv3EoHGfYCprLdG1
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -92,9 +98,16 @@ system:
       sort: 0
       name: ''
       img: ''
-      appliedEffects:
-        - Bv3EoHGfYCprLdG1
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: shield
+  method: spell
+  prepared: 0
 _id: phbsplShield0000
 type: spell
 img: icons/equipment/shield/heater-crystal-blue.webp
@@ -103,9 +116,9 @@ effects:
     flags: {}
     disabled: true
     duration:
-      value: 1
+      value: null
       units: rounds
-      expiry: turnStart
+      expiry: sourceStart
       expired: false
     origin: Compendium.dnd5e.spells24.Item.phbsplShield0000
     tint: '#ffffff'
@@ -117,14 +130,13 @@ effects:
       Missile</em>.</p>
     statuses: []
     _stats:
-      compendiumSource: >-
-        Compendium.dnd5e.spells.Item.z1mx84ONwkXKUZd7.ActiveEffect.6pbotGIvqQkraPva
+      compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543976775
-      modifiedTime: 1783543976775
+      createdTime: 1787693626984
+      modifiedTime: 1787693626984
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     img: icons/equipment/shield/heater-steel-crystal-red.webp
@@ -136,8 +148,12 @@ effects:
           priority: null
           type: add
           phase: initial
-          _id: ksKJTeu1kVZikrvL
+          _id: AOVTL6UbE1BphM3E
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     sort: 0
     start: null
     showIcon: 1
@@ -147,18 +163,14 @@ folder: pBaAAtXBCq9FVEnL
 sort: 700000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425970477
-  modifiedTime: 1783543976775
+  systemVersion: 6.0.0
+  createdTime: 1787693626984
+  modifiedTime: 1787693626984
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplShield0000'

--- a/packs/_source/spells24/2nd-level/alter-self.yml
+++ b/packs/_source/spells24/2nd-level/alter-self.yml
@@ -26,8 +26,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -42,9 +44,10 @@ system:
       type: self
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: self
     special: ''
@@ -63,9 +66,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -79,20 +79,27 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: 6SL9vuAkx7nAfS5D
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -108,8 +115,13 @@ system:
       sort: 0
       name: Aquatic Adaptation
       img: icons/creatures/fish/fish-bluefin-yellow-blue.webp
-      appliedEffects:
-        - 6SL9vuAkx7nAfS5D
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     wQGpfux8qzcvwsDo:
       type: utility
       _id: wQGpfux8qzcvwsDo
@@ -124,18 +136,23 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       effects:
         - _id: 1jrUeJtfZMGhJOZa
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -152,8 +169,13 @@ system:
         formula: ''
       name: Change Appearance
       img: icons/creatures/magical/spirit-undead-ghost-blue.webp
-      appliedEffects:
-        - 1jrUeJtfZMGhJOZa
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     dQnMvyjoGqhgl9wP:
       type: utility
       _id: dQnMvyjoGqhgl9wP
@@ -168,18 +190,23 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       effects:
         - _id: baEBDez6IgWNpkSX
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -196,8 +223,13 @@ system:
         formula: ''
       name: Natural Weapons
       img: icons/creatures/abilities/fang-tooth-blood-red.webp
-      appliedEffects:
-        - baEBDez6IgWNpkSX
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     SEwXqOHdPCyejSYR:
       type: attack
       name: 'Attack: Claws'
@@ -213,6 +245,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -227,6 +260,7 @@ system:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -254,14 +288,22 @@ system:
               enabled: false
               formula: ''
             number: 1
-            denomination: '6'
+            denomination: 6
             bonus: '@mod'
             types:
               - slashing
             scaling:
               mode: ''
+              number: 1
+            modifiers: []
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     osceJQzUOQPJ9CLn:
       type: attack
       name: 'Attack: Fangs/Horns'
@@ -276,6 +318,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -290,6 +333,7 @@ system:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -317,15 +361,23 @@ system:
               enabled: false
               formula: ''
             number: 1
-            denomination: '6'
+            denomination: 6
             bonus: '@mod'
             types:
               - piercing
             scaling:
               mode: ''
+              number: 1
+            modifiers: []
       _id: osceJQzUOQPJ9CLn
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     eHtpASAnamFUc69H:
       type: attack
       name: 'Attack: Hooves'
@@ -340,6 +392,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -354,6 +407,7 @@ system:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -381,16 +435,26 @@ system:
               enabled: false
               formula: ''
             number: 1
-            denomination: '6'
+            denomination: 6
             bonus: '@mod'
             types:
               - bludgeoning
             scaling:
               mode: ''
+              number: 1
+            modifiers: []
       _id: eHtpASAnamFUc69H
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: alter-self
+  method: spell
+  prepared: 0
 _id: phbsplAlterSelf0
 type: spell
 img: icons/magic/control/silhouette-hold-change-green.webp
@@ -404,12 +468,16 @@ effects:
     system:
       changes:
         - key: system.attributes.movement.swim
-          value: 1
+          value: '@attributes.movement.speed'
           priority: null
           type: upgrade
           phase: initial
-          _id: RMkElG5syvNWdrap
+          _id: Y1VzPEUPwB3QhhV2
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: 3600
@@ -422,15 +490,17 @@ effects:
     tint: '#ffffff'
     statuses: []
     sort: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725048208451
-      modifiedTime: 1783543973848
+      createdTime: 1786481079598
+      modifiedTime: 1786481079598
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -446,6 +516,9 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: 3600
@@ -460,11 +533,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725048980878
-      modifiedTime: 1783543973849
+      createdTime: 1786481079599
+      modifiedTime: 1786481079599
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -480,6 +553,9 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: 3600
@@ -499,11 +575,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725049566534
-      modifiedTime: 1783543973849
+      createdTime: 1786481079599
+      modifiedTime: 1786481079599
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -514,18 +590,14 @@ folder: 3SjcO2acsFnWegp4
 sort: 5600000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 5.2.0
-  createdTime: 1724425940243
-  modifiedTime: 1783543973848
+  systemVersion: 6.0.0
+  createdTime: 1786481079598
+  modifiedTime: 1786481079598
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplAlterSelf0'

--- a/packs/_source/spells24/2nd-level/enlarge-reduce.yml
+++ b/packs/_source/spells24/2nd-level/enlarge-reduce.yml
@@ -23,9 +23,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
-    book: ''
     revision: 2
+    book: ''
+    page: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -40,9 +41,10 @@ system:
       choice: false
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     value: '30'
     units: ft
@@ -63,9 +65,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -79,23 +78,32 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: Wi2E10l7n6Ka8k6u
           onSave: false
+          uuid: null
+          level: {}
         - _id: NXdtOxX4HvPeodml
           onSave: false
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -103,15 +111,27 @@ system:
         onSave: half
         parts: []
       save:
-        ability: con
+        ability:
+          - con
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
       sort: 0
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: enlarge-reduce
+  method: spell
+  prepared: 0
 _id: phbsplEnlargeRed
 type: spell
 img: icons/consumables/mushrooms/mushroom-spotted-red.webp
@@ -133,31 +153,45 @@ effects:
     type: base
     system:
       changes:
-        - key: system.bonuses.mwak.damage
+        - key: system.rolls.damage.mwak.bonus
           value: 1d4
           priority: null
           type: add
           phase: initial
-          _id: BILOOAY4dj2TaYo6
-        - key: system.bonuses.rwak.damage
+          _id: liAne1IbyyUNiCd4
+          conditions: '{}'
+        - key: system.rolls.damage.rwak.bonus
           value: 1d4
           priority: null
           type: add
           phase: initial
-          _id: Ads6r9B1HxdiUZCy
+          _id: 1tyB0m0RWR13wAn5
+          conditions: '{}'
         - key: system.abilities.str.check.roll.mode
           value: 1
           priority: null
           type: add
           phase: initial
-          _id: 4FOwOOP9LfyeEvZM
+          _id: PclGL5LwNTZqjO7v
+          conditions: '{}'
         - key: system.abilities.str.save.roll.mode
           value: 1
           priority: null
           type: add
           phase: initial
-          _id: svpIMfPDpRdBNBk4
+          _id: rwlTBEmpSIHiE04n
+          conditions: '{}'
+        - key: system.traits.size
+          type: add
+          value: 1
+          phase: initial
+          _id: qavAEe7zJsBCoVvd
+          conditions: '{}'
+          priority: null
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
       <p>The target’s size increases by one category—from Medium to Large, for
       example. The target also has Advantage on Strength checks and Strength
@@ -170,11 +204,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543974912
-      modifiedTime: 1783543974912
+      createdTime: 1786480120519
+      modifiedTime: 1786480120519
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -198,31 +232,45 @@ effects:
     type: base
     system:
       changes:
-        - key: system.bonuses.mwak.damage
-          value: '- 1d4'
+        - key: system.rolls.damage.mwak.bonus
+          value: 1d4
           priority: null
-          type: add
+          type: subtract
           phase: initial
-          _id: 6lp3F7BQYinW6zgt
-        - key: system.bonuses.rwak.damage
-          value: '- 1d4'
+          _id: Y6EVhD7qmhHWwX7S
+          conditions: '{}'
+        - key: system.rolls.damage.rwak.bonus
+          value: 1d4
           priority: null
-          type: add
+          type: subtract
           phase: initial
-          _id: 7TaorlUsDOitZvcY
+          _id: 1tSKjRN5ozmQODHH
+          conditions: '{}'
         - key: system.abilities.str.check.roll.mode
           value: -1
           priority: null
           type: add
           phase: initial
-          _id: qxCndCBm9LBJD8ln
+          _id: 8hcR8EZuZfBZjX1r
+          conditions: '{}'
         - key: system.abilities.str.save.roll.mode
           value: -1
           priority: null
           type: add
           phase: initial
-          _id: kA20tabH3yLdR1Jh
+          _id: RfEQNZwYek96Scpu
+          conditions: '{}'
+        - key: system.traits.size
+          type: subtract
+          value: 1
+          phase: initial
+          _id: alrq1Wu0gwWCg3EA
+          conditions: '{}'
+          priority: null
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
       <p>The target’s size decreases by one category—from Medium to Small, for
       example. The target also has Disadvantage on Strength checks and Strength
@@ -236,11 +284,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543974912
-      modifiedTime: 1783543974912
+      createdTime: 1786480120519
+      modifiedTime: 1786480120519
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -254,11 +302,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 5.1.9
-  createdTime: 1724425952041
-  modifiedTime: 1783543974912
+  systemVersion: 6.0.0
+  createdTime: 1786480120518
+  modifiedTime: 1786480120518
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplEnlargeRed'

--- a/packs/_source/spells24/2nd-level/enlarge-reduce.yml
+++ b/packs/_source/spells24/2nd-level/enlarge-reduce.yml
@@ -23,7 +23,7 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 2
+    revision: 3
     book: ''
     page: ''
     license: CC-BY-4.0

--- a/packs/_source/spells24/2nd-level/find-steed.yml
+++ b/packs/_source/spells24/2nd-level/find-steed.yml
@@ -6,8 +6,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -22,9 +23,10 @@ system:
       choice: false
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     value: '30'
     units: ft
@@ -43,9 +45,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -59,18 +58,23 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -87,6 +91,8 @@ system:
         proficiency: true
         attacks: true
         saves: true
+        disposition: true
+        ability: ''
       profiles:
         - count: ''
           name: ''
@@ -113,7 +119,6 @@ system:
             max: 3
           types: []
       summon:
-        identifier: ''
         mode: ''
         prompt: true
       uses:
@@ -123,8 +128,17 @@ system:
       sort: 0
       name: Summon Steed
       img: ''
-      appliedEffects: []
       effects: []
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      tempHP: ''
+      behaviors: []
+      flags: {}
     o4YsONnsS8rOOEaS:
       type: summon
       activation:
@@ -139,17 +153,20 @@ system:
         spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
         concentration: false
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -166,6 +183,8 @@ system:
         proficiency: true
         attacks: true
         saves: true
+        disposition: true
+        ability: ''
       profiles:
         - count: ''
           name: ''
@@ -192,7 +211,6 @@ system:
             max: null
           types: []
       summon:
-        identifier: ''
         mode: ''
         prompt: true
       uses:
@@ -203,11 +221,25 @@ system:
       name: Summon Flying Steed
       effects:
         - _id: SgNNVLaKxZOVKyKx
+          level:
+            min: null
+            max: null
+          uuid: null
       _id: o4YsONnsS8rOOEaS
       img: ''
-      appliedEffects:
-        - SgNNVLaKxZOVKyKx
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      tempHP: ''
+      behaviors: []
+      flags: {}
   identifier: find-steed
+  method: spell
+  prepared: 0
 _id: phbsplFindSteed0
 type: spell
 img: icons/commodities/claws/claw-blue-grey.webp
@@ -231,8 +263,12 @@ effects:
           priority: null
           type: upgrade
           phase: initial
-          _id: rleCxwtCK7SuesbT
+          _id: rA2Vxk7c088zbppZ
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
       <p>The steed has a Fly speed of 60ft. when summoned by a level 4+
       spell.</p>
@@ -243,11 +279,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543975120
-      modifiedTime: 1783543975120
+      createdTime: 1787693557532
+      modifiedTime: 1787693557532
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -258,18 +294,14 @@ folder: 3SjcO2acsFnWegp4
 sort: 3500000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425953437
-  modifiedTime: 1783543975120
+  systemVersion: 6.0.0
+  createdTime: 1787693557532
+  modifiedTime: 1787693557532
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplFindSteed0'

--- a/packs/_source/spells24/2nd-level/heat-metal.yml
+++ b/packs/_source/spells24/2nd-level/heat-metal.yml
@@ -18,9 +18,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
-    revision: 2
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -35,9 +36,10 @@ system:
       choice: false
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     value: '60'
     units: ft
@@ -58,9 +60,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -78,12 +77,16 @@ system:
         spellSlot: false
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: true
+        concentration: false
       effects:
         - _id: VVQbCUE5W44bF4QU
           onSave: false
+          uuid: null
+          level: {}
       range:
         override: true
         units: any
@@ -94,6 +97,7 @@ system:
           contiguous: false
           units: ft
           type: ''
+          stationary: false
         affects:
           choice: false
           count: '1'
@@ -104,10 +108,12 @@ system:
         onSave: none
         parts: []
       save:
-        ability: con
+        ability:
+          - con
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
@@ -115,8 +121,13 @@ system:
       sort: 100000
       name: On Damage Save
       img: ''
-      appliedEffects:
-        - VVQbCUE5W44bF4QU
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     2jWlvr2titPfBMEm:
       type: damage
       _id: 2jWlvr2titPfBMEm
@@ -132,6 +143,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -139,10 +151,12 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -167,9 +181,16 @@ system:
               mode: whole
               number: 1
               formula: ''
+            modifiers: []
       name: Cast and Heat
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     YPEmwJHX7g68307N:
       type: damage
       sort: 0
@@ -185,6 +206,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -192,10 +214,12 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -220,11 +244,20 @@ system:
               mode: whole
               number: 1
               formula: ''
+            modifiers: []
       name: Reheat
       _id: YPEmwJHX7g68307N
       img: systems/dnd5e/icons/svg/statuses/concentrating.svg
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: heat-metal
+  method: spell
+  prepared: 0
 _id: phbsplHeatMetal0
 type: spell
 img: icons/magic/fire/flame-burning-chain.webp
@@ -238,11 +271,14 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
-      value: 1
+      value: null
       units: rounds
-      expiry: turnStart
+      expiry: sourceStart
       expired: false
     description: >-
       <p>If a creature is holding or wearing the object and takes the damage
@@ -257,11 +293,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725651192762
-      modifiedTime: 1783543975459
+      createdTime: 1787693585380
+      modifiedTime: 1787693585380
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -272,18 +308,14 @@ folder: 3SjcO2acsFnWegp4
 sort: 2900000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425958340
-  modifiedTime: 1783543975459
+  systemVersion: 6.0.0
+  createdTime: 1787693585377
+  modifiedTime: 1787693585377
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplHeatMetal0'

--- a/packs/_source/spells24/2nd-level/misty-step.yml
+++ b/packs/_source/spells24/2nd-level/misty-step.yml
@@ -8,7 +8,7 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 1
+    revision: 2
     book: ''
     license: CC-BY-4.0
   activation:

--- a/packs/_source/spells24/2nd-level/misty-step.yml
+++ b/packs/_source/spells24/2nd-level/misty-step.yml
@@ -8,8 +8,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: bonus
     condition: ''
@@ -23,8 +24,9 @@ system:
       count: '1'
       choice: false
     template:
-      units: ''
+      units: ft
       contiguous: false
+      stationary: false
   range:
     units: self
   uses:
@@ -40,13 +42,10 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
-      type: utility
+      type: teleport
       activation:
         type: action
         value: null
@@ -56,32 +55,50 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects: []
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
-      roll:
-        formula: ''
-        name: ''
-        prompt: false
-        visible: false
       uses:
         spent: 0
         recovery: []
+        max: ''
       sort: 0
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      name: ''
+      teleport:
+        override: true
+        value: '30'
+        units: ft
   identifier: misty-step
+  method: spell
+  prepared: 0
 _id: phbsplMistyStep0
 type: spell
 img: icons/magic/lightning/orb-ball-spiral-blue.webp
@@ -90,18 +107,14 @@ folder: 3SjcO2acsFnWegp4
 sort: 1700000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425964396
-  modifiedTime: 1745256796349
+  systemVersion: 6.0.0
+  createdTime: 1786473187561
+  modifiedTime: 1786473187561
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplMistyStep0'

--- a/packs/_source/spells24/2nd-level/ray-of-enfeeblement.yml
+++ b/packs/_source/spells24/2nd-level/ray-of-enfeeblement.yml
@@ -14,9 +14,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
-    revision: 2
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -30,8 +31,9 @@ system:
       count: '1'
       choice: false
     template:
-      units: ''
+      units: ft
       contiguous: false
+      stationary: false
   range:
     value: '60'
     units: ft
@@ -50,9 +52,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -66,23 +65,32 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: yril8uhQgO1dR507
           onSave: false
+          uuid: null
+          level: {}
         - _id: uaHZaHEalgWa6eoC
           onSave: false
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -90,15 +98,27 @@ system:
         onSave: half
         parts: []
       save:
-        ability: con
+        ability:
+          - con
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
       sort: 0
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: ray-of-enfeeblement
+  method: spell
+  prepared: 0
 _id: phbsplRayofEnfee
 type: spell
 img: icons/magic/lightning/bolt-strike-beam-purple.webp
@@ -106,9 +126,9 @@ effects:
   - name: Brief Enfeeblement
     origin: Compendium.dnd5e.spells24.Item.phbsplRayofEnfee
     duration:
-      value: 1
+      value: null
       units: rounds
-      expiry: turnStart
+      expiry: sourceStart
       expired: false
     disabled: false
     flags: {}
@@ -118,6 +138,9 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
       <p>The target has Disadvantage on the next attack roll it makes until the
       start of your next turn.</p>
@@ -128,11 +151,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543976519
-      modifiedTime: 1783543976519
+      createdTime: 1787693616932
+      modifiedTime: 1787693616932
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -149,8 +172,7 @@ effects:
     disabled: false
     flags:
       dnd5e:
-        riders:
-          statuses: []
+        riders: {}
     img: icons/skills/wounds/blood-cells-disease-green.webp
     _id: uaHZaHEalgWa6eoC
     type: base
@@ -161,38 +183,47 @@ effects:
           priority: null
           type: add
           phase: initial
-          _id: 1uDwblWGdJVTQbBr
+          _id: ogXXyFIH4SZaHtGc
+          conditions: '{}'
         - key: system.bonuses.rwak.damage
           value: '- 1d8'
           priority: null
           type: add
           phase: initial
-          _id: Dil2VSCdXVsZ21rG
+          _id: U6mQsDGcLB1Gi9eC
+          conditions: '{}'
         - key: system.bonuses.msak.damage
           value: '- 1d8'
           priority: null
           type: add
           phase: initial
-          _id: FYKlWyCltgtXaEFg
+          _id: 0fEsVBVIa4MQxEHl
+          conditions: '{}'
         - key: system.bonuses.rsak.damage
           value: '- 1d8'
           priority: null
           type: add
           phase: initial
-          _id: bGHcPQ4Ul0orTs30
+          _id: sUz6h4vGlJHEPjER
+          conditions: '{}'
         - key: system.abilities.str.check.roll.mode
           value: -1
           priority: null
           type: add
           phase: initial
-          _id: Qc2sxBt76YreaDmM
+          _id: WeGsSzxJX8j4qy1F
+          conditions: '{}'
         - key: system.abilities.str.save.roll.mode
           value: -1
           priority: null
           type: add
           phase: initial
-          _id: XVoVArAG1dZU0iwP
+          _id: 72BZsWuUnO9SncJg
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
       <p>The target has Disadvantage on Strength-based D20 Tests for the
       duration. During that time, it also subtracts 1d8 from all its damage
@@ -205,11 +236,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543976519
-      modifiedTime: 1783543976519
+      createdTime: 1787693616932
+      modifiedTime: 1787693616932
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -223,11 +254,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 5.1.9
-  createdTime: 1724425968070
-  modifiedTime: 1783543976519
+  systemVersion: 6.0.0
+  createdTime: 1787693616931
+  modifiedTime: 1787693616931
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplRayofEnfee'

--- a/packs/_source/spells24/2nd-level/silence.yml
+++ b/packs/_source/spells24/2nd-level/silence.yml
@@ -12,7 +12,7 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 1
+    revision: 2
     book: ''
     license: CC-BY-4.0
   activation:

--- a/packs/_source/spells24/2nd-level/silence.yml
+++ b/packs/_source/spells24/2nd-level/silence.yml
@@ -12,8 +12,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -25,10 +26,11 @@ system:
     affects:
       choice: false
     template:
-      units: ''
+      units: ft
       type: sphere
       size: '20'
       contiguous: false
+      stationary: false
   range:
     value: '120'
     units: ft
@@ -48,9 +50,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -64,20 +63,24 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
-      effects:
-        - _id: kjbKMAk1y5VUyEoT
+        concentration: false
+      effects: []
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -89,74 +92,49 @@ system:
       uses:
         spent: 0
         recovery: []
+        max: ''
       sort: 0
+      img: ''
+      behaviors:
+        - name: ''
+          _id: p5aDVXeBpxvl5JRe
+          type: applyActiveEffect
+          config:
+            effects:
+              - Compendium.dnd5e.effects.ActiveEffect.phbeffSilenced00
+            sizes: []
+            types: []
+          level:
+            min: null
+            max: null
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      name: Cast
   identifier: silence
+  method: spell
+  prepared: 0
 _id: phbsplSilence000
 type: spell
 img: icons/magic/control/debuff-chains-orb-movement-blue.webp
-effects:
-  - name: Silenced
-    origin: Compendium.dnd5e.spells24.Item.phbsplSilence000
-    duration:
-      value: 600
-      units: seconds
-      expiry: turnStart
-      expired: false
-    disabled: false
-    flags: {}
-    img: icons/magic/control/encase-creature-humanoid-hold.webp
-    _id: kjbKMAk1y5VUyEoT
-    type: base
-    system:
-      changes:
-        - key: system.traits.di.value
-          value: thunder
-          priority: null
-          type: add
-          phase: initial
-          _id: RJjPYvOAzW7maELZ
-      magical: true
-    description: >-
-      <p>Any creature or object entirely inside the Sphere has Immunity to
-      Thunder damage, and creatures have the Deafened condition while entirely
-      inside it. Casting a spell that includes a Verbal component is impossible
-      there.</p>
-    tint: '#ffffff'
-    transfer: false
-    statuses:
-      - deafened
-      - silenced
-    sort: 0
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '14.364'
-      systemId: dnd5e
-      systemVersion: 6.0.0
-      createdTime: 1783543976980
-      modifiedTime: 1783543976980
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    showIcon: 2
-    start: null
-    folder: null
-    _key: '!items.effects!phbsplSilence000.kjbKMAk1y5VUyEoT'
+effects: []
 folder: 3SjcO2acsFnWegp4
 sort: 500000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425970956
-  modifiedTime: 1783543976980
+  systemVersion: 6.0.0
+  createdTime: 1786472101982
+  modifiedTime: 1786472101982
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplSilence000'

--- a/packs/_source/spells24/2nd-level/spike-growth.yml
+++ b/packs/_source/spells24/2nd-level/spike-growth.yml
@@ -3,9 +3,9 @@ system:
   description:
     value: >-
       <p>The ground in a 20-foot-radius Sphere centered on a point within range
-      sprouts hard spikes and thorns. The area becomes Difficult Terrain for the
-      duration. When a creature moves into or within the area, it takes
-      [[/damage 2d4 type=piercing]] damage for every 5 feet it
+      sprouts hard spikes and thorns. The area becomes &amp;Reference[Difficult
+      Terrain] for the duration. When a creature moves into or within the area,
+      it takes [[/damage 2d4 type=piercing]] damage for every 5 feet it
       travels.</p><p>The transformation of the ground is camouflaged to look
       natural. Any creature that can't see the area when the spell is cast must
       take a Search action and succeed on a [[/check ability=wis skill=prc
@@ -16,9 +16,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
-    revision: 2
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -38,6 +39,7 @@ system:
       size: '20'
       contiguous: false
       count: ''
+      stationary: false
   range:
     value: '150'
     units: ft
@@ -58,9 +60,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -74,19 +73,24 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects: []
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -106,6 +110,7 @@ system:
             scaling:
               mode: ''
               number: 1
+            modifiers: []
       uses:
         spent: 0
         recovery: []
@@ -113,8 +118,27 @@ system:
       sort: 0
       name: ''
       img: ''
-      appliedEffects: []
+      behaviors:
+        - name: ''
+          _id: sOfWSPGymqiAqbGw
+          type: difficultTerrain
+          config:
+            types:
+              - plants
+          level:
+            min: null
+            max: null
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: spike-growth
+  method: spell
+  prepared: 0
 _id: phbsplSpikeGrowt
 type: spell
 img: icons/creatures/abilities/stinger-spine-horn-blood.webp
@@ -123,18 +147,14 @@ folder: 3SjcO2acsFnWegp4
 sort: 300000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425972056
-  modifiedTime: 1745256798632
+  systemVersion: 6.0.0
+  createdTime: 1786472113394
+  modifiedTime: 1786472113394
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplSpikeGrowt'

--- a/packs/_source/spells24/2nd-level/web.yml
+++ b/packs/_source/spells24/2nd-level/web.yml
@@ -22,9 +22,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
-    revision: 2
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -43,6 +44,7 @@ system:
       size: '20'
       contiguous: false
       count: ''
+      stationary: false
   range:
     value: '60'
     units: ft
@@ -63,9 +65,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -79,19 +78,24 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects: []
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -109,18 +113,43 @@ system:
             scaling:
               mode: ''
               number: 1
+            modifiers: []
       save:
-        ability: dex
+        ability:
+          - dex
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
         max: ''
       sort: 0
       name: ''
+      img: ''
+      behaviors:
+        - name: ''
+          _id: eSbdtQ7KsNn0onHD
+          type: difficultTerrain
+          config:
+            types:
+              - web
+          level:
+            min: null
+            max: null
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: web
+  method: spell
+  prepared: 0
 _id: phbsplWeb0000000
 type: spell
 img: icons/creatures/webs/web-spider-casting-caught-purple.webp
@@ -129,18 +158,14 @@ folder: 3SjcO2acsFnWegp4
 sort: 106250
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425977860
-  modifiedTime: 1745256800037
+  systemVersion: 6.0.0
+  createdTime: 1786472123825
+  modifiedTime: 1786472123825
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplWeb0000000'

--- a/packs/_source/spells24/3rd-level/blink.yml
+++ b/packs/_source/spells24/3rd-level/blink.yml
@@ -19,8 +19,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -31,11 +32,15 @@ system:
   target:
     affects:
       choice: false
+      type: self
     template:
-      units: ''
+      units: ft
       contiguous: false
+      type: ''
+      stationary: false
   range:
     units: self
+    special: ''
   uses:
     max: ''
     recovery: []
@@ -50,9 +55,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -66,20 +68,27 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: La5ofK0TnPSTL3iq
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -92,7 +101,17 @@ system:
         spent: 0
         recovery: []
       sort: 0
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: blink
+  method: spell
+  prepared: 0
 _id: phbsplBlink00000
 type: spell
 img: icons/magic/unholy/hand-marked-pink.webp
@@ -100,32 +119,37 @@ effects:
   - name: Ethereal
     origin: Compendium.dnd5e.spells24.Item.phbsplBlink00000
     duration:
-      value: 1
+      value: null
       units: rounds
-      expiry: turnStart
+      expiry: sourceStart
       expired: false
-    disabled: false
-    flags: {}
+    disabled: true
+    flags:
+      dnd5e:
+        riders: {}
     img: systems/dnd5e/icons/svg/statuses/ethereal.svg
     _id: La5ofK0TnPSTL3iq
     type: base
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: ''
     tint: '#ffffff'
-    transfer: false
+    transfer: true
     statuses:
       - ethereal
     sort: 0
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543974237
-      modifiedTime: 1783543974237
+      createdTime: 1787693505475
+      modifiedTime: 1787693505475
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -136,18 +160,14 @@ folder: HCovEE4VoPGlIbKi
 sort: 3400000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425943980
-  modifiedTime: 1783543974237
+  systemVersion: 6.0.0
+  createdTime: 1787693505475
+  modifiedTime: 1787693505475
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplBlink00000'

--- a/packs/_source/spells24/3rd-level/haste.yml
+++ b/packs/_source/spells24/3rd-level/haste.yml
@@ -186,8 +186,7 @@ effects:
     disabled: false
     flags:
       dnd5e:
-        riders:
-          statuses: []
+        riders: {}
     img: icons/magic/time/clock-spinning-gold-pink.webp
     _id: NEFWcyysYgsE6de3
     type: base
@@ -234,11 +233,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.365'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1786481118454
-      modifiedTime: 1786481118454
+      createdTime: 1787693581584
+      modifiedTime: 1787693581584
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -248,9 +247,9 @@ effects:
   - name: Lethargy
     origin: Compendium.dnd5e.spells24.Item.phbsplHaste00000
     duration:
-      value: 1
-      units: rounds
-      expiry: turnStart
+      value: null
+      units: seconds
+      expiry: targetEnd
       expired: false
     disabled: false
     flags:
@@ -284,11 +283,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.365'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1786481118454
-      modifiedTime: 1786481118454
+      createdTime: 1787693581584
+      modifiedTime: 1787693581584
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -302,11 +301,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.365'
+  coreVersion: '14.367'
   systemId: dnd5e
   systemVersion: 6.0.0
-  createdTime: 1786481118454
-  modifiedTime: 1786481118454
+  createdTime: 1787693581584
+  modifiedTime: 1787693581584
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplHaste00000'

--- a/packs/_source/spells24/3rd-level/haste.yml
+++ b/packs/_source/spells24/3rd-level/haste.yml
@@ -14,9 +14,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
-    revision: 2
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -31,9 +32,10 @@ system:
       choice: false
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     value: '30'
     units: ft
@@ -54,9 +56,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -70,20 +69,27 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: NEFWcyysYgsE6de3
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -99,8 +105,13 @@ system:
       sort: 0
       name: Cast
       img: ''
-      appliedEffects:
-        - NEFWcyysYgsE6de3
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     rBQrZnq7cHkSUAK9:
       type: utility
       name: Apply Lethargy
@@ -118,6 +129,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: round
         concentration: false
@@ -125,6 +137,8 @@ system:
         value: '1'
       effects:
         - _id: S5XcFawnnNHO8bUr
+          uuid: null
+          level: {}
       range:
         override: true
         units: any
@@ -133,6 +147,7 @@ system:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -147,9 +162,16 @@ system:
         name: ''
         formula: ''
       img: ''
-      appliedEffects:
-        - S5XcFawnnNHO8bUr
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: haste
+  method: spell
+  prepared: 0
 _id: phbsplHaste00000
 type: spell
 img: icons/magic/time/clock-spinning-gold-pink.webp
@@ -171,49 +193,31 @@ effects:
     type: base
     system:
       changes:
-        - key: system.attributes.movement.walk
+        - key: system.attributes.movement.multiplier
           value: 2
           priority: null
           type: multiply
           phase: initial
-          _id: VNjQTf5nemDRVEy1
-        - key: system.attributes.movement.burrow
-          value: 2
-          priority: null
-          type: multiply
-          phase: initial
-          _id: L8tIkGOj0wyI6l0i
-        - key: system.attributes.movement.climb
-          value: 2
-          priority: null
-          type: multiply
-          phase: initial
-          _id: oo3xA2QDgpV3m9C6
-        - key: system.attributes.movement.fly
-          value: 2
-          priority: null
-          type: multiply
-          phase: initial
-          _id: QAv9M3oLNJJSP5v7
-        - key: system.attributes.movement.swim
-          value: 2
-          priority: null
-          type: multiply
-          phase: initial
-          _id: 25aJVhryJj5S8CB7
+          _id: FyaPasxi38V8bl43
+          conditions: '{}'
         - key: system.attributes.ac.bonus
           value: 2
           priority: null
           type: add
           phase: initial
-          _id: UPblsKx9Njx3JBHN
+          _id: z9R8AkKJmXwnaQ6C
+          conditions: '{}'
         - key: system.abilities.dex.save.roll.mode
           value: 1
           priority: null
           type: add
           phase: initial
-          _id: gIfPzfbWMMkvwgZy
+          _id: HJrKfWpGn9QtcXGr
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
       <p>Until the spell ends, the target’s Speed is doubled, it gains a +2
       bonus to Armor Class, it has Advantage on Dexterity saving throws, and it
@@ -221,7 +225,7 @@ effects:
       to take only the Attack (one attack only), Dash, Disengage, Hide, or
       Utilize action.</p><p>When the spell ends, the target is Incapacitated and
       has a Speed of 0 until the end of its next turn, as a
-      @UUID[Compendium.dnd5e.spells24.Item.phbsplHaste00000.ActiveEffect.S5XcFawnnNHO8bUr]{wave
+      @UUID[Compendium.dnd-players-handbook.spells.Item.phbsplHaste00000.ActiveEffect.S5XcFawnnNHO8bUr]{wave
       of lethargy} washes over it.</p>
     tint: '#ffffff'
     transfer: false
@@ -230,11 +234,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543975435
-      modifiedTime: 1783543975435
+      createdTime: 1786481118454
+      modifiedTime: 1786481118454
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -249,43 +253,25 @@ effects:
       expiry: turnStart
       expired: false
     disabled: false
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     img: icons/tools/nautical/anchor-blue.webp
     _id: S5XcFawnnNHO8bUr
     type: base
     system:
       changes:
-        - key: system.attributes.movement.walk
+        - key: system.attributes.movement.multiplier
           value: 0
           priority: null
-          type: downgrade
+          type: override
           phase: initial
-          _id: Y7UNigwv1E20shQR
-        - key: system.attributes.movement.burrow
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: APHi1pYEDqjM2UmU
-        - key: system.attributes.movement.climb
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: aNsWpK9fcd5jgJFq
-        - key: system.attributes.movement.fly
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: U9GtZdC1yxypSL1b
-        - key: system.attributes.movement.swim
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: peTnJBoKqVVUgEgq
+          _id: KIbE4sxIpCZAZp57
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
       <p>When the spell ends, the target is &amp;Reference[incapacitated
       apply=false] and has a Speed of 0 until the end of its next turn, as a
@@ -298,11 +284,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543975435
-      modifiedTime: 1783543975435
+      createdTime: 1786481118454
+      modifiedTime: 1786481118454
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -313,18 +299,14 @@ folder: HCovEE4VoPGlIbKi
 sort: 1700000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 5.1.9
-  createdTime: 1724425958065
-  modifiedTime: 1783543975435
+  systemVersion: 6.0.0
+  createdTime: 1786481118454
+  modifiedTime: 1786481118454
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplHaste00000'

--- a/packs/_source/spells24/3rd-level/hypnotic-pattern.yml
+++ b/packs/_source/spells24/3rd-level/hypnotic-pattern.yml
@@ -14,8 +14,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
+    page: ''
+    license: CC-BY-4.0
+    revision: 2
   activation:
     type: action
     condition: ''
@@ -26,14 +28,18 @@ system:
   target:
     affects:
       choice: false
+      type: ''
     template:
       units: ft
       type: cube
       size: '30'
       contiguous: false
+      count: ''
+      stationary: false
   range:
     value: '120'
     units: ft
+    special: ''
   uses:
     max: ''
     recovery: []
@@ -43,14 +49,12 @@ system:
   properties:
     - somatic
     - material
+    - concentration
   materials:
     value: a pinch of confetti
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -64,21 +68,28 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: mjAs8ssQlgp0AQOp
           onSave: false
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -86,15 +97,27 @@ system:
         onSave: half
         parts: []
       save:
-        ability: wis
+        ability:
+          - wis
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
       sort: 0
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: hypnotic-pattern
+  method: spell
+  prepared: 0
 _id: phbsplHypnoticPa
 type: spell
 img: icons/magic/control/hypnosis-mesmerism-swirl.webp
@@ -107,43 +130,25 @@ effects:
       expiry: turnStart
       expired: false
     disabled: false
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     img: icons/magic/control/hypnosis-mesmerism-eye-tan.webp
     _id: mjAs8ssQlgp0AQOp
     type: base
     system:
       changes:
-        - key: system.attributes.movement.walk
+        - key: system.attributes.movement.multiplier
           value: 0
           priority: null
-          type: downgrade
+          type: override
           phase: initial
-          _id: 4bmIn7pTXc7o8QP3
-        - key: system.attributes.movement.burrow
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: dTkSYIlZL52bRapI
-        - key: system.attributes.movement.climb
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: vI4AVqelMSLR56rE
-        - key: system.attributes.movement.fly
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: zFbAt7zaiabzUUVJ
-        - key: system.attributes.movement.swim
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: GrhFyvkGAnFgWrNy
+          _id: EnLoDmMiguoOeZ1a
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
       <p>While &amp;Reference[charmed apply=false], the creature has the
       &amp;Reference[incapacitated apply=false] condition and a Speed of
@@ -159,11 +164,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543975684
-      modifiedTime: 1783543975684
+      createdTime: 1786481123747
+      modifiedTime: 1786481123747
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -174,18 +179,14 @@ folder: HCovEE4VoPGlIbKi
 sort: 1500000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425959310
-  modifiedTime: 1783543975684
+  systemVersion: 6.0.0
+  createdTime: 1786481123747
+  modifiedTime: 1786481123747
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplHypnoticPa'

--- a/packs/_source/spells24/3rd-level/sleet-storm.yml
+++ b/packs/_source/spells24/3rd-level/sleet-storm.yml
@@ -14,8 +14,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    page: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -35,6 +37,7 @@ system:
       contiguous: false
       height: ''
       count: ''
+      stationary: false
   range:
     value: '150'
     units: ft
@@ -55,9 +58,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -71,19 +71,24 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects: []
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -91,15 +96,41 @@ system:
         onSave: half
         parts: []
       save:
-        ability: dex
+        ability:
+          - dex
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
+        max: ''
       sort: 0
+      img: ''
+      behaviors:
+        - name: ''
+          _id: g8r7ffr94j68JiS6
+          type: difficultTerrain
+          config:
+            types:
+              - ice
+          level:
+            min: null
+            max: null
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      name: ''
   identifier: sleet-storm
+  method: spell
+  prepared: 0
 _id: phbsplSleetStorm
 type: spell
 img: icons/magic/water/projectile-icecicles-salvo.webp
@@ -108,18 +139,14 @@ folder: HCovEE4VoPGlIbKi
 sort: 125000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425971321
-  modifiedTime: 1745256798385
+  systemVersion: 6.0.0
+  createdTime: 1786472106603
+  modifiedTime: 1786472106603
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplSleetStorm'

--- a/packs/_source/spells24/3rd-level/slow.yml
+++ b/packs/_source/spells24/3rd-level/slow.yml
@@ -20,9 +20,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
-    revision: 2
+    page: ''
+    license: CC-BY-4.0
+    revision: 4
   activation:
     type: action
     condition: ''
@@ -41,6 +42,7 @@ system:
       size: '40'
       contiguous: false
       count: ''
+      stationary: false
   range:
     value: '120'
     units: ft
@@ -61,9 +63,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -77,21 +76,28 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: z1lkguBohjqXRSHm
           onSave: false
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -99,15 +105,27 @@ system:
         onSave: half
         parts: []
       save:
-        ability: wis
+        ability:
+          - wis
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
       sort: 0
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: slow
+  method: spell
+  prepared: 0
 _id: phbsplSlow000000
 type: spell
 img: icons/magic/time/clock-stopwatch-white-blue.webp
@@ -142,11 +160,11 @@ effects:
       compendiumSource: >-
         Compendium.dnd5e.spells.Item.yqUDoxk4x0NWG5Bz.ActiveEffect.YtN8kTDQyxFaxpEx
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543977046
-      modifiedTime: 1783543977046
+      createdTime: 1786481146902
+      modifiedTime: 1786481146902
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     img: icons/magic/time/clock-stopwatch-white-blue.webp
@@ -158,44 +176,26 @@ effects:
           priority: null
           type: add
           phase: initial
-          _id: RUGZEglM6jZDUfOB
-        - key: system.attributes.movement.burrow
+          _id: dOfo7OvlIfELRalB
+          conditions: '{}'
+        - key: system.attributes.movement.multiplier
           value: 0.5
           priority: null
           type: multiply
           phase: initial
-          _id: 7wL4mCSL1qo0NACY
-        - key: system.attributes.movement.climb
-          value: 0.5
-          priority: null
-          type: multiply
-          phase: initial
-          _id: kA0RxuRFx3iVUroq
-        - key: system.attributes.movement.fly
-          value: 0.5
-          priority: null
-          type: multiply
-          phase: initial
-          _id: cQDirOfXRUlnsUb4
-        - key: system.attributes.movement.swim
-          value: 0.5
-          priority: null
-          type: multiply
-          phase: initial
-          _id: qrxHB6R6ETXvbmdm
-        - key: system.attributes.movement.walk
-          value: 0.5
-          priority: null
-          type: multiply
-          phase: initial
-          _id: X3bgzVYRwn6eWgP1
+          _id: 53qIYh6YPvWA0kh4
+          conditions: '{}'
         - key: system.abilities.dex.bonuses.save
           value: -2
           priority: null
           type: add
           phase: initial
-          _id: mdSJz9LJR2leZxPD
+          _id: JoFWO8VVifosg173
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     sort: 0
     start: null
     showIcon: 1
@@ -205,18 +205,14 @@ folder: HCovEE4VoPGlIbKi
 sort: 112500
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 5.1.1
-  createdTime: 1724425971412
-  modifiedTime: 1783543977045
+  systemVersion: 6.0.0
+  createdTime: 1786481146902
+  modifiedTime: 1786481146902
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplSlow000000'

--- a/packs/_source/spells24/3rd-level/spirit-guardians.yml
+++ b/packs/_source/spells24/3rd-level/spirit-guardians.yml
@@ -19,8 +19,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -40,6 +42,7 @@ system:
       size: '15'
       contiguous: false
       count: ''
+      stationary: false
   range:
     units: self
     special: ''
@@ -59,9 +62,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -69,24 +69,28 @@ system:
       activation:
         type: ''
         value: null
-        override: true
+        override: false
         condition: ''
       consumption:
         targets: []
         scaling:
           allowed: false
           max: ''
-        spellSlot: false
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
-        override: true
+        override: false
+        concentration: false
       effects:
         - _id: Q3CLqX7crfusAxkj
           onSave: true
+          uuid: null
+          level: {}
       range:
-        override: true
+        override: false
         units: ft
         special: ''
         value: '15'
@@ -96,12 +100,13 @@ system:
           contiguous: false
           units: ft
           type: ''
+          stationary: false
         affects:
           choice: false
           count: '1'
           type: creature
           special: ''
-        override: true
+        override: false
       damage:
         onSave: half
         parts:
@@ -109,7 +114,7 @@ system:
               enabled: false
               formula: ''
             number: 3
-            denomination: '8'
+            denomination: 8
             bonus: ''
             types:
               - necrotic
@@ -118,57 +123,31 @@ system:
               mode: whole
               number: 1
               formula: ''
+            modifiers: []
       save:
-        ability: wis
+        ability:
+          - wis
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
         max: ''
       sort: 200000
-      name: Emanation Save
+      name: Cast and Save
       img: ''
-      appliedEffects:
-        - Q3CLqX7crfusAxkj
-    Rw9xP3RWH9K4eDya:
-      type: utility
-      name: Cast
-      _id: Rw9xP3RWH9K4eDya
-      sort: 100000
-      activation:
-        type: action
-        value: null
-        override: false
-      consumption:
-        scaling:
-          allowed: false
-        spellSlot: true
-        targets: []
-      description: {}
-      duration:
-        units: inst
-        concentration: false
-        override: false
-      effects: []
-      range:
-        override: false
-      target:
-        template:
-          contiguous: false
-          units: ft
-        affects:
-          choice: false
-        override: false
-        prompt: true
-      uses:
-        spent: 0
-        recovery: []
-      roll:
-        prompt: false
-        visible: false
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: spirit-guardians
+  method: spell
+  prepared: 0
 _id: phbsplSpiritGuar
 type: spell
 img: icons/magic/light/orb-hands-humanoid-yellow.webp
@@ -181,43 +160,25 @@ effects:
       expiry: turnStart
       expired: false
     disabled: false
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     img: icons/magic/movement/abstract-ribbons-red-orange.webp
     _id: Q3CLqX7crfusAxkj
     type: base
     system:
       changes:
-        - key: system.attributes.movement.walk
+        - key: system.attributes.movement.multiplier
           value: 0.5
           priority: null
           type: multiply
           phase: initial
-          _id: SXTBNKL9ZnffurSB
-        - key: system.attributes.movement.fly
-          value: 0.5
-          priority: null
-          type: multiply
-          phase: initial
-          _id: VhIMQqp5A7Jlk5zO
-        - key: system.attributes.movement.climb
-          value: 0.5
-          priority: null
-          type: multiply
-          phase: initial
-          _id: h6yMByEiTBe8Ozua
-        - key: system.attributes.movement.swim
-          value: 0.5
-          priority: null
-          type: multiply
-          phase: initial
-          _id: ulFnA6cFzUqf8p3B
-        - key: system.attributes.movement.burrow
-          value: 0.5
-          priority: null
-          type: multiply
-          phase: initial
-          _id: Twm9zOQE3S2v00cj
+          _id: UWErnBwYMRBgOtap
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: <p>The creature's speed is halved while within the Emanation.</p>
     tint: '#ffffff'
     transfer: false
@@ -226,11 +187,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543977173
-      modifiedTime: 1783543977173
+      createdTime: 1786481154204
+      modifiedTime: 1786481154204
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -241,18 +202,14 @@ folder: HCovEE4VoPGlIbKi
 sort: 101563
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425972143
-  modifiedTime: 1783543977173
+  systemVersion: 6.0.0
+  createdTime: 1786481154204
+  modifiedTime: 1786481154204
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplSpiritGuar'

--- a/packs/_source/spells24/4th-level/aura-of-life.yml
+++ b/packs/_source/spells24/4th-level/aura-of-life.yml
@@ -10,8 +10,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    page: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -23,13 +25,14 @@ system:
     affects:
       choice: false
       count: ''
-      type: ''
+      type: ally
     template:
       units: ft
       type: radius
       size: '30'
       contiguous: false
       count: ''
+      stationary: false
   range:
     units: self
     special: ''
@@ -47,9 +50,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -63,26 +63,30 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
-      effects:
-        - _id: GV4hKah5zwQ3Bisx
+        concentration: false
+      effects: []
       range:
         override: false
+        units: self
       target:
         prompt: false
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
       healing:
         number: null
-        denomination: ''
+        denomination: null
         bonus: '1'
         types:
           - healing
@@ -93,6 +97,7 @@ system:
           mode: ''
           number: null
           formula: ''
+        modifiers: []
       uses:
         spent: 0
         recovery: []
@@ -100,73 +105,45 @@ system:
       sort: 0
       name: Create Aura
       img: systems/dnd5e/icons/svg/trait-damage-immunities.svg
-      appliedEffects:
-        - GV4hKah5zwQ3Bisx
+      behaviors:
+        - name: ''
+          _id: UEv5tgbar7amV4k5
+          type: applyActiveEffect
+          config:
+            effects:
+              - Compendium.dnd5e.effects.ActiveEffect.phbeffAuraLife00
+            sizes: []
+            types: []
+          level:
+            min: null
+            max: null
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: aura-of-life
+  method: spell
+  prepared: 0
 _id: phbsplAuraofLife
 type: spell
 img: icons/magic/holy/meditation-chi-focus-blue.webp
-effects:
-  - name: Aura of Life
-    origin: Compendium.dnd5e.spells24.Item.phbsplAuraofLife
-    duration:
-      value: 600
-      units: seconds
-      expiry: turnStart
-      expired: false
-    disabled: false
-    flags: {}
-    img: icons/magic/life/ankh-gold-blue.webp
-    _id: GV4hKah5zwQ3Bisx
-    type: base
-    system:
-      changes:
-        - key: system.traits.dr.value
-          value: necrotic
-          priority: null
-          type: add
-          phase: initial
-          _id: RtFuCaHQuPMcusGJ
-      magical: true
-    description: >-
-      <p>While in the aura, you and your allies have Resistance to Necrotic
-      damage, and your Hit Point maximums can’t be reduced. If an ally with 0
-      Hit Points starts its turn in the aura, that ally regains [[/healing 1
-      type=healing]]{1 Hit Point}.</p>
-    tint: '#ffffff'
-    transfer: false
-    statuses: []
-    sort: 0
-    _stats:
-      compendiumSource: null
-      duplicateSource: null
-      coreVersion: '14.364'
-      systemId: dnd5e
-      systemVersion: 6.0.0
-      createdTime: 1783543974005
-      modifiedTime: 1783543974005
-      lastModifiedBy: dnd5ebuilder0000
-      exportSource: null
-    start: null
-    showIcon: 1
-    folder: null
-    _key: '!items.effects!phbsplAuraofLife.GV4hKah5zwQ3Bisx'
+effects: []
 folder: qi3IbnEwap7mRw4b
 sort: 3800000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425941996
-  modifiedTime: 1783543974005
+  systemVersion: 6.0.0
+  createdTime: 1786472007766
+  modifiedTime: 1786472007766
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplAuraofLife'

--- a/packs/_source/spells24/4th-level/black-tentacles.yml
+++ b/packs/_source/spells24/4th-level/black-tentacles.yml
@@ -16,10 +16,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
-    revision: 2
     page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -38,6 +38,7 @@ system:
       size: '20'
       contiguous: false
       count: ''
+      stationary: false
   range:
     value: '90'
     units: ft
@@ -58,9 +59,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -74,21 +72,28 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: NDytclFrNmC418CS
           onSave: false
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -107,16 +112,34 @@ system:
               mode: ''
               number: null
               formula: ''
+            modifiers: []
       save:
-        ability: str
+        ability:
+          - str
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
       sort: 0
+      img: null
+      behaviors:
+        - type: difficultTerrain
+          _id: 9QZR7Lz1ZILzgkHb
+          config:
+            types: []
+          level: {}
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: black-tentacles
+  method: spell
+  prepared: 0
 _id: phbsplEvardsBlac
 type: spell
 img: icons/creatures/tentacles/tentacles-suctioncups-pink.webp
@@ -136,6 +159,9 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
       <p>A &amp;Reference[Restrained apply=false] creature can take an action to
       make a [[/check ability=str skill=ath dc=@attributes.spell.dc]] check
@@ -149,11 +175,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543975026
-      modifiedTime: 1783543975026
+      createdTime: 1786472055059
+      modifiedTime: 1786472055059
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -164,18 +190,14 @@ folder: qi3IbnEwap7mRw4b
 sort: 2400000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 5.1.0
-  createdTime: 1724425952514
-  modifiedTime: 1783543975026
+  systemVersion: 6.0.0
+  createdTime: 1786472055059
+  modifiedTime: 1786472055059
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplEvardsBlac'

--- a/packs/_source/spells24/4th-level/blight.yml
+++ b/packs/_source/spells24/4th-level/blight.yml
@@ -13,8 +13,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -29,9 +30,10 @@ system:
       choice: false
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     value: '30'
     units: ft
@@ -50,9 +52,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -66,19 +65,24 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects: []
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -97,16 +101,29 @@ system:
               mode: whole
               number: 1
               formula: ''
+            modifiers: []
       save:
-        ability: con
+        ability:
+          - con
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
       sort: 0
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: blight
+  method: spell
+  prepared: 0
 _id: phbsplBlight0000
 type: spell
 img: icons/magic/unholy/strike-body-life-soul-green.webp
@@ -115,18 +132,14 @@ folder: qi3IbnEwap7mRw4b
 sort: 3500000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425943709
-  modifiedTime: 1745256786999
+  systemVersion: 6.0.0
+  createdTime: 1787693501964
+  modifiedTime: 1787693501964
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplBlight0000'

--- a/packs/_source/spells24/4th-level/conjure-minor-elementals.yml
+++ b/packs/_source/spells24/4th-level/conjure-minor-elementals.yml
@@ -14,10 +14,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
     page: ''
-    revision: 2
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -29,7 +29,7 @@ system:
     affects:
       choice: false
       count: ''
-      type: creature
+      type: enemy
       special: ''
     template:
       units: ft
@@ -37,6 +37,7 @@ system:
       size: '15'
       contiguous: false
       count: ''
+      stationary: false
   range:
     units: self
     special: ''
@@ -55,9 +56,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -75,9 +73,11 @@ system:
         spellSlot: false
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: true
+        concentration: false
       effects: []
       range:
         override: true
@@ -90,10 +90,11 @@ system:
           contiguous: false
           units: ft
           type: ''
+          stationary: false
         affects:
           choice: false
           count: ''
-          type: any
+          type: creature
           special: ''
         override: true
       damage:
@@ -105,7 +106,7 @@ system:
               enabled: false
               formula: ''
             number: 2
-            denomination: '8'
+            denomination: 8
             bonus: ''
             types:
               - acid
@@ -116,6 +117,7 @@ system:
               mode: whole
               number: 1
               formula: ''
+            modifiers: []
       uses:
         spent: 0
         recovery: []
@@ -123,7 +125,15 @@ system:
       sort: 100000
       name: Bonus Attack Damage
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     VSwMJFQoi3KU3Ais:
       type: utility
       _id: VSwMJFQoi3KU3Ais
@@ -138,6 +148,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -145,10 +156,12 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -165,8 +178,21 @@ system:
         formula: ''
       name: Cast
       img: ''
-      appliedEffects: []
+      behaviors:
+        - type: difficultTerrain
+          _id: r6D64e8FznKMOLcT
+          config:
+            types: []
+          level: {}
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: conjure-minor-elementals
+  method: spell
+  prepared: 0
 _id: phbsplConjureMin
 type: spell
 img: icons/creatures/magical/spirit-fire-orange.webp
@@ -175,18 +201,14 @@ folder: qi3IbnEwap7mRw4b
 sort: 3100000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.2
-  createdTime: 1724425947075
-  modifiedTime: 1746119620226
+  systemVersion: 6.0.0
+  createdTime: 1786472030811
+  modifiedTime: 1786472030811
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplConjureMin'

--- a/packs/_source/spells24/4th-level/dimension-door.yml
+++ b/packs/_source/spells24/4th-level/dimension-door.yml
@@ -16,8 +16,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -32,9 +33,10 @@ system:
       choice: false
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     value: '500'
     units: ft
@@ -52,9 +54,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -68,19 +67,24 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects: []
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -100,15 +104,79 @@ system:
             scaling:
               mode: ''
               number: 1
+            modifiers: []
       uses:
         spent: 0
         recovery: []
         max: ''
-      sort: 0
+      sort: 200000
       name: ''
-      img: systems/dnd5e/icons/svg/trait-saves.svg
-      appliedEffects: []
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+    hCOnUZIondeOKxE5:
+      type: teleport
+      name: ''
+      _id: hCOnUZIondeOKxE5
+      img: ''
+      sort: 100000
+      activation:
+        type: action
+        override: false
+      behaviors: []
+      consumption:
+        scaling:
+          allowed: false
+        spellSlot: true
+        targets: []
+      description:
+        value: ''
+        chatFlavor: ''
+      duration:
+        units: inst
+        concentration: false
+        override: false
+      effects: []
+      flags: {}
+      range:
+        units: ft
+        override: true
+        special: ''
+        value: '5'
+      target:
+        template:
+          contiguous: false
+          stationary: false
+          units: ft
+        affects:
+          choice: false
+        override: false
+        prompt: true
+      uses:
+        spent: 0
+        recovery: []
+        max: ''
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      teleport:
+        override: true
+        units: ft
+        value: '500'
   identifier: dimension-door
+  method: spell
+  prepared: 0
 _id: phbsplDimensionD
 type: spell
 img: icons/environment/wilderness/portal.webp
@@ -117,18 +185,14 @@ folder: qi3IbnEwap7mRw4b
 sort: 2700000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425949835
-  modifiedTime: 1745256790484
+  systemVersion: 6.0.0
+  createdTime: 1786473177191
+  modifiedTime: 1786473177191
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplDimensionD'

--- a/packs/_source/spells24/4th-level/dimension-door.yml
+++ b/packs/_source/spells24/4th-level/dimension-door.yml
@@ -16,7 +16,7 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 1
+    revision: 2
     book: ''
     license: CC-BY-4.0
   activation:

--- a/packs/_source/spells24/4th-level/giant-insect.yml
+++ b/packs/_source/spells24/4th-level/giant-insect.yml
@@ -1,13 +1,14 @@
 name: Giant Insect
 system:
   description:
-    value: "<p>You summon a giant centipede, spider, or wasp (chosen when you cast the spell). It manifests in an unoccupied space you can see within range and uses the <strong>@UUID[Compendium.dnd5e.actors24.Actor.phbmobGiantInsec]{Giant Insect}</strong> stat block. The form you choose determines certain details in its stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.</p><p>The creature is an ally to you and your allies. In combat, the creature shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the &amp;Reference[Dodge] action and uses its movement to avoid danger.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Use the spell slot's level for the spell's level in the stat block.</p><section class=\"fvtt advice\" style=\"margin:0.5rem;padding:0.5rem\"><article><p>In addition to the noted usage of the spell's level in the insect's Traits and Actions, the following attributes are also affected.</p><table><caption>Giant Insect</caption><tbody><tr><td><strong>AC</strong></td><td>11 + the spell's level</td></tr><tr><td><strong>HP</strong></td><td>30 + 10 for each spell level above 4</td></tr><tr><td><strong>Speed</strong></td><td>40 ft., Climb 40 ft., Fly 40 ft. (Wasp only)</td></tr><tr><td><strong>PB</strong></td><td>equals your Proficiency Bonus</td></tr></tbody></table></article></section>"
+    value: "<p>You summon a giant centipede, spider, or wasp (chosen when you cast the spell). It manifests in an unoccupied space you can see within range and uses the <strong>@UUID[Compendium.dnd5e.actors24.Actor.phbmobGiantInsec]{Giant Insect}</strong> stat block. The form you choose determines certain details in its stat block. The creature disappears when it drops to 0 Hit Points or when the spell ends.</p><p>The creature is an ally to you and your allies. In combat, the creature shares your Initiative count, but it takes its turn immediately after yours. It obeys your verbal commands (no action required by you). If you don't issue any, it takes the &amp;Reference[Dodge] action and uses its movement to avoid danger.</p><p><strong>Using a Higher-Level Spell Slot.</strong>\_Use the spell slot's level for the spell's level in the stat block.</p><p>@Embed[Compendium.dnd5e.actors24.Actor.phbmobGiantInsec statblock caption=false]</p>"
     chat: ''
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -22,9 +23,10 @@ system:
       choice: false
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     value: '60'
     units: ft
@@ -44,9 +46,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -60,18 +59,23 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -88,6 +92,8 @@ system:
         proficiency: true
         attacks: true
         saves: true
+        disposition: true
+        ability: ''
       profiles:
         - count: ''
           name: ''
@@ -114,7 +120,6 @@ system:
             max: null
           types: []
       summon:
-        identifier: ''
         mode: ''
         prompt: true
       uses:
@@ -124,8 +129,20 @@ system:
       sort: 0
       name: ''
       img: ''
-      appliedEffects: []
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      tempHP: ''
+      behaviors: []
+      effects: []
+      flags: {}
   identifier: giant-insect
+  method: spell
+  prepared: 0
 _id: phbsplGiantInsec
 type: spell
 img: icons/creatures/invertebrates/bee-yellow.webp
@@ -134,18 +151,14 @@ folder: qi3IbnEwap7mRw4b
 sort: 1900000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425956378
-  modifiedTime: 1745256793724
+  systemVersion: 6.0.0
+  createdTime: 1787693573229
+  modifiedTime: 1787693573229
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplGiantInsec'

--- a/packs/_source/spells24/4th-level/ice-storm.yml
+++ b/packs/_source/spells24/4th-level/ice-storm.yml
@@ -14,8 +14,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    page: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -35,6 +37,7 @@ system:
       contiguous: false
       height: ''
       count: ''
+      stationary: false
   range:
     value: '300'
     units: ft
@@ -54,9 +57,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -70,19 +70,24 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects: []
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -93,27 +98,35 @@ system:
               enabled: false
               formula: (@item.level - 2)d10
             number: 2
-            denomination: '10'
+            denomination: 10
             bonus: ''
+            modifiers: []
             types:
               - bludgeoning
             scaling:
               mode: whole
+              number: 1
+              formula: ''
           - custom:
               enabled: false
               formula: ''
             number: 4
-            denomination: '6'
+            denomination: 6
             bonus: ''
+            modifiers: []
             types:
               - cold
             scaling:
               mode: ''
+              number: 1
       save:
-        ability: dex
+        ability:
+          - dex
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
+        bonus: ''
       uses:
         spent: 0
         recovery: []
@@ -121,8 +134,27 @@ system:
       sort: 0
       name: ''
       img: ''
-      appliedEffects: []
+      behaviors:
+        - name: ''
+          _id: QsUrxfdGYAfydDDX
+          type: difficultTerrain
+          config:
+            types:
+              - ice
+          level:
+            min: null
+            max: null
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: ice-storm
+  method: spell
+  prepared: 0
 _id: phbsplIceStorm00
 type: spell
 img: icons/magic/water/projectile-ice-chunks-salvo.webp
@@ -131,18 +163,14 @@ folder: qi3IbnEwap7mRw4b
 sort: 1400000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425959498
-  modifiedTime: 1745256794969
+  systemVersion: 6.0.0
+  createdTime: 1786472072064
+  modifiedTime: 1786472072064
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplIceStorm00'

--- a/packs/_source/spells24/5th-level/dream.yml
+++ b/packs/_source/spells24/5th-level/dream.yml
@@ -23,8 +23,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: minute
     condition: ''
@@ -38,8 +39,9 @@ system:
       count: '1'
       choice: false
     template:
-      units: ''
+      units: ft
       contiguous: false
+      stationary: false
   range:
     units: spec
   uses:
@@ -57,9 +59,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -73,21 +72,28 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects:
         - _id: x52Ga7U45IJOPFxK
           onSave: false
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -106,16 +112,29 @@ system:
               mode: ''
               number: null
               formula: ''
+            modifiers: []
       save:
-        ability: wis
+        ability:
+          - wis
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
       sort: 0
+      img: null
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: dream
+  method: spell
+  prepared: 0
 _id: phbsplDream00000
 type: spell
 img: icons/magic/control/sleep-bubble-purple.webp
@@ -128,46 +147,28 @@ effects:
       expiry: turnStart
       expired: false
     disabled: false
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     img: icons/magic/control/hypnosis-mesmerism-eye-tan.webp
     _id: x52Ga7U45IJOPFxK
     type: base
     system:
       changes:
-        - key: system.attributes.movement.walk
+        - key: system.attributes.movement.multiplier
           value: 0
           priority: null
-          type: downgrade
+          type: override
           phase: initial
-          _id: vRpWCiIB5wLxG7rq
-        - key: system.attributes.movement.fly
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: 3BkI4V5IRpCq6fhA
-        - key: system.attributes.movement.swim
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: 6UZGd2wahbWqc56N
-        - key: system.attributes.movement.burrow
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: ijHUjR1pTMDf9anA
-        - key: system.attributes.movement.climb
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: AhRoSEja5VYZfNwe
+          _id: Zx8G6G78n4ba25pw
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     description: >-
-      <p><span style="font-family:Signika, sans-serif">While in the trance, the
-      messenger is Incapacitated and has a Speed of 0.</span></p>
+      <p><span style="font-family:'Signika, sans-serif'">While in the trance,
+      the messenger is Incapacitated and has a Speed of 0.</span></p>
     tint: '#ffffff'
     transfer: false
     statuses:
@@ -176,11 +177,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1783543974823
-      modifiedTime: 1783543974823
+      createdTime: 1786481093942
+      modifiedTime: 1786481093942
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -191,18 +192,14 @@ folder: beZ8MTpWY2cMEUlp
 sort: 2100000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425951385
-  modifiedTime: 1783543974823
+  systemVersion: 6.0.0
+  createdTime: 1786481093942
+  modifiedTime: 1786481093942
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplDream00000'

--- a/packs/_source/spells24/5th-level/insect-plague.yml
+++ b/packs/_source/spells24/5th-level/insect-plague.yml
@@ -17,8 +17,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    page: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -34,6 +36,7 @@ system:
       type: sphere
       size: '20'
       contiguous: false
+      stationary: false
   range:
     value: '300'
     units: ft
@@ -53,9 +56,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     dnd5eactivity000:
       _id: dnd5eactivity000
@@ -69,19 +69,24 @@ system:
         scaling:
           allowed: false
           max: ''
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         override: false
+        concentration: false
       effects: []
       range:
         override: false
+        units: self
       target:
         prompt: true
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -100,16 +105,34 @@ system:
               mode: whole
               number: 1
               formula: ''
+            modifiers: []
       save:
-        ability: con
+        ability:
+          - con
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       uses:
         spent: 0
         recovery: []
       sort: 0
+      img: null
+      behaviors:
+        - type: difficultTerrain
+          _id: 9juAVC9YZwqlJO2G
+          config:
+            types: []
+          level: {}
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: insect-plague
+  method: spell
+  prepared: 0
 _id: phbsplInsectPlag
 type: spell
 img: icons/creatures/invertebrates/wasp-swarm-attack.webp
@@ -118,18 +141,14 @@ folder: beZ8MTpWY2cMEUlp
 sort: 1500000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425960098
-  modifiedTime: 1745256795207
+  systemVersion: 6.0.0
+  createdTime: 1786472077287
+  modifiedTime: 1786472077287
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplInsectPlag'

--- a/packs/_source/spells24/5th-level/teleportation-circle.yml
+++ b/packs/_source/spells24/5th-level/teleportation-circle.yml
@@ -22,7 +22,7 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 1
+    revision: 2
     book: ''
     license: CC-BY-4.0
   activation:

--- a/packs/_source/spells24/5th-level/teleportation-circle.yml
+++ b/packs/_source/spells24/5th-level/teleportation-circle.yml
@@ -22,8 +22,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: minute
     condition: ''
@@ -44,6 +45,7 @@ system:
       size: '5'
       count: ''
       height: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -62,12 +64,9 @@ system:
     consumed: true
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     naWXNn0rMcVvKOi2:
-      type: utility
+      type: teleport
       name: ''
       _id: naWXNn0rMcVvKOi2
       sort: 0
@@ -80,7 +79,9 @@ system:
           allowed: false
         spellSlot: true
         targets: []
-      description: {}
+      description:
+        value: ''
+        chatFlavor: ''
       duration:
         units: inst
         concentration: false
@@ -88,10 +89,12 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -99,10 +102,23 @@ system:
       uses:
         spent: 0
         recovery: []
-      roll:
-        prompt: false
-        visible: false
+        max: ''
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      teleport:
+        override: true
+        units: ft
   identifier: teleportation-circle
+  method: spell
+  prepared: 0
 _id: phbsplTeleportat
 type: spell
 img: icons/magic/symbols/runes-carved-stone-yellow.webp
@@ -111,18 +127,14 @@ folder: beZ8MTpWY2cMEUlp
 sort: 101563
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425975042
-  modifiedTime: 1745256799140
+  systemVersion: 6.0.0
+  createdTime: 1786473200176
+  modifiedTime: 1786473200176
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplTeleportat'

--- a/packs/_source/spells24/5th-level/tree-stride.yml
+++ b/packs/_source/spells24/5th-level/tree-stride.yml
@@ -17,7 +17,7 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 1
+    revision: 2
     book: ''
     license: CC-BY-4.0
   activation:

--- a/packs/_source/spells24/5th-level/tree-stride.yml
+++ b/packs/_source/spells24/5th-level/tree-stride.yml
@@ -17,8 +17,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -30,12 +31,13 @@ system:
     affects:
       choice: false
       count: ''
-      type: ''
+      type: self
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: self
     special: ''
@@ -54,12 +56,9 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     vcosPna67heYEKpl:
-      type: utility
+      type: teleport
       name: ''
       _id: vcosPna67heYEKpl
       sort: 0
@@ -74,6 +73,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -81,10 +81,12 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -93,12 +95,23 @@ system:
         spent: 0
         recovery: []
         max: ''
-      roll:
-        prompt: false
-        visible: false
-        name: ''
-        formula: ''
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      teleport:
+        override: true
+        value: '500'
+        units: ft
   identifier: tree-stride
+  method: spell
+  prepared: 0
 _id: phbsplTreeStride
 type: spell
 img: icons/magic/nature/tree-spirit-blue.webp
@@ -107,18 +120,14 @@ folder: beZ8MTpWY2cMEUlp
 sort: 100782
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425976015
-  modifiedTime: 1745256799353
+  systemVersion: 6.0.0
+  createdTime: 1786473212471
+  modifiedTime: 1786473212471
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplTreeStride'

--- a/packs/_source/spells24/6th-level/blade-barrier.yml
+++ b/packs/_source/spells24/6th-level/blade-barrier.yml
@@ -15,8 +15,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    page: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -31,13 +33,14 @@ system:
       type: space
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
       size: ''
       width: ''
       height: ''
       count: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -57,9 +60,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     Y0nT1EvDbg7IDovC:
       type: save
@@ -72,8 +72,10 @@ system:
         targets: []
         scaling:
           allowed: false
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -81,6 +83,7 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
@@ -90,6 +93,7 @@ system:
           width: '5'
           height: '20'
           count: ''
+          stationary: false
         affects:
           choice: false
           count: ''
@@ -108,21 +112,36 @@ system:
               enabled: false
               formula: ''
             number: 6
-            denomination: '10'
+            denomination: 10
             bonus: ''
             types:
               - force
             scaling:
               mode: ''
+              number: 1
+            modifiers: []
         onSave: half
       save:
-        ability: dex
+        ability:
+          - dex
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       name: Blade Wall
       img: ''
-      appliedEffects: []
+      behaviors:
+        - type: difficultTerrain
+          _id: GOjsz7ypzDPQ94Pe
+          config:
+            types: []
+          level: {}
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     SRwETzebAYXEJKux:
       type: save
       activation:
@@ -133,8 +152,10 @@ system:
         targets: []
         scaling:
           allowed: false
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -142,15 +163,17 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
           count: ''
-          type: cylinder
+          type: ring
           size: '30'
           width: '5'
           height: '20'
+          stationary: false
         affects:
           choice: false
           count: ''
@@ -169,23 +192,43 @@ system:
               enabled: false
               formula: ''
             number: 6
-            denomination: '10'
+            denomination: 10
             bonus: ''
             types:
               - force
             scaling:
               mode: ''
+              number: 1
+            modifiers: []
         onSave: half
       save:
-        ability: dex
+        ability:
+          - dex
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
+        bonus: ''
       name: Blade Ring
       _id: SRwETzebAYXEJKux
       img: ''
-      appliedEffects: []
+      behaviors:
+        - type: difficultTerrain
+          _id: Ij7UtePKpUtTcCZu
+          config:
+            types: []
+          level: {}
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: blade-barrier
+  method: spell
+  prepared: 0
 _id: phbsplBladeBarri
 type: spell
 img: icons/magic/defensive/shield-barrier-blades-teal.webp
@@ -194,18 +237,14 @@ folder: 8WmlLARx1Df3Ii9v
 sort: 100000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425943425
-  modifiedTime: 1745256786934
+  systemVersion: 6.0.0
+  createdTime: 1786472018951
+  modifiedTime: 1786472018951
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplBladeBarri'

--- a/packs/_source/spells24/6th-level/conjure-fey.yml
+++ b/packs/_source/spells24/6th-level/conjure-fey.yml
@@ -18,10 +18,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
-    revision: 3
     page: ''
+    license: CC-BY-4.0
+    revision: 2
   activation:
     type: action
     condition: ''
@@ -36,9 +36,10 @@ system:
       type: space
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -58,9 +59,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     w2sWkRQ3xMVRf7g3:
       type: summon
@@ -73,18 +71,22 @@ system:
         targets: []
         scaling:
           allowed: false
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -98,7 +100,7 @@ system:
         ac: ''
         hd: ''
         hp: ''
-        attackDamage: '@mod + (@scaling)d12'
+        attackDamage: '@mod + (@item.level - 6)d12'
         saveDamage: ''
         healing: ''
       creatureSizes: []
@@ -108,6 +110,7 @@ system:
         proficiency: true
         saves: false
         ability: ''
+        disposition: false
       profiles:
         - count: ''
           name: ''
@@ -116,13 +119,20 @@ system:
           level:
             min: null
             max: null
+          types: []
       summon:
         prompt: true
         mode: ''
-        identifier: ''
       name: ''
       img: ''
-      appliedEffects: []
+      behaviors: []
+      effects: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     sKmRcy0IDp9aOuAt:
       type: utility
       _id: sKmRcy0IDp9aOuAt
@@ -135,8 +145,10 @@ system:
         targets: []
         scaling:
           allowed: false
+        spellSlot: true
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -152,6 +164,7 @@ system:
           contiguous: false
           units: ft
           type: ''
+          stationary: false
         affects:
           choice: false
           count: '1'
@@ -171,8 +184,16 @@ system:
         formula: ''
       name: Teleport and Attack
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: conjure-fey
+  method: spell
+  prepared: 0
 _id: phbsplConjureFey
 type: spell
 img: icons/creatures/magical/spirit-poison-smoke-green.webp
@@ -181,18 +202,14 @@ folder: 8WmlLARx1Df3Ii9v
 sort: 1800000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.2
-  createdTime: 1724425946958
-  modifiedTime: 1746119659353
+  systemVersion: 6.0.0
+  createdTime: 1787693535141
+  modifiedTime: 1787693535141
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplConjureFey'

--- a/packs/_source/spells24/6th-level/conjure-fey.yml
+++ b/packs/_source/spells24/6th-level/conjure-fey.yml
@@ -21,7 +21,7 @@ system:
     book: ''
     page: ''
     license: CC-BY-4.0
-    revision: 2
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -100,7 +100,7 @@ system:
         ac: ''
         hd: ''
         hp: ''
-        attackDamage: '@mod + (@item.level - 6)d12'
+        attackDamage: '@mod + (@scaling)d12'
         saveDamage: ''
         healing: ''
       creatureSizes: []

--- a/packs/_source/spells24/6th-level/flesh-to-stone.yml
+++ b/packs/_source/spells24/6th-level/flesh-to-stone.yml
@@ -24,7 +24,7 @@ system:
     book: ''
     page: ''
     license: CC-BY-4.0
-    revision: 2
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -167,11 +167,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.365'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1786481111223
-      modifiedTime: 1786481111223
+      createdTime: 1787693563696
+      modifiedTime: 1787693563696
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -199,9 +199,9 @@ effects:
       conditions: '{}'
     disabled: false
     duration:
-      value: 1
-      units: rounds
-      expiry: turnStart
+      value: null
+      units: seconds
+      expiry: sourceStart
       expired: false
     description: >-
       <p>On a successful save, its Speed is 0 until the start of your next
@@ -215,11 +215,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.365'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1786481111223
-      modifiedTime: 1786481111223
+      createdTime: 1787693563696
+      modifiedTime: 1787693563696
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -233,11 +233,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.365'
+  coreVersion: '14.367'
   systemId: dnd5e
   systemVersion: 6.0.0
-  createdTime: 1786481111223
-  modifiedTime: 1786481111223
+  createdTime: 1787693563696
+  modifiedTime: 1787693563696
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplFleshtoSto'

--- a/packs/_source/spells24/6th-level/flesh-to-stone.yml
+++ b/packs/_source/spells24/6th-level/flesh-to-stone.yml
@@ -15,14 +15,16 @@ system:
       collects three of a kind.</p><p>If you maintain your Concentration on this
       spell for the entire possible duration, the target is Petrified until the
       condition is ended by
-      <em>@UUID[Compendium.dnd5e.spells24.Item.phbsplGreaterRes]{Greater
+      <em>@UUID[Compendium.dnd-players-handbook.spells.Item.phbsplGreaterRes]{Greater
       Restoration}</em> or similar magic.</p>
     chat: ''
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
+    page: ''
+    license: CC-BY-4.0
+    revision: 2
   activation:
     type: action
     condition: ''
@@ -37,9 +39,10 @@ system:
       type: creature
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -60,9 +63,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     g34TzvzMcBYBxqp4:
       type: save
@@ -78,6 +78,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -85,14 +86,20 @@ system:
       effects:
         - _id: Xt8AUh0PfYhGYBvY
           onSave: false
+          uuid: null
+          level: {}
         - _id: sFyjp6wt9bjyIl9W
           onSave: true
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -106,16 +113,24 @@ system:
         parts: []
         onSave: half
       save:
-        ability: con
+        ability:
+          - con
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       name: ''
       img: ''
-      appliedEffects:
-        - Xt8AUh0PfYhGYBvY
-        - sFyjp6wt9bjyIl9W
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: flesh-to-stone
+  method: spell
+  prepared: 0
 _id: phbsplFleshtoSto
 type: spell
 img: icons/magic/earth/strike-body-stone-crumble.webp
@@ -129,6 +144,9 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: 60
@@ -140,7 +158,7 @@ effects:
       ability=con format=long]] at the end of each of its turns. If it
       successfully saves against this spell three times, the spell ends. If it
       fails its saves three times, it is turned to stone and has the
-      &amp;Reference[Petrified] condition for the duration. </p>
+      &amp;Reference[Petrified] condition for the duration.</p>
     tint: '#ffffff'
     statuses:
       - restrained
@@ -149,11 +167,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1724708938829
-      modifiedTime: 1783543975172
+      createdTime: 1786481111223
+      modifiedTime: 1786481111223
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -168,37 +186,17 @@ effects:
     type: base
     system:
       changes:
-        - key: system.attributes.movement.walk
+        - key: system.attributes.movement.multiplier
           value: 0
           priority: null
-          type: downgrade
+          type: override
           phase: initial
-          _id: A5oWquY12JbLRdiM
-        - key: system.attributes.movement.fly
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: VMRl9KHPvsPP4GVQ
-        - key: system.attributes.movement.swim
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: OKzYOtESVrTV5Qh2
-        - key: system.attributes.movement.climb
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: tu4MKf4KvzLwEmBp
-        - key: system.attributes.movement.burrow
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: rUOgc8M8CHcBDHv9
+          _id: IaIbX4xdVh4zIrsl
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: 1
@@ -211,15 +209,17 @@ effects:
     tint: '#ffffff'
     statuses: []
     sort: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1724709070719
-      modifiedTime: 1783543975172
+      createdTime: 1786481111223
+      modifiedTime: 1786481111223
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -230,18 +230,14 @@ folder: 8WmlLARx1Df3Ii9v
 sort: 1100000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425954533
-  modifiedTime: 1783543975172
+  systemVersion: 6.0.0
+  createdTime: 1786481111223
+  modifiedTime: 1786481111223
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplFleshtoSto'

--- a/packs/_source/spells24/6th-level/irresistible-dance.yml
+++ b/packs/_source/spells24/6th-level/irresistible-dance.yml
@@ -5,20 +5,20 @@ system:
       <p>One creature that you can see within range must make a Wisdom saving
       throw. On a successful save, the target dances comically until the end of
       its next turn, during which it must spend all its movement to dance in
-      place.</p><p>On a failed save, the target has the Charmed condition for
-      the duration. While Charmed, the target dances comically, must use all its
-      movement to dance in place, and has Disadvantage on Dexterity saving
-      throws and attack rolls, and other creatures have Advantage on attack
-      rolls against it. On each of its turns, the target can take an action to
-      collect itself and repeat the save, ending the spell on itself on a
-      success.</p>
+      place.</p><p>On a failed save, the target has the &amp;Reference[Charmed
+      apply=false] condition for the duration. While Charmed, the target dances
+      comically, must use all its movement to dance in place, and has
+      Disadvantage on Dexterity saving throws and attack rolls, and other
+      creatures have Advantage on attack rolls against it. On each of its turns,
+      the target can take an action to collect itself and repeat the save,
+      ending the spell on itself on a success.</p>
     chat: ''
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
-    page: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -33,9 +33,10 @@ system:
       type: creature
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -54,9 +55,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     DonYhtwZ56TnAk3B:
       type: save
@@ -72,6 +70,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -79,14 +78,20 @@ system:
       effects:
         - _id: MpToumiJ2o3S16K7
           onSave: false
+          uuid: null
+          level: {}
         - _id: UhFtBDEZEDpVgz9G
           onSave: true
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -100,16 +105,24 @@ system:
         parts: []
         onSave: none
       save:
-        ability: wis
+        ability:
+          - wis
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       name: ''
       img: ''
-      appliedEffects:
-        - MpToumiJ2o3S16K7
-        - UhFtBDEZEDpVgz9G
-  identifier: irresistible-dance
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+  identifier: ottos-irresistible-dance
+  method: spell
+  prepared: 0
 _id: phbsplOttosIrres
 type: spell
 img: icons/magic/control/voodoo-doll-pain-damage-green.webp
@@ -123,6 +136,9 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: 60
@@ -144,11 +160,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1724789517489
-      modifiedTime: 1783543976221
+      createdTime: 1787693604312
+      modifiedTime: 1787693604312
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -164,11 +180,14 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
-      value: 1
+      value: null
       units: turns
-      expiry: turnStart
+      expiry: targetEnd
       expired: false
     description: >-
       <p>The target dances comically until the end of its next turn, during
@@ -180,11 +199,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1724789679356
-      modifiedTime: 1783543976221
+      createdTime: 1787693604312
+      modifiedTime: 1787693604312
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -195,18 +214,14 @@ folder: 8WmlLARx1Df3Ii9v
 sort: 112500
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 5.1.0
-  createdTime: 1724425965394
-  modifiedTime: 1783543976221
+  systemVersion: 6.0.0
+  createdTime: 1787693604312
+  modifiedTime: 1787693604312
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplOttosIrres'

--- a/packs/_source/spells24/6th-level/magic-jar.yml
+++ b/packs/_source/spells24/6th-level/magic-jar.yml
@@ -11,9 +11,9 @@ system:
       your living body (and ending the spell) or attempting to possess a
       Humanoid's body.</p><p>You can attempt to possess any Humanoid within 100
       feet of you that you can see (creatures warded by a
-      <em>@UUID[Compendium.dnd5e.spells24.Item.phbEvilAndGoodPr]{Protection from
-      Evil and Good}</em> or
-      <em>@UUID[Compendium.dnd5e.spells24.Item.phbsplMagicCircl]{Magic
+      <em>@UUID[Compendium.dnd-players-handbook.spells.Item.phbEvilAndGoodPr]{Protection
+      from Evil and Good}</em> or
+      <em>@UUID[Compendium.dnd-players-handbook.spells.Item.phbsplMagicCircl]{Magic
       Circle}</em> spell can't be possessed). The target makes a Charisma saving
       throw. On a failed save, your soul enters the target's body, and the
       target's soul becomes trapped in the container. On a successful save, the
@@ -39,8 +39,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    page: ''
+    license: CC-BY-4.0
   activation:
     type: minute
     condition: ''
@@ -52,12 +54,13 @@ system:
     affects:
       choice: false
       count: '1'
-      type: object
-      special: container used for the Material component
+      type: self
+      special: and the container used as the Material component
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: self
     special: ''
@@ -76,9 +79,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     rWrSlmlxvdtAcieq:
       type: utility
@@ -94,18 +94,23 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       effects:
         - _id: JUeiirjbzslhBtNL
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -120,10 +125,15 @@ system:
         visible: false
         name: ''
         formula: ''
-      name: Transfer Soul
+      name: Cast and Transfer Soul
       img: systems/dnd5e/icons/svg/ink-pot.svg
-      appliedEffects:
-        - JUeiirjbzslhBtNL
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     Ak9GmFAQNh9o2ioq:
       type: save
       _id: Ak9GmFAQNh9o2ioq
@@ -139,12 +149,16 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: dstr
         concentration: false
         override: true
       effects:
         - _id: rgKqVmb0inZoKREu
+          uuid: null
+          level: {}
+          onSave: false
       range:
         override: true
         units: ft
@@ -155,6 +169,7 @@ system:
           contiguous: false
           units: ft
           type: ''
+          stationary: false
         affects:
           choice: false
           count: '1'
@@ -171,14 +186,21 @@ system:
         parts: []
         onSave: none
       save:
-        ability: cha
+        ability:
+          - cha
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       name: Possess Humanoid
       img: systems/dnd5e/icons/svg/multiclass.svg
-      appliedEffects:
-        - rgKqVmb0inZoKREu
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     lXTy3zj3DwBH2QJc:
       type: utility
       _id: lXTy3zj3DwBH2QJc
@@ -194,6 +216,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -201,10 +224,12 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -221,8 +246,16 @@ system:
         formula: ''
       name: Return from Host
       img: systems/dnd5e/icons/svg/trait-saves.svg
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: magic-jar
+  method: spell
+  prepared: 0
 _id: phbsplMagicJar00
 type: spell
 img: icons/containers/kitchenware/jug-bottle-clay-brown-gold-blue.webp
@@ -230,13 +263,16 @@ effects:
   - name: Catatonic
     img: icons/magic/control/hypnosis-mesmerism-eye-tan.webp
     origin: Compendium.dnd5e.spells24.Item.phbsplMagicJar00
-    transfer: false
+    transfer: true
     _id: JUeiirjbzslhBtNL
     type: base
     system:
       changes: []
       magical: true
-    disabled: false
+      rider:
+        statuses: []
+      conditions: '{}'
+    disabled: true
     duration:
       value: null
       units: seconds
@@ -250,15 +286,17 @@ effects:
     statuses:
       - silenced
     sort: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1724775242350
-      modifiedTime: 1783543975864
+      createdTime: 1786481129640
+      modifiedTime: 1786481129640
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -273,37 +311,17 @@ effects:
     type: base
     system:
       changes:
-        - key: system.attributes.movement.walk
+        - key: system.attributes.movement.multiplier
           value: 0
           priority: null
-          type: downgrade
+          type: override
           phase: initial
-          _id: G59DvaycH5ATg9ys
-        - key: system.attributes.movement.climb
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: Q9Dpk3BFtFePWzPe
-        - key: system.attributes.movement.fly
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: rFIO3I40qJbQKYcH
-        - key: system.attributes.movement.swim
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: 4u05AbJ0r3waZk3P
-        - key: system.attributes.movement.burrow
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: tz4RBdOXsSlbzhJ2
+          _id: rOV54LG9qKFd6CUH
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: null
@@ -318,15 +336,17 @@ effects:
     statuses:
       - incapacitated
     sort: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1724778161589
-      modifiedTime: 1783543975864
+      createdTime: 1786481129640
+      modifiedTime: 1786481129640
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -337,18 +357,14 @@ folder: 8WmlLARx1Df3Ii9v
 sort: 400000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425962300
-  modifiedTime: 1783543975864
+  systemVersion: 6.0.0
+  createdTime: 1786481129640
+  modifiedTime: 1786481129640
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplMagicJar00'

--- a/packs/_source/spells24/6th-level/sunbeam.yml
+++ b/packs/_source/spells24/6th-level/sunbeam.yml
@@ -14,8 +14,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -36,6 +37,7 @@ system:
       size: '60'
       width: '5'
       count: ''
+      stationary: false
   range:
     units: self
     special: ''
@@ -55,9 +57,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     o3kffaumfNGjVvg9:
       type: save
@@ -73,18 +72,24 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       effects:
         - _id: RZmnRyi6pyjIRN1i
+          uuid: null
+          level: {}
+          onSave: false
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -100,22 +105,31 @@ system:
               enabled: false
               formula: ''
             number: 6
-            denomination: '8'
+            denomination: 8
             bonus: ''
             types:
               - radiant
             scaling:
               mode: ''
+              number: 1
+            modifiers: []
         onSave: half
       save:
-        ability: con
+        ability:
+          - con
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       name: Initial Cast
       img: ''
-      appliedEffects:
-        - RZmnRyi6pyjIRN1i
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     Y0cJvZuD7EfwGqkf:
       type: save
       name: Create New Sunbeam
@@ -131,18 +145,24 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: true
       effects:
         - _id: RZmnRyi6pyjIRN1i
+          uuid: null
+          level: {}
+          onSave: false
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -158,22 +178,33 @@ system:
               enabled: false
               formula: ''
             number: 6
-            denomination: '8'
+            denomination: 8
             bonus: ''
             types:
               - radiant
             scaling:
               mode: ''
+              number: 1
+            modifiers: []
         onSave: half
       save:
-        ability: con
+        ability:
+          - con
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       img: systems/dnd5e/icons/svg/statuses/concentrating.svg
-      appliedEffects:
-        - RZmnRyi6pyjIRN1i
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: sunbeam
+  method: spell
+  prepared: 0
 _id: phbsplSunbeam000
 type: spell
 img: icons/magic/light/beam-rays-orange-large.webp
@@ -187,11 +218,14 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
-      value: 1
-      units: rounds
-      expiry: turnStart
+      value: null
+      units: seconds
+      expiry: sourceStart
       expired: false
     description: >-
       <p>The target has the &amp;Reference[Blinded apply=false] condition until
@@ -204,11 +238,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1724798213021
-      modifiedTime: 1783543977318
+      createdTime: 1787693656196
+      modifiedTime: 1787693656196
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -219,18 +253,14 @@ folder: 8WmlLARx1Df3Ii9v
 sort: 100782
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425974121
-  modifiedTime: 1783543977318
+  systemVersion: 6.0.0
+  createdTime: 1787693656196
+  modifiedTime: 1787693656196
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplSunbeam000'

--- a/packs/_source/spells24/6th-level/transport-via-plants.yml
+++ b/packs/_source/spells24/6th-level/transport-via-plants.yml
@@ -11,7 +11,7 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 1
+    revision: 2
     book: ''
     license: CC-BY-4.0
   activation:

--- a/packs/_source/spells24/6th-level/transport-via-plants.yml
+++ b/packs/_source/spells24/6th-level/transport-via-plants.yml
@@ -11,8 +11,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -27,9 +28,10 @@ system:
       type: object
       special: Large or larger inanimate plant
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -48,12 +50,9 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     HgtppydN1kkpdVyw:
-      type: utility
+      type: teleport
       name: ''
       _id: HgtppydN1kkpdVyw
       sort: 0
@@ -68,6 +67,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -75,10 +75,12 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -87,12 +89,22 @@ system:
         spent: 0
         recovery: []
         max: ''
-      roll:
-        prompt: false
-        visible: false
-        name: ''
-        formula: ''
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      teleport:
+        override: true
+        units: ft
   identifier: transport-via-plants
+  method: spell
+  prepared: 0
 _id: phbsplTransportv
 type: spell
 img: icons/magic/nature/tree-spirit-green.webp
@@ -101,18 +113,14 @@ folder: 8WmlLARx1Df3Ii9v
 sort: 100196
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425975925
-  modifiedTime: 1745256799326
+  systemVersion: 6.0.0
+  createdTime: 1786473208062
+  modifiedTime: 1786473208062
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplTransportv'

--- a/packs/_source/spells24/6th-level/word-of-recall.yml
+++ b/packs/_source/spells24/6th-level/word-of-recall.yml
@@ -13,8 +13,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -29,9 +30,10 @@ system:
       type: willing
       special: you and five other creatures
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -49,12 +51,9 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     fErYiqUpSCDHfV61:
-      type: utility
+      type: teleport
       _id: fErYiqUpSCDHfV61
       activation:
         type: action
@@ -67,6 +66,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -74,10 +74,12 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -87,14 +89,20 @@ system:
         recovery: []
         max: ''
       sort: 0
-      roll:
-        prompt: false
-        visible: false
-        name: ''
-        formula: ''
       name: Teleport to Sanctuary
       img: systems/dnd5e/icons/svg/trait-saves.svg
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      teleport:
+        override: true
+        units: ft
     CJ6NOsqtoO3HCGjQ:
       type: utility
       name: Designate Sanctuary
@@ -110,6 +118,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -124,6 +133,7 @@ system:
           contiguous: false
           units: ft
           type: ''
+          stationary: false
         affects:
           choice: false
           count: '1'
@@ -142,8 +152,16 @@ system:
         name: ''
         formula: ''
       img: systems/dnd5e/icons/svg/items/background.svg
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: word-of-recall
+  method: spell
+  prepared: 0
 _id: phbsplWordofReca
 type: spell
 img: icons/magic/movement/portal-vortex-orange.webp
@@ -152,18 +170,14 @@ folder: 8WmlLARx1Df3Ii9v
 sort: 100007
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425978529
-  modifiedTime: 1745256800278
+  systemVersion: 6.0.0
+  createdTime: 1786473216939
+  modifiedTime: 1786473216939
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplWordofReca'

--- a/packs/_source/spells24/6th-level/word-of-recall.yml
+++ b/packs/_source/spells24/6th-level/word-of-recall.yml
@@ -13,7 +13,7 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 1
+    revision: 2
     book: ''
     license: CC-BY-4.0
   activation:

--- a/packs/_source/spells24/7th-level/plane-shift.yml
+++ b/packs/_source/spells24/7th-level/plane-shift.yml
@@ -16,8 +16,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -32,9 +33,10 @@ system:
       type: willing
       special: you and up to eight willing creatures
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: touch
     special: ''
@@ -53,12 +55,9 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     xE0rm4EPLcH17Ypa:
-      type: utility
+      type: teleport
       _id: xE0rm4EPLcH17Ypa
       activation:
         type: action
@@ -71,6 +70,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -78,10 +78,12 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -91,15 +93,23 @@ system:
         recovery: []
         max: ''
       sort: 0
-      roll:
-        prompt: false
-        visible: false
-        name: ''
-        formula: ''
       name: Transport
-      img: systems/dnd5e/icons/svg/trait-saves.svg
-      appliedEffects: []
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      teleport:
+        override: true
+        units: ft
   identifier: plane-shift
+  method: spell
+  prepared: 0
 _id: phbsplPlaneShift
 type: spell
 img: icons/skills/targeting/target-glowing-yellow.webp
@@ -108,18 +118,14 @@ folder: EdAGMG8IF26PLkD3
 sort: 1200000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425966118
-  modifiedTime: 1745256796851
+  systemVersion: 6.0.0
+  createdTime: 1786473193972
+  modifiedTime: 1786473193972
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplPlaneShift'

--- a/packs/_source/spells24/7th-level/plane-shift.yml
+++ b/packs/_source/spells24/7th-level/plane-shift.yml
@@ -16,7 +16,7 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 1
+    revision: 2
     book: ''
     license: CC-BY-4.0
   activation:

--- a/packs/_source/spells24/7th-level/teleport.yml
+++ b/packs/_source/spells24/7th-level/teleport.yml
@@ -55,7 +55,7 @@ system:
   source:
     custom: ''
     rules: '2024'
-    revision: 1
+    revision: 2
     book: ''
     license: CC-BY-4.0
   activation:

--- a/packs/_source/spells24/7th-level/teleport.yml
+++ b/packs/_source/spells24/7th-level/teleport.yml
@@ -11,7 +11,7 @@ system:
       destination determines whether you arrive there successfully. The DM rolls
       [[/gmr 1d100]] and consults the Teleportation Outcome table and the
       explanations after
-      it.</p><details><summary><strong>@UUID[Compendium.dnd5e.tables24.RollTable.phbsplTeleportMi]{Teleportation
+      it.</p><details><summary><strong>@UUID[Compendium.dnd-players-handbook.tables.RollTable.phbsplTeleportMi]{Teleportation
       Outcome}</strong></summary><table><thead><tr><td>Familiarity</td><td>Mishap</td><td>Similar
       Area</td><td>Off Target</td><td>On
       Target</td></tr></thead><tbody><tr><td>Permanent
@@ -55,8 +55,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 1
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -71,9 +72,10 @@ system:
       type: willing
       special: you and up to eight creatures or one object
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -91,12 +93,9 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     CBfszVA8MvW52CdU:
-      type: utility
+      type: teleport
       _id: CBfszVA8MvW52CdU
       activation:
         type: action
@@ -109,6 +108,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -116,10 +116,12 @@ system:
       effects: []
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -129,15 +131,23 @@ system:
         recovery: []
         max: ''
       sort: 0
-      roll:
-        prompt: false
-        visible: false
-        name: ''
-        formula: ''
       name: ''
-      img: systems/dnd5e/icons/svg/trait-saves.svg
-      appliedEffects: []
+      img: ''
+      behaviors: []
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
+      teleport:
+        override: true
+        units: ft
   identifier: teleport
+  method: spell
+  prepared: 0
 _id: phbsplTeleport00
 type: spell
 img: icons/skills/movement/arrows-up-trio-red.webp
@@ -146,18 +156,14 @@ folder: EdAGMG8IF26PLkD3
 sort: 200000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '13.344'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425974953
-  modifiedTime: 1745256799110
+  systemVersion: 6.0.0
+  createdTime: 1786473202467
+  modifiedTime: 1786473202467
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplTeleport00'

--- a/packs/_source/spells24/8th-level/holy-aura.yml
+++ b/packs/_source/spells24/8th-level/holy-aura.yml
@@ -13,9 +13,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
-    revision: 2
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -35,6 +36,7 @@ system:
       type: radius
       size: '30'
       count: ''
+      stationary: false
   range:
     units: self
     special: ''
@@ -54,9 +56,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     jbvvkjZ7szK9wjeA:
       type: utility
@@ -72,18 +71,23 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       effects:
         - _id: csA26qg5YSsji1ZZ
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -100,8 +104,13 @@ system:
         formula: ''
       name: Create Aura
       img: systems/dnd5e/icons/svg/trait-damage-immunities.svg
-      appliedEffects:
-        - csA26qg5YSsji1ZZ
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     0kylpwRauH0WgW0G:
       type: save
       _id: 0kylpwRauH0WgW0G
@@ -117,6 +126,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: round
         concentration: false
@@ -124,6 +134,9 @@ system:
         value: '1'
       effects:
         - _id: wqBjgsd2xRnmSm8Z
+          uuid: null
+          level: {}
+          onSave: false
       range:
         override: true
         units: any
@@ -133,6 +146,7 @@ system:
           contiguous: false
           units: ft
           type: ''
+          stationary: false
         affects:
           choice: false
           count: '1'
@@ -149,14 +163,24 @@ system:
         parts: []
         onSave: half
       save:
-        ability: con
+        ability:
+          - con
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       name: Fiend/Undead Save
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: holy-aura
+  method: spell
+  prepared: 0
 _id: phbsplHolyAura00
 type: spell
 img: icons/magic/life/ankh-shadow-green.webp
@@ -174,38 +198,47 @@ effects:
           priority: null
           type: add
           phase: initial
-          _id: HORkT3BebgGm685E
+          _id: EV62Bc7O88IABjNl
+          conditions: '{}'
         - key: system.abilities.dex.save.roll.mode
           value: 1
           priority: null
           type: add
           phase: initial
-          _id: iUICMTfrVBzAHRNO
+          _id: iJzk8PkKQ4anoeT6
+          conditions: '{}'
         - key: system.abilities.con.save.roll.mode
           value: 1
           priority: null
           type: add
           phase: initial
-          _id: wOXzAVh720Z1057V
+          _id: gI8xMnwgAUqtqTrh
+          conditions: '{}'
         - key: system.abilities.int.save.roll.mode
           value: 1
           priority: null
           type: add
           phase: initial
-          _id: 0YTiqe2iuDBpw3VO
+          _id: ITkZAF4CX6jTJwse
+          conditions: '{}'
         - key: system.abilities.wis.save.roll.mode
           value: 1
           priority: null
           type: add
           phase: initial
-          _id: y7McdUDwOQorGA7M
+          _id: i4hUJGQtMR5VpKfJ
+          conditions: '{}'
         - key: system.abilities.cha.save.roll.mode
           value: 1
           priority: null
           type: add
           phase: initial
-          _id: jrtnBvW3RK2zspWS
+          _id: D7PVYGPG1Bgq5IfK
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: 60
@@ -218,16 +251,15 @@ effects:
     sort: 0
     flags:
       dnd5e:
-        riders:
-          statuses: []
+        riders: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725305728157
-      modifiedTime: 1783543975632
+      createdTime: 1787693588718
+      modifiedTime: 1787693588718
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -243,11 +275,14 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
-      value: 1
-      units: rounds
-      expiry: turnStart
+      value: null
+      units: seconds
+      expiry: targetEnd
       expired: false
     description: >-
       <p>The attacker has the &amp;Reference[Blinded apply=false] condition
@@ -260,11 +295,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725306554545
-      modifiedTime: 1783543975632
+      createdTime: 1787693588718
+      modifiedTime: 1787693588718
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -278,11 +313,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 5.1.9
-  createdTime: 1724425959000
-  modifiedTime: 1783543975632
+  systemVersion: 6.0.0
+  createdTime: 1787693588718
+  modifiedTime: 1787693588718
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplHolyAura00'

--- a/packs/_source/spells24/8th-level/power-word-stun.yml
+++ b/packs/_source/spells24/8th-level/power-word-stun.yml
@@ -15,7 +15,7 @@ system:
     book: ''
     page: ''
     license: CC-BY-4.0
-    revision: 3
+    revision: 4
   activation:
     type: action
     condition: ''
@@ -146,11 +146,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.365'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1786481136430
-      modifiedTime: 1786481136430
+      createdTime: 1787693609840
+      modifiedTime: 1787693609840
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -178,9 +178,9 @@ effects:
       conditions: '{}'
     disabled: false
     duration:
-      value: 1
+      value: null
       units: rounds
-      expiry: turnStart
+      expiry: sourceStart
       expired: false
     description: <p>The target's Speed is 0 until the start of your next turn.</p>
     tint: '#ffffff'
@@ -192,11 +192,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.365'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1786481136430
-      modifiedTime: 1786481136430
+      createdTime: 1787693609840
+      modifiedTime: 1787693609840
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -210,11 +210,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.365'
+  coreVersion: '14.367'
   systemId: dnd5e
   systemVersion: 6.0.0
-  createdTime: 1786481136430
-  modifiedTime: 1786481136430
+  createdTime: 1787693609840
+  modifiedTime: 1787693609840
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplPowerWordS'

--- a/packs/_source/spells24/8th-level/power-word-stun.yml
+++ b/packs/_source/spells24/8th-level/power-word-stun.yml
@@ -12,9 +12,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
-    revision: 2
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -29,9 +30,10 @@ system:
       type: creature
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -49,9 +51,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     Sy5x2VhhG7mcnPvF:
       type: utility
@@ -67,19 +66,26 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       effects:
         - _id: o7XJceFSBTiIIPFo
+          uuid: null
+          level: {}
         - _id: B5dLPDfw1fDtfRW1
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -96,8 +102,16 @@ system:
         formula: ''
       name: ''
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: power-word-stun
+  method: spell
+  prepared: 0
 _id: phbsplPowerWordS
 type: spell
 img: icons/magic/unholy/strike-body-life-soul-purple.webp
@@ -111,6 +125,9 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: null
@@ -129,11 +146,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725309558474
-      modifiedTime: 1783543976329
+      createdTime: 1786481136430
+      modifiedTime: 1786481136430
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -148,37 +165,17 @@ effects:
     type: base
     system:
       changes:
-        - key: system.attributes.movement.walk
+        - key: system.attributes.movement.multiplier
           value: 0
           priority: null
-          type: downgrade
+          type: override
           phase: initial
-          _id: cUf9ouWOHimBfnRx
-        - key: system.attributes.movement.climb
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: Zazei337YU6J0Tq2
-        - key: system.attributes.movement.swim
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: pkll3KT00SnFBGyI
-        - key: system.attributes.movement.fly
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: UO48xgcZ5Kol7T3m
-        - key: system.attributes.movement.burrow
-          value: 0
-          priority: null
-          type: downgrade
-          phase: initial
-          _id: WU2XY0ZqEqiqI56V
+          _id: NkUmiPsajiHlEqyV
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: 1
@@ -189,15 +186,17 @@ effects:
     tint: '#ffffff'
     statuses: []
     sort: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725309698245
-      modifiedTime: 1783543976330
+      createdTime: 1786481136430
+      modifiedTime: 1786481136430
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -208,18 +207,14 @@ folder: M5CvwK9zVtzx6Dnn
 sort: 100013
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425966817
-  modifiedTime: 1783543976329
+  systemVersion: 6.0.0
+  createdTime: 1786481136430
+  modifiedTime: 1786481136430
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplPowerWordS'

--- a/packs/_source/spells24/9th-level/storm-of-vengeance.yml
+++ b/packs/_source/spells24/9th-level/storm-of-vengeance.yml
@@ -24,8 +24,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    page: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -45,6 +47,7 @@ system:
       type: circle
       size: '300'
       count: ''
+      stationary: false
   range:
     units: mi
     special: ''
@@ -64,9 +67,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: prepared
-    prepared: false
   activities:
     8QALATRgSsmWWxCl:
       type: save
@@ -83,18 +83,24 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       effects:
         - _id: ujpteFz6imf8RZsj
+          uuid: null
+          level: {}
+          onSave: false
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -110,21 +116,30 @@ system:
               enabled: false
               formula: ''
             number: 2
-            denomination: '6'
+            denomination: 6
             bonus: ''
             types:
               - thunder
             scaling:
               mode: ''
+              number: 1
+            modifiers: []
         onSave: none
       save:
-        ability: con
+        ability:
+          - con
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       img: systems/dnd5e/icons/svg/statuses/exhaustion-1.svg
-      appliedEffects:
-        - ujpteFz6imf8RZsj
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     WOo8u0FLAzNMpMJN:
       type: damage
       name: 'Turn 2: Acid Rain'
@@ -141,6 +156,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -155,6 +171,7 @@ system:
           contiguous: false
           units: ft
           type: ''
+          stationary: false
         affects:
           choice: false
           count: ''
@@ -175,14 +192,22 @@ system:
               enabled: false
               formula: ''
             number: 4
-            denomination: '6'
+            denomination: 6
             bonus: ''
             types:
               - acid
             scaling:
               mode: ''
+              number: 1
+            modifiers: []
       img: systems/dnd5e/icons/svg/statuses/exhaustion-2.svg
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     Fd8ZGgmDyNmJJuj3:
       type: save
       name: 'Turn 3: Lightning'
@@ -199,6 +224,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -213,6 +239,7 @@ system:
           contiguous: false
           units: ft
           type: ''
+          stationary: false
         affects:
           choice: false
           count: ''
@@ -231,20 +258,30 @@ system:
               enabled: false
               formula: ''
             number: 10
-            denomination: '6'
+            denomination: 6
             bonus: ''
             types:
               - lightning
             scaling:
               mode: ''
+              number: 1
+            modifiers: []
         onSave: half
       save:
-        ability: dex
+        ability:
+          - dex
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       img: systems/dnd5e/icons/svg/statuses/exhaustion-3.svg
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     H4uCtCkANBkttnov:
       type: damage
       _id: H4uCtCkANBkttnov
@@ -260,6 +297,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -274,6 +312,7 @@ system:
           contiguous: false
           units: ft
           type: ''
+          stationary: false
         affects:
           choice: false
           count: ''
@@ -294,15 +333,23 @@ system:
               enabled: false
               formula: ''
             number: 2
-            denomination: '6'
+            denomination: 6
             bonus: ''
             types:
               - bludgeoning
             scaling:
               mode: ''
+              number: 1
+            modifiers: []
       name: 'Turn 4: Hailstones'
       img: systems/dnd5e/icons/svg/statuses/exhaustion-4.svg
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
     yt2oWWelZl1zV4CB:
       type: damage
       name: 'Turn 5+: Gusts and Rain'
@@ -319,6 +366,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -332,7 +380,10 @@ system:
         template:
           contiguous: false
           units: ft
-          type: ''
+          type: circle
+          stationary: false
+          size: '300'
+          count: ''
         affects:
           choice: false
           count: ''
@@ -360,9 +411,25 @@ system:
             scaling:
               mode: ''
               number: 1
+            modifiers: []
       img: systems/dnd5e/icons/svg/statuses/exhaustion-5.svg
-      appliedEffects: []
+      behaviors:
+        - type: difficultTerrain
+          _id: vlKWM9EV0sp0BoDg
+          config:
+            types: []
+          level: {}
+      flags: {}
+      visibility:
+        level:
+          min: null
+          max: null
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: storm-of-vengeance
+  method: spell
+  prepared: 0
 _id: phbsplStormofVen
 type: spell
 img: icons/magic/lightning/bolt-cloud-sky-white.webp
@@ -376,6 +443,9 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: 60
@@ -391,11 +461,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725386260763
-      modifiedTime: 1783543977270
+      createdTime: 1786472117938
+      modifiedTime: 1786472117938
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     showIcon: 2
@@ -406,18 +476,14 @@ folder: iG0Zia8jh6uK39TB
 sort: 100196
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425973107
-  modifiedTime: 1783543977270
+  systemVersion: 6.0.0
+  createdTime: 1786472117937
+  modifiedTime: 1786472117937
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplStormofVen'

--- a/packs/_source/spells24/cantrips/chill-touch.yml
+++ b/packs/_source/spells24/cantrips/chill-touch.yml
@@ -11,8 +11,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -27,9 +28,10 @@ system:
       type: any
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: touch
     special: ''
@@ -47,9 +49,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: always
-    prepared: false
   activities:
     mUy5EZouOr5kqvYN:
       type: attack
@@ -66,18 +65,23 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       effects:
         - _id: zwks0mAqBHGZC1Pk
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -104,7 +108,7 @@ system:
               enabled: false
               formula: ''
             number: 1
-            denomination: '10'
+            denomination: 10
             bonus: ''
             types:
               - necrotic
@@ -112,11 +116,19 @@ system:
               mode: whole
               number: 1
               formula: ''
+            modifiers: []
       name: ''
       img: ''
-      appliedEffects:
-        - zwks0mAqBHGZC1Pk
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: chill-touch
+  method: spell
+  prepared: 2
 _id: phbsplChillTouch
 type: spell
 img: icons/magic/unholy/strike-hand-glow-pink.webp
@@ -130,25 +142,30 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
-      value: 1
-      units: rounds
-      expiry: turnStart
+      value: null
+      units: turns
+      expiry: sourceEnd
       expired: false
     description: <p>The target can’t regain Hit Points until the end of your next turn.</p>
     tint: '#ffffff'
     statuses: []
     sort: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725396574015
-      modifiedTime: 1783543974362
+      createdTime: 1787693517022
+      modifiedTime: 1787693517022
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -159,18 +176,14 @@ folder: 4FhsY9FJQd7h7MZb
 sort: 1900000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425944733
-  modifiedTime: 1783543974362
+  systemVersion: 6.0.0
+  createdTime: 1787693517022
+  modifiedTime: 1787693517022
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplChillTouch'

--- a/packs/_source/spells24/cantrips/ray-of-frost.yml
+++ b/packs/_source/spells24/cantrips/ray-of-frost.yml
@@ -156,9 +156,9 @@ effects:
       conditions: '{}'
     disabled: false
     duration:
-      value: 1
+      value: null
       units: rounds
-      expiry: turnStart
+      expiry: sourceStart
       expired: false
     description: >-
       <p>The target's Speed is reduced by 10 feet until the start of your next
@@ -172,11 +172,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.365'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1786481140886
-      modifiedTime: 1786481140886
+      createdTime: 1787693619069
+      modifiedTime: 1787693619069
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -190,11 +190,11 @@ ownership:
 flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.365'
+  coreVersion: '14.367'
   systemId: dnd5e
   systemVersion: 6.0.0
-  createdTime: 1786481140886
-  modifiedTime: 1786481140886
+  createdTime: 1787693619069
+  modifiedTime: 1787693619069
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplRayofFrost'

--- a/packs/_source/spells24/cantrips/ray-of-frost.yml
+++ b/packs/_source/spells24/cantrips/ray-of-frost.yml
@@ -12,8 +12,10 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
     book: ''
+    page: ''
+    license: CC-BY-4.0
+    revision: 3
   activation:
     type: action
     condition: ''
@@ -28,9 +30,10 @@ system:
       type: creature
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -49,9 +52,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: always
-    prepared: false
   activities:
     VQQgdw0BEVD6wapC:
       type: attack
@@ -68,18 +68,23 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       effects:
         - _id: 7dnnwBMWLykrVJub
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -106,16 +111,26 @@ system:
               enabled: false
               formula: ''
             number: 1
-            denomination: '8'
+            denomination: 8
             bonus: ''
             types:
               - cold
             scaling:
               mode: whole
+              number: 1
+            modifiers: []
       name: ''
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: ray-of-frost
+  method: spell
+  prepared: 2
 _id: phbsplRayofFrost
 type: spell
 img: icons/magic/water/projectile-icecicle-glowing.webp
@@ -128,37 +143,17 @@ effects:
     type: base
     system:
       changes:
-        - key: system.attributes.movement.walk
+        - key: system.attributes.movement.bonus
           value: -10
           priority: null
           type: add
           phase: initial
-          _id: wrvzbPmvNz5F1tPd
-        - key: system.attributes.movement.swim
-          value: -10
-          priority: null
-          type: add
-          phase: initial
-          _id: Mu729JPOwGIthoCj
-        - key: system.attributes.movement.climb
-          value: -10
-          priority: null
-          type: add
-          phase: initial
-          _id: 7EPUbpfVRbLluYX7
-        - key: system.attributes.movement.fly
-          value: -10
-          priority: null
-          type: add
-          phase: initial
-          _id: BThq46tD4JD0FeY8
-        - key: system.attributes.movement.burrow
-          value: -10
-          priority: null
-          type: add
-          phase: initial
-          _id: nimG03cIeDoOBgI5
+          _id: IfmY3KgiCyQ3SUWQ
+          conditions: '{}'
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
       value: 1
@@ -171,15 +166,17 @@ effects:
     tint: '#ffffff'
     statuses: []
     sort: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.365'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725489565438
-      modifiedTime: 1783543976545
+      createdTime: 1786481140886
+      modifiedTime: 1786481140886
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -190,18 +187,14 @@ folder: 4FhsY9FJQd7h7MZb
 sort: 200000
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.365'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425968524
-  modifiedTime: 1783543976545
+  systemVersion: 6.0.0
+  createdTime: 1786481140886
+  modifiedTime: 1786481140886
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplRayofFrost'

--- a/packs/_source/spells24/cantrips/shocking-grasp.yml
+++ b/packs/_source/spells24/cantrips/shocking-grasp.yml
@@ -12,8 +12,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -28,9 +29,10 @@ system:
       type: creature
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: touch
     special: ''
@@ -48,9 +50,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: always
-    prepared: false
   activities:
     x1A2tC9t6R5uxBG0:
       type: attack
@@ -67,18 +66,23 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       effects:
         - _id: DQCAm67ck1GEKHtE
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -105,7 +109,7 @@ system:
               enabled: false
               formula: ''
             number: 1
-            denomination: '8'
+            denomination: 8
             bonus: ''
             types:
               - lightning
@@ -113,10 +117,19 @@ system:
               mode: whole
               number: 1
               formula: ''
+            modifiers: []
       name: ''
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: shocking-grasp
+  method: spell
+  prepared: 2
 _id: phbsplShockingGr
 type: spell
 img: icons/magic/lightning/claws-unarmed-strike-teal.webp
@@ -130,11 +143,14 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
-      value: 1
+      value: null
       units: turns
-      expiry: turnStart
+      expiry: targetStart
       expired: false
     description: >-
       <p>The target can’t make Opportunity Attacks until the start of its next
@@ -146,11 +162,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725555777146
-      modifiedTime: 1783543976947
+      createdTime: 1787693630237
+      modifiedTime: 1787693630237
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -161,18 +177,14 @@ folder: 4FhsY9FJQd7h7MZb
 sort: 106250
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425970868
-  modifiedTime: 1783543976947
+  systemVersion: 6.0.0
+  createdTime: 1787693630237
+  modifiedTime: 1787693630237
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplShockingGr'

--- a/packs/_source/spells24/cantrips/starry-wisp.yml
+++ b/packs/_source/spells24/cantrips/starry-wisp.yml
@@ -5,15 +5,17 @@ system:
       <p>You launch a mote of light at one creature or object within range. Make
       a ranged spell attack against the target. On a hit, the target takes 1d8
       Radiant damage, and until the end of your next turn, it emits Dim Light in
-      a 10-foot radius and can't benefit from the &amp;Reference[Invisible]
-      condition.</p><p><strong>Cantrip Upgrade.</strong> The damage increases by
-      1d8 when you reach levels 5 (2d8), 11 (3d8), and 17 (4d8).</p>
+      a 10-foot radius and can't benefit from the &amp;Reference[Invisible
+      apply=false] condition.</p><p><strong>Cantrip Upgrade.</strong> The damage
+      increases by 1d8 when you reach levels 5 (2d8), 11 (3d8), and 17
+      (4d8).</p>
     chat: ''
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -28,9 +30,10 @@ system:
       type: creatureOrObject
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -49,9 +52,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: always
-    prepared: false
   activities:
     iuVRPWuNTiTm0fkj:
       type: attack
@@ -68,18 +68,23 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
         override: false
       effects:
         - _id: T9kBIL7LS3j0Upwz
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -106,16 +111,26 @@ system:
               enabled: false
               formula: ''
             number: 1
-            denomination: '8'
+            denomination: 8
             bonus: ''
             types:
               - radiant
             scaling:
               mode: whole
+              number: 1
+            modifiers: []
       name: ''
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: starry-wisp
+  method: spell
+  prepared: 2
 _id: phbsplStarryWisp
 type: spell
 img: icons/magic/light/orb-hand-green.webp
@@ -129,11 +144,14 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
-      value: 1
-      units: rounds
-      expiry: turnStart
+      value: null
+      units: seconds
+      expiry: sourceEnd
       expired: false
     description: >-
       <p>Until the end of your next turn, it emits Dim Light in a 10-foot radius
@@ -141,15 +159,17 @@ effects:
     tint: '#ffffff'
     statuses: []
     sort: 0
-    flags: {}
+    flags:
+      dnd5e:
+        riders: {}
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725561224825
-      modifiedTime: 1783543977198
+      createdTime: 1787693638044
+      modifiedTime: 1787693638044
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -160,18 +180,14 @@ folder: 4FhsY9FJQd7h7MZb
 sort: 100782
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425972403
-  modifiedTime: 1783543977198
+  systemVersion: 6.0.0
+  createdTime: 1787693638044
+  modifiedTime: 1787693638044
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplStarryWisp'

--- a/packs/_source/spells24/cantrips/vicious-mockery.yml
+++ b/packs/_source/spells24/cantrips/vicious-mockery.yml
@@ -12,8 +12,9 @@ system:
   source:
     custom: ''
     rules: '2024'
-    license: CC-BY-4.0
+    revision: 2
     book: ''
+    license: CC-BY-4.0
   activation:
     type: action
     condition: ''
@@ -28,9 +29,10 @@ system:
       type: creature
       special: ''
     template:
-      units: ''
+      units: ft
       contiguous: false
       type: ''
+      stationary: false
   range:
     units: ft
     special: ''
@@ -48,9 +50,6 @@ system:
     consumed: false
     cost: 0
     supply: 0
-  preparation:
-    mode: always
-    prepared: false
   activities:
     DwMhkWD6NEwUa1L3:
       type: save
@@ -67,6 +66,7 @@ system:
         targets: []
       description:
         chatFlavor: ''
+        value: ''
       duration:
         units: inst
         concentration: false
@@ -74,12 +74,16 @@ system:
       effects:
         - _id: suEeAQQXl0X2JqzF
           onSave: false
+          uuid: null
+          level: {}
       range:
         override: false
+        units: self
       target:
         template:
           contiguous: false
           units: ft
+          stationary: false
         affects:
           choice: false
         override: false
@@ -101,16 +105,27 @@ system:
             scaling:
               mode: whole
               number: 1
+            modifiers: []
         onSave: none
       save:
-        ability: wis
+        ability:
+          - wis
         dc:
           calculation: spellcasting
           formula: ''
+        visible: true
       name: ''
       img: ''
-      appliedEffects: []
+      behaviors: []
+      flags: {}
+      visibility:
+        level: {}
+        requireAttunement: false
+        requireIdentification: false
+        requireMagic: false
   identifier: vicious-mockery
+  method: spell
+  prepared: 2
 _id: phbsplViciousMoc
 type: spell
 img: icons/magic/control/fear-fright-monster-grin-green.webp
@@ -124,11 +139,14 @@ effects:
     system:
       changes: []
       magical: true
+      rider:
+        statuses: []
+      conditions: '{}'
     disabled: false
     duration:
-      value: 1
+      value: null
       units: rounds
-      expiry: turnStart
+      expiry: targetEnd
       expired: false
     description: >-
       <p>The target has Disadvantage on the next attack roll it makes before the
@@ -140,11 +158,11 @@ effects:
     _stats:
       compendiumSource: null
       duplicateSource: null
-      coreVersion: '14.364'
+      coreVersion: '14.367'
       systemId: dnd5e
       systemVersion: 6.0.0
-      createdTime: 1725573178035
-      modifiedTime: 1783543977536
+      createdTime: 1787693667914
+      modifiedTime: 1787693667914
       lastModifiedBy: dnd5ebuilder0000
       exportSource: null
     start: null
@@ -155,18 +173,14 @@ folder: 4FhsY9FJQd7h7MZb
 sort: 100013
 ownership:
   default: 0
-flags:
-  dnd5e:
-    riders:
-      activity: []
-      effect: []
+flags: {}
 _stats:
   duplicateSource: null
-  coreVersion: '14.364'
+  coreVersion: '14.367'
   systemId: dnd5e
-  systemVersion: 4.4.0
-  createdTime: 1724425976745
-  modifiedTime: 1783543977536
+  systemVersion: 6.0.0
+  createdTime: 1787693667914
+  modifiedTime: 1787693667914
   lastModifiedBy: dnd5ebuilder0000
   exportSource: null
 _key: '!items!phbsplViciousMoc'


### PR DESCRIPTION
### Difficult Terrain Behavior
- Black Tentacles
- Blade Burrier
- Conjure Minor Elementals
- Entangle
- Ice Storm
- Insect Plague
- Sleet Storm
- Spike Growth
- Storm of Vengeance
- Web

### Apply Active Effect Behavior
- Aura of Life
- Silence

### Teleport Activity
- Dimension Door
- Misty Step
- Plane Shift
- Teleport
- Teleportation Circle
- Transport via Plants
- Tree Stride
- Word of Recall

### Size Active Effects
- Enlarge/Reduce

### Use Movement Multiplier
- Dream
- Flesh to Stone
- Haste
- Hypnotic Pattern
- Magic Jar
- Power Word Stun
- Slow
- Spirit Guardians

### Fix Movement Issues
- Alter Self (use upgrade rather than override for swim speed)
- Ray of Frost (swap to using bonus)

### New Expiry Events
- Blink
- Chill Touch
- Color Spray
- Conjure Fey
- Find Steed
- Flesh to Stone
- Giant Insect
- Guiding Bolt
- Haste
- Heat Metal
- Holy Aura
- Irresistible Dance
- Power Word Stun
- Ray of Enfeeblement
- Ray of Frost
- Ray of Sickness
- Shield
- Shocking Grasp
- Sunbeam
- Vicious Mockery