### PR TITLE
Add compact styling to effects tray.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -334,6 +334,10 @@
   },
   "Expired": "Expired",
   "Expiry": {
+    "Abbreviation": {
+      "End": "End",
+      "Start": "Start"
+    },
     "GROUPS": {
       "General": "General",
       "Specific": "Specific"
@@ -1762,6 +1766,9 @@
     "rollCheck": "Ability checks",
     "rollSave": "Saving throws"
   },
+  "Targets": {
+    "Count": "{number}× {name}"
+  },
   "TURN": {
     "NoCombatant": "Combatant no longer exists!"
   }
@@ -2616,6 +2623,7 @@
 "DND5E.EFFECT": {
   "Action": {
     "AddChange": "Add Change",
+    "Apply": "Apply",
     "CreateEffect": "Create Effect",
     "DeleteEffect": "Delete Effect",
     "DeleteChange": "Delete Change",
@@ -5556,6 +5564,7 @@
 "DND5E.Tokens": {
   "NoneSelected": "No Tokens Selected",
   "NoneTargeted": "No Tokens Targeted",
+  "NoTargets": "No Targets",
   "Selected": "Selected",
   "Targeted": "Targeted"
 },

--- a/less/elements.less
+++ b/less/elements.less
@@ -317,3 +317,52 @@ section.secret > button.reveal {
 prose-mirror {
   button.toggle:disabled { display: none; }
 }
+
+/* -------------------------------------------- */
+/*  Target Pills                                */
+/* -------------------------------------------- */
+
+.dnd5e2 .pills target-pill.pill {
+  --pip-fill: var(--color-text-secondary);
+  --pip-size: 7px;
+  align-items: center;
+  background-color: transparent;
+  border: var(--pill-border-dotted);
+  color: var(--pill-transparent-color);
+  user-select: none;
+
+  &.context { pointer-events: auto; }
+
+  &:not(:disabled) {
+    cursor: var(--cursor-pointer);
+    label { cursor: var(--cursor-pointer); }
+  }
+
+  .pip {
+    block-size: var(--pip-size);
+    border: 1px solid var(--pip-fill);
+    border-radius: 50%;
+    inline-size: var(--pip-size);
+  }
+
+  &[checked] {
+    --pip-fill: var(--color-level-success);
+    background-color: #1a6b22;
+    border-color: var(--color-level-success-border);
+    color: var(--pill-colored-text-color);
+    .pip { background: var(--pip-fill); }
+  }
+
+  &[indeterminate] {
+    --pip-fill: transparent;
+    background-color: var(--dnd5e-background-card);
+
+    .pip {
+      background: var(--color-text-secondary);
+      block-size: 2px;
+      border-radius: 0;
+      inline-size: 6px;
+      padding-block-start: 1px;
+    }
+  }
+}

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -415,37 +415,37 @@
     display: flex;
     flex-wrap: wrap;
     gap: .25rem;
+  }
 
-    .pill {
-      font-family: var(--dnd5e-font-roboto-condensed);
-      font-weight: 400;
-      font-size: var(--font-size-11);
-      line-height: 1;
-      text-transform: none;
-      border: var(--pill-border);
-      border-radius: 3px;
-      background: var(--dnd5e-background-card);
-      padding: 2px 5px;
-      display: flex;
-      gap: .25rem;
-      margin: 0;
+  .pill {
+    font-family: var(--dnd5e-font-roboto-condensed);
+    font-weight: 400;
+    font-size: var(--font-size-11);
+    line-height: 1;
+    text-transform: none;
+    border: var(--pill-border);
+    border-radius: 3px;
+    background: var(--dnd5e-background-card);
+    padding: 2px 5px;
+    display: flex;
+    gap: .25rem;
+    margin: 0;
 
-      &.green, &.maroon {
-        color: var(--pill-colored-text-color);
-        border: var(--pill-colored-border);
-      }
-
-      &.green { background-color: var(--pill-background-green); }
-      &.maroon { background-color: var(--pill-background-maroon); }
-
-      &.transparent {
-        color: var(--pill-transparent-color);
-        border: var(--pill-border-dotted);
-        background-color: transparent;
-      }
-
-      > .separator { color: var(--color-text-tertiary); }
+    &.green, &.maroon {
+      color: var(--pill-colored-text-color);
+      border: var(--pill-colored-border);
     }
+
+    &.green { background-color: var(--pill-background-green); }
+    &.maroon { background-color: var(--pill-background-maroon); }
+
+    &.transparent {
+      color: var(--pill-transparent-color);
+      border: var(--pill-border-dotted);
+      background-color: transparent;
+    }
+
+    > .separator { color: var(--color-text-tertiary); }
   }
 
   .gold-button, &.standard-form button.gold-button {

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -2020,7 +2020,10 @@ dialog.dnd5e2.application {
   .collapsible-content {
     display: grid;
     transition: grid-template-rows 250ms ease;
-    > .wrapper { overflow: hidden; }
+    > .wrapper {
+      overflow: hidden;
+      transition: padding-block 250ms ease;
+    }
   }
 }
 
@@ -2030,7 +2033,10 @@ dialog.dnd5e2.application {
   }
   :scope.collapsed {
     .fa-caret-down { transform: rotate(-90deg); }
-    .collapsible-content { grid-template-rows: 0fr; }
+    .collapsible-content {
+      grid-template-rows: 0fr;
+      > .wrapper { padding-block: 0; }
+    }
   }
 }
 

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -528,8 +528,8 @@
   content-visibility: auto;
 }
 
-.dnd5e2 :is(.card-tray, .effects-tray, .targets-tray) {
-  margin-top: .125rem;
+.dnd5e2 :is(.card-tray, .targets-tray):not(.effects-tray) {
+  margin-top: 4px;
   &.damage-tray, &.effects-tray { margin-block-start: 8px; }
   &.targets-tray {
     margin-top: 6px;

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -540,10 +540,16 @@
     }
   }
 
-  .effect-name .duration, &.effect-tooltip .duration {
-    padding: .25rem;
-    border: var(--dnd5e-border-dashed-faint);
-    border-radius: 4px;
+  .effect-name .duration {
+    align-items: center;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+
+    > i { font-size: var(--font-size-9); }
+    .least-significant { color: var(--color-text-tertiary); }
+  }
+
+  &.effect-tooltip .duration {
     font-family: var(--dnd5e-font-roboto-condensed);
     text-transform: uppercase;
     font-size: var(--font-size-11);

--- a/less/v3/chat.less
+++ b/less/v3/chat.less
@@ -236,14 +236,23 @@
   .effects {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    margin-block: -4px;
     user-select: none;
 
-    .effect {
+    .effect > button {
       align-items: center;
+      block-size: auto;
+      color: inherit;
       cursor: var(--cursor-pointer);
       display: flex;
       gap: 8px;
+      inline-size: 100%;
+      padding: 4px 0;
+      text-align: start;
+      text-transform: none;
+
+      &:hover:not(:disabled), &:focus { box-shadow: none; }
+      &:focus-visible { text-shadow: 0 0 5px var(--color-shadow-highlight); }
 
       > .gold-icon {
         block-size: 16px;
@@ -270,9 +279,9 @@
         border: 1px solid var(--dnd5e-color-gold);
         border-radius: 50%;
         inline-size: 7px;
-
-        &[aria-pressed=true] { background: var(--dnd5e-color-gold); }
       }
+
+      &[aria-pressed=true] > .pip { background: var(--dnd5e-color-gold); }
     }
   }
 
@@ -281,7 +290,8 @@
     color: var(--color-level-error);
   }
 
-  .icon-row > .target-source-toggle {
+  .icon-row > button.target-source-toggle {
+    align-self: stretch;
     block-size: unset;
     color: var(--dnd5e-color-gold);
     font-size: var(--font-size-12);

--- a/less/v3/chat.less
+++ b/less/v3/chat.less
@@ -216,15 +216,11 @@
     }
   }
 
-  .collapsible-content {
-    overflow: hidden;
-
-    > .wrapper {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-      padding: 4px 8px 8px;
-    }
+  .collapsible-content > .wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 4px 8px 8px;
   }
 
   .apply-button {

--- a/less/v3/chat.less
+++ b/less/v3/chat.less
@@ -1,6 +1,6 @@
-/* ---------------------------------- */
-/*  Chat Cards                        */
-/* ---------------------------------- */
+/* -------------------------------------------- */
+/*  Chat Cards                                  */
+/* -------------------------------------------- */
 
 .chat-log, .chat-popout {
   .message.compact {
@@ -153,7 +153,7 @@
         flex-wrap: wrap;
         gap: 4px;
         justify-content: end;
-        margin-left: auto;
+        margin-inline-start: auto;
       }
 
       button {
@@ -187,9 +187,125 @@
   }
 }
 
-/* ---------------------------------- */
-/*  Hidden Content                    */
-/* ---------------------------------- */
+/* -------------------------------------------- */
+/*  Trays                                       */
+/* -------------------------------------------- */
+
+.dnd5e2 .card-tray {
+  margin-block-start: 8px;
+  margin-inline: -8px;
+  margin: 8px -8px -8px;
+
+  > label {
+    align-items: center;
+    color: var(--color-text-secondary);
+    cursor: var(--cursor-pointer);
+    display: flex;
+    font-size: var(--font-size-11);
+    gap: 4px;
+    justify-content: center;
+
+    > span { flex: none; }
+    > i:first-of-type { color: var(--dnd5e-color-gold); }
+    .fa-caret-down { transition: all 250ms ease; }
+
+    &::before, &::after {
+      border-block-start: 1px dashed var(--dnd5e-color-blue-gray-3);
+      content: "";
+      flex-basis: 50%;
+    }
+  }
+
+  .collapsible-content {
+    overflow: hidden;
+
+    > .wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 4px 8px 8px;
+    }
+  }
+
+  .apply-button {
+    --input-height: 20px;
+    font-variant: all-small-caps;
+    i { font-size: var(--font-size-10); }
+  }
+
+  .effects {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    user-select: none;
+
+    .effect {
+      align-items: center;
+      cursor: var(--cursor-pointer);
+      display: flex;
+      gap: 8px;
+
+      > .gold-icon {
+        block-size: 16px;
+        inline-size: 16px;
+        flex-basis: 16px;
+      }
+
+      > .title {
+        flex: 1;
+        font-family: var(--dnd5e-font-roboto-slab);
+        font-size: var(--font-size-12);
+        font-weight: bold;
+      }
+
+      > .duration {
+        align-items: center;
+        color: var(--color-text-secondary);
+
+        > i { font-size: var(--font-size-8); }
+      }
+
+      > .pip {
+        block-size: 7px;
+        border: 1px solid var(--dnd5e-color-gold);
+        border-radius: 50%;
+        inline-size: 7px;
+
+        &[aria-pressed=true] { background: var(--dnd5e-color-gold); }
+      }
+    }
+  }
+
+  .target.none {
+    border: 1px solid var(--color-level-error-border);
+    color: var(--color-level-error);
+  }
+
+  .icon-row > .target-source-toggle {
+    block-size: unset;
+    color: var(--dnd5e-color-gold);
+    font-size: var(--font-size-12);
+
+    &::before {
+      content: "\f140";
+      font-family: var(--font-awesome);
+      font-weight: bold;
+    }
+
+    &[data-mode=selected]::before { content: "\f065"; }
+
+    &:hover:not(:disabled), &:focus {
+      box-shadow: none;
+      text-shadow: 0 0 5px var(--color-shadow-highlight);
+    }
+
+    &:disabled:hover { text-shadow: none; }
+  }
+}
+
+/* -------------------------------------------- */
+/*  Hidden Content                              */
+/* -------------------------------------------- */
 
 .chat-sidebar, .chat-popout, #chat-notifications {
   &:not([data-gm-user]) .message.compact .card-header[data-concealed] {

--- a/module/applications/components/_module.mjs
+++ b/module/applications/components/_module.mjs
@@ -16,6 +16,7 @@ import InventoryElement from "./inventory.mjs";
 import ItemListControlsElement from "./item-list-controls.mjs";
 import ProficiencyCycleElement from "./proficiency-cycle.mjs";
 import SlideToggleElement from "./slide-toggle.mjs";
+import TargetPillElement from "./target-pill.mjs";
 
 window.customElements.define(CopyableTextElement.tagName, CopyableTextElement);
 window.customElements.define(DamageApplicationElement.tagName, DamageApplicationElement);
@@ -34,10 +35,11 @@ window.customElements.define(FilterStateElement.tagName, FilterStateElement);
 window.customElements.define(ItemListControlsElement.tagName, ItemListControlsElement);
 window.customElements.define(ProficiencyCycleElement.tagName, ProficiencyCycleElement);
 window.customElements.define(SlideToggleElement.tagName, SlideToggleElement);
+window.customElements.define(TargetPillElement.tagName, TargetPillElement);
 
 export {
   ActivitiesElement, AdoptedStyleSheetMixin, CopyableTextElement, CheckboxElement, DamageApplicationElement,
   DoubleRangePickerElement, EffectApplicationElement, EffectsElement, EnchantmentApplicationElement,
   FiligreeBoxElement, FiltersInputElement, FilterStateElement, IconElement, IdentifierInputElement,
-  InventoryElement, ItemListControlsElement, ProficiencyCycleElement, SlideToggleElement
+  InventoryElement, ItemListControlsElement, ProficiencyCycleElement, SlideToggleElement, TargetPillElement
 };

--- a/module/applications/components/chat-tray-element.mjs
+++ b/module/applications/components/chat-tray-element.mjs
@@ -52,9 +52,10 @@ export default class ChatTrayElement extends (foundry.applications.elements.Adop
    * @param {PointerEvent} event  Triggering click event.
    */
   _handleClickHeader(event) {
+    if ( event.target.closest(".collapsible-content") ) return;
     event.preventDefault();
     event.stopImmediatePropagation();
-    if ( !event.target.closest(".collapsible-content") ) this.toggleAttribute("open");
+    this.toggleAttribute("open");
   }
 
   /* -------------------------------------------- */

--- a/module/applications/components/checkbox.mjs
+++ b/module/applications/components/checkbox.mjs
@@ -19,6 +19,11 @@ export default class CheckboxElement extends AdoptedStyleSheetMixin(
   /* -------------------------------------------- */
 
   /** @override */
+  static observedAttributes = ["checked"];
+
+  /* -------------------------------------------- */
+
+  /** @override */
   static tagName = "dnd5e-checkbox";
 
   /* -------------------------------------------- */
@@ -130,7 +135,6 @@ export default class CheckboxElement extends AdoptedStyleSheetMixin(
 
   set checked(checked) {
     this.toggleAttribute("checked", checked);
-    this._refresh();
   }
 
   /* -------------------------------------------- */
@@ -158,6 +162,13 @@ export default class CheckboxElement extends AdoptedStyleSheetMixin(
 
   /* -------------------------------------------- */
   /*  Element Lifecycle                           */
+  /* -------------------------------------------- */
+
+  /** @override */
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    if ( this.isConnected ) this._refresh();
+  }
+
   /* -------------------------------------------- */
 
   /** @override */

--- a/module/applications/components/damage-application.mjs
+++ b/module/applications/components/damage-application.mjs
@@ -124,19 +124,19 @@ export default class DamageApplicationElement extends TargetedApplicationMixin(C
       div.addEventListener("click", this._handleClickHeader.bind(this));
     }
 
-    this.targetingMode = this.targetSourceControl.hidden ? "selected" : "targeted";
+    this.targetingMode = "targeted";
   }
 
   /* -------------------------------------------- */
 
   /** @override */
   buildTargetListEntry({ uuid, name }) {
-    const actor = fromUuidSync(uuid);
-    if ( !actor?.isOwner ) return;
+    const token = fromUuidSync(uuid);
+    if ( !token?.isOwner ) return;
 
     // Calculate damage to apply
     const targetOptions = this.getTargetOptions(uuid);
-    const { temp, tempMax, total, active } = this.calculateDamage(actor, targetOptions);
+    const { temp, tempMax, total, active } = this.calculateDamage(token.actor, targetOptions);
 
     const types = [];
     for ( const [change, values] of Object.entries(active) ) {
@@ -174,7 +174,7 @@ export default class DamageApplicationElement extends TargetedApplicationMixin(C
       </div>
       <menu class="damage-multipliers unlist"></menu>
     `;
-    Object.assign(li.querySelector(".gold-icon"), { alt: name, src: actor.img });
+    Object.assign(li.querySelector(".gold-icon"), { alt: name, src: token.texture.src });
     li.querySelector(".name-stacked .title").append(name);
     const menu = li.querySelector("menu");
     for ( const [value, display] of MULTIPLIERS ) {
@@ -187,7 +187,7 @@ export default class DamageApplicationElement extends TargetedApplicationMixin(C
       menu.append(entry);
     }
 
-    this.refreshListEntry(actor, li, targetOptions);
+    this.refreshListEntry(token, li, targetOptions);
     li.addEventListener("click", this._onChangeOptions.bind(this));
 
     return li;
@@ -284,12 +284,12 @@ export default class DamageApplicationElement extends TargetedApplicationMixin(C
 
   /**
    * Refresh the damage total on a list entry based on modified options.
-   * @param {Actor5e} token
+   * @param {TokenDocument5e} token
    * @param {HTMLLiElement} entry
    * @param {DamageApplicationOptions} options
    */
   refreshListEntry(token, entry, options) {
-    const { active, temp, tempMax, total } = this.calculateDamage(token, options);
+    const { active, temp, tempMax, total } = this.calculateDamage(token.actor, options);
     const calculatedDamage = entry.querySelector(".calculated.damage");
     calculatedDamage.innerText = formatNumber(-total, { signDisplay: "exceptZero" });
     calculatedDamage.classList.toggle("healing", total < 0);

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -1,4 +1,4 @@
-import { loadingTooltip } from "../../utils.mjs";
+import { convertTime, formatTime, loadingTooltip } from "../../utils.mjs";
 import ChatTrayElement from "./chat-tray-element.mjs";
 import TargetedApplicationMixin from "./targeted-application-mixin.mjs";
 
@@ -51,10 +51,39 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
   /* -------------------------------------------- */
 
   /**
+   * Checked status for effects.
+   * @type {Map<string, boolean>}
+   */
+  #effectOptions = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Target pills grouped by their grouping keys.
+   * @type {Record<string, TargetPillElement>}
+   */
+  #targetGroups;
+
+  /* -------------------------------------------- */
+
+  /**
    * Checked status for application targets.
    * @type {Map<string, boolean>}
    */
   #targetOptions = new Map();
+
+  /* -------------------------------------------- */
+
+  /**
+   * Checked status for the given effect.
+   * @param {string} uuid  UUID of the effect.
+   * @returns {boolean}
+   */
+  effectChecked(uuid) {
+    return this.#effectOptions.get(uuid) ?? false;
+  }
+
+  /* -------------------------------------------- */
 
   /**
    * Options for a specific target.
@@ -95,8 +124,11 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
         </label>
         <div class="collapsible-content">
           <div class="wrapper">
-            <hr>
             <menu class="effects unlist"></menu>
+            <button type="button" class="apply-button" data-action="apply">
+              <i class="fa-solid fa-reply-all fa-flip-horizontal" inert></i>
+              <span>${_loc("DND5E.EFFECT.Action.Apply")}</span>
+            </button>
           </div>
         </div>
       `;
@@ -106,10 +138,12 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       else this.buildEffectsList();
       div.querySelector(".wrapper").prepend(...this.buildTargetContainer());
       this.targetList.addEventListener("change", this._onCheckTarget.bind(this));
+      this.effectsList.addEventListener("click", this._onCheckEffect.bind(this));
       div.addEventListener("click", this._handleClickHeader.bind(this));
+      div.querySelector(".apply-button").addEventListener("click", this._onApplyEffects.bind(this));
     }
 
-    this.targetingMode = this.targetSourceControl.hidden ? "selected" : "targeted";
+    this.targetingMode = "targeted";
   }
 
   /* -------------------------------------------- */
@@ -118,8 +152,12 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
    * Build a list of active effects.
    */
   buildEffectsList() {
+    if ( this.effects.length && foundry.utils.isEmpty(this.#effectOptions) ) {
+      this.#effectOptions.set(this.effects[0].uuid, true);
+    }
     for ( const effect of this.effects ) {
       effect.updateDuration();
+      const { icon, label } = this.#formatDuration(effect);
       const li = document.createElement("li");
       li.classList.add("effect");
       Object.assign(li.dataset, {
@@ -131,52 +169,115 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       });
       li.innerHTML = `
         <img class="gold-icon">
-        <div class="name-stacked">
-          <span class="title"></span>
-          <span class="subtitle">${effect.duration.label}</span>
+        <span class="title"></span>
+        <div class="duration pill transparent">
+          <i class="fa-solid ${icon}" inert></i>
+          <span>${label}</span>
         </div>
-        <button class="apply-effect" type="button" data-action="applyEffect"
-                data-tooltip aria-label="${_loc("DND5E.EFFECT.Application.Action.ApplyTokens")}">
-          <i class="fas fa-reply-all fa-flip-horizontal" inert></i>
-        </button>
+        <span class="pip" aria-pressed="${this.effectChecked(effect.uuid)}"></span>
       `;
       Object.assign(li.querySelector(".gold-icon"), { alt: effect.name, src: effect.img });
-      li.querySelector(".name-stacked .title").append(effect.name);
+      li.querySelector(".title").append(effect.name);
       this.effectsList.append(li);
-      li.addEventListener("click", this._onApplyEffect.bind(this));
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  buildTargetContainer() {
+    const [control, list] = super.buildTargetContainer();
+    const row = document.createElement("section");
+    row.classList.add("icon-row");
+    row.append(control, list);
+    list.classList.add("pills");
+    return [row];
   }
 
   /* -------------------------------------------- */
 
   /** @override */
   buildTargetListEntry({ uuid, name }) {
-    const actor = fromUuidSync(uuid);
-    if ( !actor?.isOwner ) return;
+    const token = fromUuidSync(uuid);
+    if ( !token?.isOwner ) return;
 
-    const disabled = this.targetingMode === "selected" ? " disabled" : "";
-    const checked = this.targetChecked(uuid) ? " checked" : "";
+    const key = token.getGroupingKey() ?? token.uuid;
+    let group = this.#targetGroups[key];
+    const isGrouped = group;
 
-    const li = document.createElement("li");
-    li.classList.add("target");
-    li.dataset.targetUuid = uuid;
-    li.innerHTML = `
-      <img class="gold-icon">
-      <div class="name-stacked">
-        <span class="title"></span>
-      </div>
-      <div class="checkbox">
-        <dnd5e-checkbox name="${uuid}"${checked}${disabled}></dnd5e-checkbox>
-      </div>
-    `;
-    Object.assign(li.querySelector(".gold-icon"), { alt: name, src: actor.img });
-    li.querySelector(".name-stacked .title").append(name);
+    if ( !group ) {
+      group = document.createElement("target-pill");
+      group.insertAdjacentHTML("afterbegin", "<label></label><datalist></datalist>");
+      group.querySelector("label").append(name);
+      group.disabled = this.targetingMode === "selected";
+    }
 
-    return li;
+    const option = document.createElement("option");
+    option.value = token.uuid;
+    option.toggleAttribute("data-checked", this.targetChecked(token.uuid));
+    option.append(name);
+    const data = group.querySelector("datalist");
+    data.append(option);
+    const count = data.children.length;
+    group.querySelector("label").textContent = count > 1
+      ? _loc("DND5E.CHATMESSAGE.Targets.Count", { name, number: count })
+      : name;
+    this.#targetGroups[key] = group;
+
+    return isGrouped ? null : group;
   }
 
   /* -------------------------------------------- */
-  /*  Event Handlers                              */
+
+  /** @inheritDoc */
+  buildTargetsList() {
+    this.#targetGroups = {};
+    return super.buildTargetsList();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _buildTargetSourceControl() {
+    const control = document.createElement("button");
+    control.type = "button";
+    control.classList.add("unbutton", "control-button", "target-source-toggle");
+    control.toggleAttribute("data-tooltip", true);
+    control.addEventListener("click", this._onChangeTargetMode.bind(this));
+    return control;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _refreshTargetMode() {
+    const targeted = this.targetingMode === "targeted";
+    this.targetSourceControl.dataset.mode = this.targetingMode;
+    this.targetSourceControl.ariaLabel = _loc(`DND5E.Tokens.${targeted ? "Targeted" : "Selected"}`);
+    this.targetSourceControl.disabled = !this.hasRecordedTargets;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Abbreviate an effect's duration, using the most significant unit that can represent it.
+   * @param {ActiveEffect5e} effect              The effect being displayed.
+   * @returns {{ icon: string, label: string }}  Icon and label to display.
+   */
+  #formatDuration(effect) {
+    const special = effect.getSpecialDurationParts();
+    if ( special ) return special;
+    const { label, units, value } = effect.duration;
+    if ( !Number.isFinite(value) || !units ) return { icon: "fa-clock", label };
+    const from = units.replace(/s$/, "");
+    const { unit, value: converted } = CONFIG.DND5E.timeUnits[from]?.combat
+      ? { value, unit: from }
+      : convertTime(value, from, { truncate: true });
+    return { icon: "fa-clock", label: formatTime(converted, unit, { unitDisplay: "narrow" }) };
+  }
+
+  /* -------------------------------------------- */
+  /*  Methods                                     */
   /* -------------------------------------------- */
 
   /**
@@ -188,6 +289,22 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
    * @protected
    */
   async _applyEffectToActor(effect, actor) {
+    const { action, data } = this._prepareEffectData(effect, actor);
+    if ( action === "update" ) return actor.effects.get(data._id).update(data);
+    return ActiveEffect.implementation.create(data, { parent: actor });
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare the data for applying an Active Effect to an Actor.
+   * @param {ActiveEffect5e} effect                         The effect to apply.
+   * @param {Actor5e} actor                                 The actor.
+   * @returns {{ action: "create"|"update", data: object }} The effect data and the operation required to apply it.
+   * @throws {Error}                                        If the effect could not be applied.
+   * @protected
+   */
+  _prepareEffectData(effect, actor) {
     const concentration = this.chatMessage.getAssociatedActor()?.effects.get(this.chatMessage.system.concentration);
     const item = this.chatMessage.getAssociatedItem();
     const origin = concentration ?? (effect.inCompendium && item ? item : effect);
@@ -214,14 +331,16 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     }
 
     // Enable an existing effect on the target if it originated from this effect
-    const existingEffect = effect.inCompendium ? actor.effects.find(e => e._stats.compendiumSource === effect.uuid)
+    const existingEffect = effect.inCompendium
+      ? actor.effects.find(e => e._stats.compendiumSource === effect.uuid)
       : actor.effects.find(e => e.origin === origin.uuid);
     if ( existingEffect ) {
-      return existingEffect.update(foundry.utils.mergeObject({
+      return { action: "update", data: foundry.utils.mergeObject({
         ...durationOverride,
+        _id: existingEffect.id,
         disabled: false,
         start: effect.constructor.getEffectStart()
-      }, effectFlags));
+      }, effectFlags) };
     }
 
     if ( !game.user.isGM && concentration && !concentration.isOwner ) {
@@ -229,7 +348,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     }
 
     // Otherwise, create a new effect on the target
-    const effectData = foundry.utils.mergeObject({
+    return { action: "create", data: foundry.utils.mergeObject({
       ...effect.toObject(),
       ...durationOverride,
       disabled: false,
@@ -239,32 +358,71 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
         [effect.inCompendium ? "compendiumSource" : "duplicateSource"]: effect.uuid,
         [effect.inCompendium ? "duplicateSource" : "compendiumSource"]: null
       }
-    }, effectFlags);
-    return await ActiveEffect.implementation.create(effectData, { parent: actor });
+    }, effectFlags) };
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Handlers                              */
+  /* -------------------------------------------- */
+
+  /**
+   * Handle applying selected effects to the appropriate targets.
+   * @protected
+   */
+  async _onApplyEffects() {
+    const effects = this.effects.filter(e => this.effectChecked(e.uuid));
+    const operations = [];
+    for ( const option of this.targetList.querySelectorAll("option[data-checked]") ) {
+      const doc = await fromUuid(option.value);
+      const actor = doc?.actor ?? doc;
+      if ( !actor ) continue;
+      const data = [];
+      const updates = [];
+      for ( const effect of effects ) {
+        try {
+          const operation = this._prepareEffectData(effect, actor);
+          (operation.action === "create" ? data : updates).push(operation.data);
+        } catch ( err ) {
+          Hooks.onError("EffectApplicationElement._prepareEffectData", err, { notify: "warn", log: "warn" });
+        }
+      }
+      if ( data.length ) operations.push({ data, action: "create", documentName: "ActiveEffect", parent: actor });
+      if ( updates.length ) {
+        operations.push({ updates, action: "update", documentName: "ActiveEffect", parent: actor });
+      }
+    }
+    if ( operations.length ) await foundry.documents.modifyBatch(operations);
+    if ( game.settings.get("dnd5e", "autoCollapseChatTrays") !== "manual" ) {
+      this.querySelector(".collapsible").dispatchEvent(new PointerEvent("click", { bubbles: true, cancelable: true }));
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onChangeTargetMode(event) {
+    event.preventDefault();
+    this.targetingMode = this.targetingMode === "targeted" ? "selected" : "targeted";
   }
 
   /* -------------------------------------------- */
 
   /**
-   * Handle clicking the apply effect button.
-   * @param {PointerEvent} event  Triggering click event.
+   * Handle checking or unchecking an effect.
+   * @param {PointerEvent} event  The triggering event.
+   * @protected
    */
-  async _onApplyEffect(event) {
-    event.preventDefault();
-    const effect = await fromUuid(event.target.closest("[data-uuid]")?.dataset.uuid);
+  _onCheckEffect(event) {
+    const effect = event.target.closest(".effect[data-uuid]");
     if ( !effect ) return;
-    for ( const target of this.targetList.querySelectorAll("[data-target-uuid]") ) {
-      const actor = fromUuidSync(target.dataset.targetUuid);
-      if ( !actor || !target.querySelector("dnd5e-checkbox")?.checked ) continue;
-      try {
-        await this._applyEffectToActor(effect, actor);
-      } catch(err) {
-        Hooks.onError("EffectApplicationElement._applyEffectToToken", err, { notify: "warn", log: "warn" });
-      }
-    }
-    if ( game.settings.get("dnd5e", "autoCollapseChatTrays") !== "manual" ) {
-      this.querySelector(".collapsible").dispatchEvent(new PointerEvent("click", { bubbles: true, cancelable: true }));
-    }
+    event.stopPropagation();
+    const { uuid } = effect.dataset;
+    const checked = this.#effectOptions.get(uuid);
+    if ( !event.shiftKey ) this.#effectOptions.clear();
+    this.#effectOptions.set(uuid, event.shiftKey ? !checked : true);
+    this.querySelectorAll(".effect[data-uuid]").forEach(el => {
+      el.querySelector(".pip").ariaPressed = `${this.#effectOptions.get(el.dataset.uuid) ?? false}`;
+    });
   }
 
   /* -------------------------------------------- */
@@ -274,9 +432,8 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
    * @param {Event} event  Triggering change event.
    */
   _onCheckTarget(event) {
-    const uuid = event.target.closest("[data-target-uuid]")?.dataset.targetUuid;
-    if ( !uuid ) return;
-    this.#targetOptions.set(uuid, event.target.checked);
+    this.#targetOptions = new Map(Iterator.from(event.currentTarget.querySelectorAll(".target option"))
+      .map(el => [el.value, "checked" in el.dataset]));
   }
 
   /* -------------------------------------------- */

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -168,13 +168,15 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
         uuid: effect.uuid
       });
       li.innerHTML = `
-        <img class="gold-icon">
-        <span class="title"></span>
-        <div class="duration pill transparent">
-          <i class="fa-solid ${icon}" inert></i>
-          <span>${label}</span>
-        </div>
-        <span class="pip" aria-pressed="${this.effectChecked(effect.uuid)}"></span>
+        <button type="button" class="unbutton" aria-pressed="${this.effectChecked(effect.uuid)}">
+          <img class="gold-icon">
+          <span class="title"></span>
+          <span class="duration pill transparent">
+            <i class="fa-solid ${icon}" inert></i>
+            <span>${label}</span>
+          </span>
+          <span class="pip" inert></span>
+        </button>
       `;
       Object.assign(li.querySelector(".gold-icon"), { alt: effect.name, src: effect.img });
       li.querySelector(".title").append(effect.name);
@@ -421,7 +423,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
     if ( !event.shiftKey ) this.#effectOptions.clear();
     this.#effectOptions.set(uuid, event.shiftKey ? !checked : true);
     this.querySelectorAll(".effect[data-uuid]").forEach(el => {
-      el.querySelector(".pip").ariaPressed = `${this.#effectOptions.get(el.dataset.uuid) ?? false}`;
+      el.querySelector("button").ariaPressed = `${this.#effectOptions.get(el.dataset.uuid) ?? false}`;
     });
   }
 

--- a/module/applications/components/proficiency-cycle.mjs
+++ b/module/applications/components/proficiency-cycle.mjs
@@ -19,7 +19,7 @@ export default class ProficiencyCycleElement extends AdoptedStyleSheetMixin(
   /* -------------------------------------------- */
 
   /**
-   * The HTML tag named used by this element.
+   * The HTML tag name used by this element.
    * @type {string}
    */
   static tagName = "proficiency-cycle";
@@ -84,14 +84,6 @@ export default class ProficiencyCycleElement extends AdoptedStyleSheetMixin(
       opacity: 0;
     }
   `;
-
-  /* -------------------------------------------- */
-
-  /**
-   * Controller for removing listeners automatically.
-   * @type {AbortController}
-   */
-  #controller;
 
   /* -------------------------------------------- */
 
@@ -182,18 +174,11 @@ export default class ProficiencyCycleElement extends AdoptedStyleSheetMixin(
 
   /** @override */
   _activateListeners() {
-    const { signal } = this.#controller = new AbortController();
+    const signal = this.abortSignal;
     this.addEventListener("click", this.#onClick.bind(this), { signal });
     this.addEventListener("contextmenu", this.#onClick.bind(this), { signal });
     this.#shadowRoot.querySelector("div").addEventListener("contextmenu", e => e.preventDefault(), { signal });
     this.#shadowRoot.querySelector("input").addEventListener("change", this.#onChangeInput.bind(this), { signal });
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
-  disconnectedCallback() {
-    this.#controller.abort();
   }
 
   /* -------------------------------------------- */

--- a/module/applications/components/target-menu.mjs
+++ b/module/applications/components/target-menu.mjs
@@ -1,0 +1,26 @@
+/**
+ * A FilterMenu implementation for listing a group of targets.
+ */
+export default class TargetMenu extends foundry.applications.ux.FilterMenu {
+
+  /** @inheritDoc */
+  _onActivate(event) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    if ( this.element?.isConnected ) return this.close();
+    return super._onActivate(event);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _onRenderEntries(menu, options) {
+    await super._onRenderEntries(menu, options);
+    this.element.classList.add("dnd5e2");
+    this.menuItems.forEach(entry => {
+      const { element, onHoverIn, onHoverOut } = entry;
+      if ( onHoverIn ) element.addEventListener("pointerenter", onHoverIn);
+      if ( onHoverOut ) element.addEventListener("pointerleave", onHoverOut);
+    });
+  }
+}

--- a/module/applications/components/target-pill.mjs
+++ b/module/applications/components/target-pill.mjs
@@ -1,0 +1,226 @@
+import TargetMenu from "./target-menu.mjs";
+
+/**
+ * A custom element that represents a grouping of one or more potential targets.
+ */
+export default class TargetPillElement extends foundry.applications.elements.AbstractFormInputElement {
+
+  constructor() {
+    super();
+    this._internals.role = "checkbox";
+  }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The HTML tag name used by this element.
+   * @type {string}
+   */
+  static tagName = "target-pill";
+
+  /* -------------------------------------------- */
+
+  /**
+   * The checked state of the pill.
+   * @type {boolean}
+   */
+  get checked() {
+    return this.#determineState().checked;
+  }
+
+  set checked(checked) {
+    this.querySelectorAll("option").forEach(o => o.toggleAttribute("data-checked", checked));
+    this.#update();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The indeterminate state of the pill.
+   * @type {boolean}
+   */
+  get indeterminate() {
+    return this.#determineState().indeterminate;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The pill's indicator pip.
+   * @type {HTMLDivElement}
+   */
+  pip;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The currently highlighted token.
+   * @type {TokenDocument5e|null}
+   */
+  #highlighted = null;
+
+  /* -------------------------------------------- */
+
+  /**
+   * The bound TargetMenu instance.
+   * @type {TargetMenu}
+   */
+  #menu;
+
+  /* -------------------------------------------- */
+  /*  Methods                                     */
+  /* -------------------------------------------- */
+
+  /** @override */
+  connectedCallback() {
+    super.connectedCallback?.();
+    if ( !this.hasAttribute("tabindex") ) this.tabIndex = 0;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _buildElements() {
+    if ( this.pip ) return this.children;
+    this.classList.add("target", "pill");
+    this.pip = document.createElement("div");
+    this.pip.classList.add("pip");
+    this.append(this.pip);
+    return this.children;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _getValue() {
+    return Iterator.from(this.querySelectorAll("[data-checked]")).map(el => el.value).toArray();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _refresh() {
+    super._refresh();
+    const { checked, indeterminate } = this.#determineState();
+    this.toggleAttribute("checked", checked);
+    this.toggleAttribute("indeterminate", indeterminate);
+    this._internals.ariaChecked = indeterminate ? "mixed" : `${checked}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _toggleDisabled(disabled) {
+    this.tabIndex = disabled ? -1 : 0;
+    this._internals.ariaDisabled = `${disabled}`;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Determine the state of the pill from its members.
+   * @returns {{ checked: boolean, indeterminate: boolean }}
+   */
+  #determineState() {
+    let checked = true;
+    let indeterminate = false;
+    for ( const option of this.querySelectorAll("option") ) {
+      const optionChecked = "checked" in option.dataset;
+      if ( optionChecked ) indeterminate = true;
+      checked &&= optionChecked;
+    }
+    if ( checked ) indeterminate = false;
+    return { checked, indeterminate };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare individual target entries.
+   * @returns {ContextMenuEntry[]}
+   */
+  #getTargetContextOptions() {
+    const options = this.querySelectorAll("option");
+    if ( this.disabled || (options.length < 2) ) return [];
+    return Iterator.from(options).map(o => ({
+      classes: ["filter-item", "checked" in o.dataset ? "active" : ""].filterJoin(" "),
+      label: o.textContent,
+      onClick: event => this.#onEntryClick(event, o.value),
+      onHoverIn: event => this.#onEntryHoverIn(event, o.value),
+      onHoverOut: this.#onEntryHoverOut.bind(this)
+    })).toArray();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Update the element's internal value state.
+   */
+  #update() {
+    this.value = this._getValue();
+  }
+
+  /* -------------------------------------------- */
+  /*  Event Listeners & Handlers                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  _activateListeners() {
+    this.#menu ??= new TargetMenu(this, this.constructor.tagName, {
+      eventName: "contextmenu",
+      menuItems: this.#getTargetContextOptions.bind(this),
+      onClose: this.#onEntryHoverOut.bind(this)
+    });
+    this.addEventListener("keydown", event => {
+      if ( event.key === " " ) this._onClick(event);
+    }, { signal: this.abortSignal });
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  _onClick(event) {
+    if ( this.disabled ) return;
+    event.preventDefault();
+    this.checked = !this.checked;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle clicking an entry in the target menu.
+   * @param {PointerEvent} event  The triggering event.
+   * @param {string} uuid         The target UUID.
+   */
+  #onEntryClick(event, uuid) {
+    this.querySelector(`[value="${uuid}"]`)?.toggleAttribute("data-checked");
+    this.#update();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle hovering an entry in the target menu.
+   * @param {PointerEvent} event  The triggering event.
+   * @param {string} uuid         The target UUID.
+   */
+  #onEntryHoverIn(event, uuid) {
+    const token = fromUuidSync(uuid)?.object;
+    if ( token && token._canHover(game.user, event) && token.visible ) {
+      token._onHoverIn(event, { hoverOutOthers: true });
+      this.#highlighted = token;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle hovering out of a target menu entry.
+   */
+  #onEntryHoverOut() {
+    this.#highlighted?._onHoverOut();
+    this.#highlighted = null;
+  }
+}

--- a/module/applications/components/targeted-application-mixin.mjs
+++ b/module/applications/components/targeted-application-mixin.mjs
@@ -20,6 +20,16 @@ export default function TargetedApplicationMixin(Base) {
     /* -------------------------------------------- */
 
     /**
+     * Whether the associated chat message recorded any targets.
+     * @type {boolean}
+     */
+    get hasRecordedTargets() {
+      return !!this.chatMessage?.system?.targets?.length;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
      * Whether to rebuild the target list.
      * @type {boolean|void}
      */
@@ -34,16 +44,13 @@ export default function TargetedApplicationMixin(Base) {
      * @type {"targeted"|"selected"}
      */
     get targetingMode() {
-      if ( this.targetSourceControl.hidden ) return "selected";
-      return this.targetSourceControl.querySelector('[aria-pressed="true"]')?.dataset.mode ?? "targeted";
+      return this.#targetingMode;
     }
 
     set targetingMode(mode) {
-      if ( this.targetSourceControl.hidden ) mode = "selected";
-      const toPress = this.targetSourceControl.querySelector(`[data-mode="${mode}"]`);
-      const currentlyPressed = this.targetSourceControl.querySelector('[aria-pressed="true"]');
-      if ( currentlyPressed ) currentlyPressed.ariaPressed = false;
-      toPress.ariaPressed = true;
+      if ( !this.hasRecordedTargets ) mode = "selected";
+      this.#targetingMode = mode;
+      this._refreshTargetMode();
 
       this.buildTargetsList();
       if ( (mode === "targeted") && (this.selectedTokensHook !== null) ) {
@@ -71,6 +78,14 @@ export default function TargetedApplicationMixin(Base) {
     targetSourceControl;
 
     /* -------------------------------------------- */
+
+    /**
+     * The current targeting mode.
+     * @type {"targeted"|"selected"}
+     */
+    #targetingMode = "targeted";
+
+    /* -------------------------------------------- */
     /*  Life-Cycle                                  */
     /* -------------------------------------------- */
 
@@ -89,20 +104,7 @@ export default function TargetedApplicationMixin(Base) {
      * @returns {HTMLElement[]}
      */
     buildTargetContainer() {
-      this.targetSourceControl = document.createElement("div");
-      this.targetSourceControl.classList.add("target-source-control");
-      this.targetSourceControl.innerHTML = `
-        <button type="button" class="unbutton" data-mode="targeted" aria-pressed="false">
-          <i class="fa-solid fa-bullseye" inert></i> ${_loc("DND5E.Tokens.Targeted")}
-        </button>
-        <button type="button" class="unbutton" data-mode="selected" aria-pressed="false">
-          <i class="fa-solid fa-expand" inert></i> ${_loc("DND5E.Tokens.Selected")}
-        </button>
-      `;
-      this.targetSourceControl.querySelectorAll("button").forEach(b =>
-        b.addEventListener("click", this._onChangeTargetMode.bind(this))
-      );
-      if ( !this.chatMessage?.system?.targets?.length ) this.targetSourceControl.hidden = true;
+      this.targetSourceControl = this._buildTargetSourceControl();
 
       this.targetList = document.createElement("ul");
       this.targetList.classList.add("targets", "unlist");
@@ -122,12 +124,14 @@ export default function TargetedApplicationMixin(Base) {
         case "targeted":
           for ( const descriptor of this.chatMessage?.system?.targets ?? [] ) {
             const { actor, token } = TargetsField.resolve(descriptor);
-            if ( actor ) targetedTokens.set(actor.uuid, token?.name ?? descriptor.name);
+            if ( actor || token ) {
+              targetedTokens.set(token?.document.uuid ?? actor?.uuid, token?.name ?? descriptor.name);
+            }
           }
           break;
         case "selected":
           canvas.tokens?.controlled?.forEach(t => {
-            if ( t.actor ) targetedTokens.set(t.actor.uuid, t.name);
+            if ( t.actor ) targetedTokens.set(t.document.uuid, t.name);
           });
           break;
       }
@@ -137,8 +141,8 @@ export default function TargetedApplicationMixin(Base) {
       if ( targets.length ) this.targetList.replaceChildren(...targets);
       else {
         const li = document.createElement("li");
-        li.classList.add("none");
-        li.innerText = _loc(`DND5E.Tokens.None${this.targetingMode.capitalize()}`);
+        li.classList.add("none", "pill", "target", "transparent");
+        li.innerText = _loc("DND5E.Tokens.NoTargets");
         this.targetList.replaceChildren(li);
       }
     }
@@ -154,6 +158,43 @@ export default function TargetedApplicationMixin(Base) {
      * @abstract
      */
     buildTargetListEntry({ uuid, name }) {}
+
+    /* -------------------------------------------- */
+
+    /**
+     * Build the control used to switch between target sources.
+     * @returns {HTMLElement}
+     * @protected
+     */
+    _buildTargetSourceControl() {
+      const control = document.createElement("div");
+      control.classList.add("target-source-control");
+      control.innerHTML = `
+        <button type="button" class="unbutton" data-mode="targeted" aria-pressed="false">
+          <i class="fa-solid fa-bullseye" inert></i> ${_loc("DND5E.Tokens.Targeted")}
+        </button>
+        <button type="button" class="unbutton" data-mode="selected" aria-pressed="false">
+          <i class="fa-solid fa-expand" inert></i> ${_loc("DND5E.Tokens.Selected")}
+        </button>
+      `;
+      control.querySelectorAll("button").forEach(b =>
+        b.addEventListener("click", this._onChangeTargetMode.bind(this))
+      );
+      if ( !this.hasRecordedTargets ) control.hidden = true;
+      return control;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Update the target source control to reflect the current targeting mode.
+     * @protected
+     */
+    _refreshTargetMode() {
+      for ( const button of this.targetSourceControl.querySelectorAll("[data-mode]") ) {
+        button.ariaPressed = `${button.dataset.mode === this.targetingMode}`;
+      }
+    }
 
     /* -------------------------------------------- */
     /*  Event Handlers                              */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -243,6 +243,22 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /* -------------------------------------------- */
 
+  /**
+   * Icon & abbreviated label for effects that expire at the start or end of a turn. The icon indicates whose turn the
+   * effect expires on, and the label which end of that turn.
+   * @returns {{ icon: string, label: string }|null}  Null if this effect has no special duration.
+   */
+  getSpecialDurationParts() {
+    const expiry = this.specialDuration;
+    if ( !expiry ) return null;
+    return {
+      icon: expiry.startsWith("target") ? "fa-bullseye" : "fa-user",
+      label: _loc(`DND5E.ACTIVEEFFECT.Expiry.Abbreviation.${expiry.endsWith("Start") ? "Start" : "End"}`)
+    };
+  }
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   static async _fromStatusEffect(statusId, { reference, ...effectData }, options) {
     if ( !("description" in effectData) && reference ) effectData.description = `@Embed[${reference} inline]`;
@@ -1253,10 +1269,12 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     this.updateDuration();
     const { id, name, img, disabled, duration } = this;
     const source = await this.getSource();
+    const special = this.getSpecialDurationParts();
     return {
       id, name, img, disabled, duration, source,
       changes: await Promise.all(this.changes.map(change => this.getSheetChangeContext(change))),
-      durationParts: this.getDurationParts(),
+      durationIcon: special?.icon ?? "fa-clock",
+      durationParts: special ? [special.label] : this.getDurationParts(),
       showDuration: !this.expirySupportsDuration() || Number.isFinite(this.duration.value),
       effect: this
     };

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -65,7 +65,7 @@ export default class Combatant5e extends Combatant {
   getGroupingKey() {
     if ( this.group ) return this.group.id;
     if ( (this.initiative === null) || !dnd5e.settings.initiativeGroupCombatants ) return null;
-    return this.getUniqueKey(Math.floor(this.initiative).paddedString(4));
+    return this.token.getGroupingKey(Math.floor(this.initiative).paddedString(4));
   }
 
   /* -------------------------------------------- */
@@ -77,7 +77,7 @@ export default class Combatant5e extends Combatant {
   getInitiativeGroupingKey() {
     if ( this.group ) return this.group.id;
     if ( !dnd5e.settings.initiativeGroupRoll ) return null;
-    return this.getUniqueKey(this.getInitiativeRoll().formula);
+    return this.token.getGroupingKey(this.getInitiativeRoll().formula);
   }
 
   /* -------------------------------------------- */
@@ -86,18 +86,6 @@ export default class Combatant5e extends Combatant {
   getInitiativeRoll(formula) {
     if ( !this.actor ) return new CONFIG.Dice.D20Roll(formula ?? "1d20", {});
     return this.actor.getInitiativeRoll();
-  }
-
-  /* -------------------------------------------- */
-
-  /**
-   * Key identifying a unique set of actors in the combat, optionally prefixed by a grouping discriminator.
-   * @param {string} [prefix]  Discriminator placed at the head of the key.
-   * @returns {string|null}
-   */
-  getUniqueKey(prefix) {
-    if ( this.token?.actorLink || !this.token?.baseActor ) return null;
-    return `${prefix === undefined ? "" : `${prefix}:`}${this.token.disposition}:${this.token.baseActor.id}`;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -177,6 +177,18 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
 
   /* -------------------------------------------- */
 
+  /**
+   * A key that allows for similar tokens to be grouped together.
+   * @param {string} [prefix]  Discriminator placed at the head of the key.
+   * @returns {string|null}
+   */
+  getGroupingKey(prefix) {
+    if ( this.actorLink || !this.baseActor ) return null;
+    return `${prefix === undefined ? "" : `${prefix}:`}${this.disposition}:${this.baseActor.id}`;
+  }
+
+  /* -------------------------------------------- */
+
   /** @override */
   prepareData() {
     super.prepareData();

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -814,23 +814,24 @@ export function convertLength(value, from, to, { strict=true }={}) {
 /**
  * Convert the provided time value to another unit. If no final unit is provided, then will convert it to the largest
  * unit that can still represent the value as a whole number.
- * @param {number} value                    The time being converted.
- * @param {string} from                     The initial unit as defined in `CONFIG.DND5E.timeUnits`.
+ * @param {number} value                      The time being converted.
+ * @param {string} from                       The initial unit as defined in `CONFIG.DND5E.timeUnits`.
  * @param {object} [options={}]
- * @param {boolean} [options.combat=false]  Use combat units when auto-selecting units, rather than normal units.
- * @param {boolean} [options.strict=true]   Throw an error if from unit isn't found.
- * @param {string} [options.to]             The final units, if explicitly provided.
+ * @param {boolean} [options.combat=false]    Use combat units when auto-selecting units, rather than normal units.
+ * @param {boolean} [options.strict=true]     Throw an error if from unit isn't found.
+ * @param {string} [options.to]               The final units, if explicitly provided.
+ * @param {boolean} [options.truncate=false]  Select the largest unit that can represent the value, discarding any
+ *                                            remainder, rather than the largest that represents it exactly.
  * @returns {{ value: number, unit: string }}
  */
-export function convertTime(value, from, { combat=false, strict=true, to }={}) {
+export function convertTime(value, from, { combat=false, strict=true, to, truncate=false }={}) {
   const base = value * (CONFIG.DND5E.timeUnits[from]?.conversion ?? 1);
   if ( !to ) {
     // Find unit with largest conversion value that can still display the value
     const unitOptions = Object.entries(CONFIG.DND5E.timeUnits)
       .reduce((arr, [key, v]) => {
-        if ( ((v.combat ?? false) === combat) && ((base % v.conversion === 0) || (base >= v.conversion * 2)) ) {
-          arr.push({ key, conversion: v.conversion });
-        }
+        const fits = truncate ? base >= v.conversion : (base % v.conversion === 0) || (base >= v.conversion * 2);
+        if ( ((v.combat ?? false) === combat) && fits ) arr.push({ key, conversion: v.conversion });
         return arr;
       }, [])
       .sort((lhs, rhs) => rhs.conversion - lhs.conversion);
@@ -838,7 +839,8 @@ export function convertTime(value, from, { combat=false, strict=true, to }={}) {
   }
 
   const message = unit => `Time unit ${unit} not defined in CONFIG.DND5E.timeUnits`;
-  return { value: _convertSystemUnits(value, from, to, CONFIG.DND5E.timeUnits, { message, strict }), unit: to };
+  const converted = _convertSystemUnits(value, from, to, CONFIG.DND5E.timeUnits, { message, strict });
+  return { unit: to, value: truncate ? Math.floor(converted) : converted };
 }
 
 /* -------------------------------------------- */

--- a/templates/chat/parts/card-face.hbs
+++ b/templates/chat/parts/card-face.hbs
@@ -60,7 +60,7 @@
     {{!-- Buttons --}}
     {{#if buttonGroups}}
     <section class="icon-row">
-        <i class="fa-solid fa-fw fa-bolt" aria-label="{{ localize "DND5E.CHATMESSAGE.Row.Actions" }}"></i>
+        <i class="fa-solid fa-fw fa-circle-play" aria-label="{{ localize "DND5E.CHATMESSAGE.Row.Actions" }}"></i>
         <ul class="unlist">
             {{#each buttonGroups}}
             {{#each entries}}

--- a/templates/chat/usage-card.hbs
+++ b/templates/chat/usage-card.hbs
@@ -3,3 +3,11 @@
 {{else}}
 {{> "dnd5e.card-face" }}
 {{/if}}
+
+{{#if effects.length}}
+<effect-application class="dnd5e2">
+    {{#each effects}}
+    <option value="{{ uuid }}"></option>
+    {{/each}}
+</effect-application>
+{{/if}}

--- a/templates/shared/active-effects.hbs
+++ b/templates/shared/active-effects.hbs
@@ -111,8 +111,8 @@
         <span class="title">{{ name }}</span>
     </div>
     {{#if showDuration}}
-    <div class="duration">
-        <i class="fa-solid fa-clock" inert></i>
+    <div class="duration pill transparent">
+        <i class="fa-solid {{ durationIcon }}" inert></i>
         <span class="most-significant">{{ durationParts.[0] }}</span>
         {{#if durationParts.[1]}}
         <span class="separator">&vert;</span>


### PR DESCRIPTION
Slightly awkward in-between state. I think the damage tray is probably not functional here, but I will hopefully get to that soon-ish.

There are some functionality changes here in addition to style changes:
- Addition of the `TargetPillElement` which encapsulates logic around grouping multiple targets and offering a context menu for individually toggling members within that group.
- Multiple effects can be applied at once now, rather than having to be applied one-at-a-time.

I also added the icon + label compact style for the various special expiry labels to the actor/item sheets where it was currently taking up a little too much space. The AE tooltips retain the full text though.

<img width="400" height="712" alt="image" src="https://github.com/user-attachments/assets/1b4ea5e1-6355-44ea-8706-109b54f8f7cd" />
