### PR TITLE
Add tooltips to activities

### DIFF
--- a/less/v2/tooltips.less
+++ b/less/v2/tooltips.less
@@ -56,7 +56,7 @@
   /*  Item Tooltips                     */
   /* ---------------------------------- */
 
-  &:is(.activity-tooltip, .effect-tooltip, .item-tooltip) {
+  &.document-tooltip {
     width: 300px;
 
     .loading {
@@ -84,11 +84,6 @@
         .subtitle { font-size: var(--font-size-11); }
       }
 
-      dnd5e-icon {
-        --icon-fill: var(--activity-icon-color);
-        --icon-size: var(--header-image-size);
-      }
-
       img {
         width: var(--header-image-size);
         height: var(--header-image-size);
@@ -103,6 +98,11 @@
         display: flex;
         gap: 8px;
         --header-image-size: 48px;
+
+        dnd5e-icon {
+          --icon-fill: var(--activity-icon-color);
+          --icon-size: var(--header-image-size);
+        }
       }
 
       .bottom {

--- a/less/v2/tooltips.less
+++ b/less/v2/tooltips.less
@@ -56,7 +56,7 @@
   /*  Item Tooltips                     */
   /* ---------------------------------- */
 
-  &:is(.item-tooltip, .effect-tooltip) {
+  &:is(.activity-tooltip, .effect-tooltip, .item-tooltip) {
     width: 300px;
 
     .loading {
@@ -71,6 +71,7 @@
       display: flex;
       flex-direction: column;
       gap: .5rem;
+      --header-image-size: 64px;
       padding-top: .75rem;
 
       .top {
@@ -83,14 +84,25 @@
         .subtitle { font-size: var(--font-size-11); }
       }
 
+      dnd5e-icon {
+        --icon-fill: var(--activity-icon-color);
+        --icon-size: var(--header-image-size);
+      }
+
       img {
-        width: 64px;
-        height: 64px;
+        width: var(--header-image-size);
+        height: var(--header-image-size);
         border: 2px solid var(--dnd5e-color-gold);
         box-shadow: 0 0 4px var(--dnd5e-shadow-45);
         border-radius: 8px;
         object-fit: cover;
         background: var(--dnd5e-background-alt-1);
+      }
+
+      .images {
+        display: flex;
+        gap: 8px;
+        --header-image-size: 48px;
       }
 
       .bottom {

--- a/module/applications/actor/api/base-actor-sheet.mjs
+++ b/module/applications/actor/api/base-actor-sheet.mjs
@@ -796,7 +796,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
    * @protected
    */
   _prepareActivity(activity) {
-    let { _id, activation, img, labels, name, range, save, uses } = activity.prepareSheetContext();
+    let { _id, activation, img, labels, name, range, save, uses, uuid } = activity.prepareSheetContext();
 
     // Activation
     const activationAbbr = {
@@ -819,7 +819,7 @@ export default class BaseActorSheet extends PrimarySheetMixin(
     uses.prop = "uses.value";
 
     return {
-      _id, img, labels, name, range, uses,
+      _id, img, labels, name, range, uses, uuid,
       activation: activationAbbr
         ? `${activation.value ?? ""}${_loc(activationAbbr)}`
         : labels.activation,

--- a/module/applications/api/primary-sheet-mixin.mjs
+++ b/module/applications/api/primary-sheet-mixin.mjs
@@ -306,7 +306,7 @@ export default function PrimarySheetMixin(Base) {
       }
       if ( !uuid ) return;
       element.dataset.tooltipHtml = loadingTooltip({ uuid });
-      element.dataset.tooltipClass = "dnd5e2 dnd5e-tooltip item-tooltip";
+      element.dataset.tooltipClass = "dnd5e2 dnd5e-tooltip item-tooltip document-tooltip";
       element.dataset.tooltipDirection ??= "LEFT";
     }
 

--- a/module/applications/compendium-browser.mjs
+++ b/module/applications/compendium-browser.mjs
@@ -697,7 +697,7 @@ export default class CompendiumBrowser extends Application5e {
     const element = foundry.utils.parseHTML(html);
     if ( documentClass !== "Item" ) return element;
     element.dataset.tooltipHtml = loadingTooltip({ uuid });
-    element.dataset.tooltipClass = "dnd5e2 dnd5e-tooltip item-tooltip";
+    element.dataset.tooltipClass = "dnd5e2 dnd5e-tooltip item-tooltip document-tooltip";
     element.dataset.tooltipDirection ??= "RIGHT";
     if ( context.prerequisites ) element.dataset.tooltipExtras = game.i18n.getListFormatter({ type: "unit" }).format(
       context.prerequisites.results.values().map(r =>

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -125,7 +125,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       Object.assign(li.dataset, {
         id: effect.id,
         tooltipHtml: loadingTooltip({ uuid: effect.uuid }),
-        tooltipClass: "dnd5e2 dnd5e-tooltip item-tooltip",
+        tooltipClass: "dnd5e2 dnd5e-tooltip effect-tooltip document-tooltip",
         tooltipDirection: "LEFT",
         uuid: effect.uuid
       });

--- a/module/data/abstract/chat-message-data-model.mjs
+++ b/module/data/abstract/chat-message-data-model.mjs
@@ -103,7 +103,7 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
       if ( !uuid ) continue;
       Object.assign(e.dataset, {
         tooltipHtml: loadingTooltip({ uuid }),
-        tooltipClass: "dnd5e2 dnd5e-tooltip item-tooltip",
+        tooltipClass: "dnd5e2 dnd5e-tooltip item-tooltip document-tooltip",
         tooltipDirection: "LEFT"
       });
     }

--- a/module/data/abstract/item-data-model.mjs
+++ b/module/data/abstract/item-data-model.mjs
@@ -181,7 +181,7 @@ export default class ItemDataModel extends SystemDataModel {
       content: await foundry.applications.handlebars.renderTemplate(
         this.constructor.ITEM_TOOLTIP_TEMPLATE, await this.getTooltipData(enrichmentOptions)
       ),
-      classes: ["dnd5e2", "dnd5e-tooltip", "item-tooltip"]
+      classes: ["dnd5e2", "dnd5e-tooltip", "item-tooltip", "document-tooltip"]
     };
   }
 

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -6,6 +6,7 @@ import FormulaField from "../fields/formula-field.mjs";
 import IdentifierField from "../fields/identifier-field.mjs";
 import ActivationField from "../shared/activation-field.mjs";
 import DurationField from "../shared/duration-field.mjs";
+import PropertyField from "../shared/property-field.mjs";
 import RangeField from "../shared/range-field.mjs";
 import TargetField from "../shared/target-field.mjs";
 import UsesField from "../shared/uses-field.mjs";
@@ -13,6 +14,7 @@ import AppliedBehaviorField from "./fields/applied-behavior-field.mjs";
 import AppliedEffectField from "./fields/applied-effect-field.mjs";
 import ConsumptionTargetsField from "./fields/consumption-targets-field.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
 const {
   ArrayField, BooleanField, DocumentFlagsField, DocumentIdField, FilePathField,
   HTMLField, IntegerSortField, NumberField, SchemaField, StringField
@@ -609,6 +611,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       this._setOverride("range");
       if ( this.range.long > this.range.value ) this.range.value = this.range.long;
       else if ( this.range.reach && !this.range.value ) this.range.value = this.range.reach;
+      if ( this.type !== "attack" ) delete this.range.reach;
     }
     if ( this.target ) this._setOverride("target");
 
@@ -718,7 +721,8 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
         isOnCooldown: hasRecharge && (this.uses.value < 1),
         prop: "uses.value",
         pct: this.uses.max ? Math.clamp((this.uses.value / this.uses.max) * 100, 0, 100) : 0
-      } : null
+      } : null,
+      uuid: this.uuid
     };
   }
 
@@ -758,9 +762,44 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
   async getCardData() {
     const { description, id, img, name, type, uuid } = this;
     return {
+      activity: { id, img, name, type, uuid, chatFlavor: description.chatFlavor },
       description: description.value,
-      activity: { id, img, name, type, uuid, chatFlavor: description.chatFlavor }
+      properties: [
+        ...PropertyField.getUsageProperties(this.getUsageData())
+      ],
+      subtitle: []
     };
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare activity tooltip template data.
+   * @param {EnrichmentOptions} [options={}]  Options for text enrichment.
+   * @param {string} [options.extras]         Extra HTML displayed with the tooltip.
+   * @returns {Promise<object>}
+   */
+  async getTooltipData({ extras, ...enrichmentOptions }={}) {
+    enrichmentOptions.rollData ??= this.getRollData();
+    enrichmentOptions.relativeTo ??= this.item;
+    const context = await this.getCardData();
+
+    let { name, type, img, uses } = this;
+    uses = this._source.uses.max || this.uses.max ? uses : null;
+
+    Object.assign(context, {
+      name, type, img, uses, extras,
+      config: CONFIG.DND5E,
+      controlHints: game.settings.get("dnd5e", "controlHints"),
+      description: await TextEditor.enrichHTML(context.description || "", enrichmentOptions),
+      item: {
+        name: this.item.name, img: this.item.img
+      },
+      labels: foundry.utils.deepClone(this.labels),
+      properties: PropertyField.getLabels(context.properties, this),
+      subtitle: context.subtitle.filterJoin(" • ")
+    });
+    return context;
   }
 
   /* -------------------------------------------- */
@@ -939,8 +978,9 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
       configurable: true,
       enumerable: false
     });
-    if ( obj.canOverride && !obj.override && !this.isRider ) {
+    if ( obj.canOverride && !obj.override && !obj.overrideSet && !this.isRider ) {
       foundry.utils.mergeObject(obj, foundry.utils.getProperty(item.system, keyPath));
+      obj.overrideSet = true;
     }
   }
 }

--- a/module/data/activity/base-activity.mjs
+++ b/module/data/activity/base-activity.mjs
@@ -980,7 +980,7 @@ export default class BaseActivityData extends foundry.abstract.DataModel {
     });
     if ( obj.canOverride && !obj.override && !obj.overrideSet && !this.isRider ) {
       foundry.utils.mergeObject(obj, foundry.utils.getProperty(item.system, keyPath));
-      obj.overrideSet = true;
+      Object.defineProperty(obj, "overrideSet", { value: true, configurable: true, enumerable: false });
     }
   }
 }

--- a/module/data/activity/cast-data.mjs
+++ b/module/data/activity/cast-data.mjs
@@ -1,6 +1,7 @@
 import BaseActivityData from "./base-activity.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
 const { BooleanField, DocumentUUIDField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
@@ -83,6 +84,25 @@ export default class BaseCastActivityData extends BaseActivityData {
       context.labels = foundry.utils.mergeObject(context.labels, spellLabels, { inplace: false });
       context.save = { ...cachedSpell.system.activities?.getByType("save")[0]?.save };
     }
+    return context;
+  }
+
+  /* -------------------------------------------- */
+  /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async getTooltipData({ extras, ...enrichmentOptions }={}) {
+    const context = await super.getTooltipData({ extras, ...enrichmentOptions });
+
+    if ( !context.description ) {
+      const cachedSpell = this.cachedSpell;
+      context.description = await TextEditor.enrichHTML(
+        cachedSpell?.system.description.value || "",
+        { ...enrichmentOptions, relativeTo: cachedSpell }
+      );
+    }
+
     return context;
   }
 }

--- a/module/data/activity/cast-data.mjs
+++ b/module/data/activity/cast-data.mjs
@@ -95,12 +95,11 @@ export default class BaseCastActivityData extends BaseActivityData {
   async getTooltipData({ extras, ...enrichmentOptions }={}) {
     const context = await super.getTooltipData({ extras, ...enrichmentOptions });
 
-    if ( !context.description ) {
-      const cachedSpell = this.cachedSpell;
-      context.description = await TextEditor.enrichHTML(
-        cachedSpell?.system.description.value || "",
-        { ...enrichmentOptions, relativeTo: cachedSpell }
-      );
+    const cachedSpell = this.cachedSpell;
+    if ( !context.description && cachedSpell?.system.description.value ) {
+      context.description = await TextEditor.enrichHTML(cachedSpell.system.description.value, {
+        ...enrichmentOptions, relativeTo: cachedSpell, rollData: cachedSpell.getRollData()
+      });
     }
 
     return context;

--- a/module/data/shared/_module.mjs
+++ b/module/data/shared/_module.mjs
@@ -6,6 +6,7 @@ export {default as DamageField, DamageData} from "./damage-field.mjs";
 export {default as DamageRollModificationField} from "./damage-roll-modification-field.mjs";
 export {default as DurationField} from "./duration-field.mjs";
 export {default as MovementField} from "./movement-field.mjs";
+export {default as PropertyField} from "./property-field.mjs";
 export {default as RangeField} from "./range-field.mjs";
 export {default as RollConfigField} from "./roll-config-field.mjs";
 export {default as SensesField} from "./senses-field.mjs";

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -1296,7 +1296,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       content: await foundry.applications.handlebars.renderTemplate(
         "systems/dnd5e/templates/effects/parts/effect-tooltip.hbs", context
       ),
-      classes: ["dnd5e2", "dnd5e-tooltip", "effect-tooltip"]
+      classes: ["dnd5e2", "dnd5e-tooltip", "effect-tooltip", "document-tooltip"]
     };
   }
 

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -52,6 +52,14 @@ export default function ActivityMixin(Base) {
     /* -------------------------------------------- */
 
     /**
+     * The handlebars template for rendering activity tooltips.
+     * @type {string}
+     */
+    static ACTIVITY_TOOLTIP_TEMPLATE = "systems/dnd5e/templates/activity/parts/activity-tooltip.hbs";
+
+    /* -------------------------------------------- */
+
+    /**
      * Perform the pre-localization of this data model.
      */
     static localize() {
@@ -1139,6 +1147,19 @@ export default function ActivityMixin(Base) {
     /*  Helpers                                     */
     /* -------------------------------------------- */
 
+    /** @override */
+    async _buildEmbedHTML(config, options={}) {
+      if ( !this.description?.value ) return null;
+      const enriched = await foundry.applications.ux.TextEditor.implementation.enrichHTML(this.description.value, {
+        ...options, rollData: this.getRollData(), relativeTo: this.item
+      });
+      const container = document.createElement("div");
+      container.innerHTML = enriched;
+      return container.children;
+    }
+
+    /* -------------------------------------------- */
+
     /**
      * Retrieve consumed flag for given update data.
      * @param {Actor5e} actor
@@ -1172,21 +1193,6 @@ export default function ActivityMixin(Base) {
         range: this.range,
         uses: { ...this.uses, name: "uses.value" }
       };
-    }
-
-    /* -------------------------------------------- */
-    /*  Helpers                                     */
-    /* -------------------------------------------- */
-
-    /** @override */
-    async _buildEmbedHTML(config, options={}) {
-      if ( !this.description?.value ) return null;
-      const enriched = await foundry.applications.ux.TextEditor.implementation.enrichHTML(this.description.value, {
-        ...options, rollData: this.getRollData(), relativeTo: this.item
-      });
-      const container = document.createElement("div");
-      container.innerHTML = enriched;
-      return container.children;
     }
 
     /* -------------------------------------------- */
@@ -1227,6 +1233,23 @@ export default function ActivityMixin(Base) {
       const activityUpdates = foundry.utils.expandObject(updates.activity);
       if ( itemIndex === -1 ) updates.item.push({ _id: this.item.id, [keyPath]: activityUpdates });
       else updates.item[itemIndex][keyPath] = activityUpdates;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Render a rich tooltip for this activity.
+     * @param {EnrichmentOptions} [enrichmentOptions={}]  Options for text enrichment.
+     * @param {string} [enrichmentOptions.extras]         Extra HTML displayed with the tooltip.
+     * @returns {Promise<{content: string, classes: string[]}>|null}
+     */
+    async richTooltip(enrichmentOptions={}) {
+      return {
+        content: await foundry.applications.handlebars.renderTemplate(
+          this.constructor.ACTIVITY_TOOLTIP_TEMPLATE, await this.getTooltipData(enrichmentOptions)
+        ),
+        classes: ["dnd5e2", "dnd5e-tooltip", "activity-tooltip"]
+      };
     }
 
     /* -------------------------------------------- */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1248,7 +1248,7 @@ export default function ActivityMixin(Base) {
         content: await foundry.applications.handlebars.renderTemplate(
           this.constructor.ACTIVITY_TOOLTIP_TEMPLATE, await this.getTooltipData(enrichmentOptions)
         ),
-        classes: ["dnd5e2", "dnd5e-tooltip", "activity-tooltip"]
+        classes: ["dnd5e2", "dnd5e-tooltip", "activity-tooltip", "document-tooltip"]
       };
     }
 

--- a/module/enrichers.mjs
+++ b/module/enrichers.mjs
@@ -1423,7 +1423,7 @@ export async function enrichItem(config, label, options) {
     _addDataset(span, dataset);
     if ( uuid ) {
       span.dataset.tooltipHtml = loadingTooltip({ uuid });
-      span.dataset.tooltipClass = "dnd5e2 dnd5e-tooltip item-tooltip";
+      span.dataset.tooltipClass = "dnd5e2 dnd5e-tooltip item-tooltip document-tooltip";
       span.dataset.tooltipDirection = "LEFT";
     }
     span.append(createRollLink(label));

--- a/module/tooltips.mjs
+++ b/module/tooltips.mjs
@@ -266,7 +266,7 @@ export default class Tooltips5e {
     game.tooltip._setAnchor(direction);
 
     // Set overflowing styles for item tooltips.
-    if ( this.tooltip.classList.contains("item-tooltip") ) {
+    if ( this.tooltip.classList.contains("document-tooltip") ) {
       const description = this.tooltip.querySelector(".description");
       description?.classList.toggle("overflowing", description.clientHeight < description.scrollHeight);
     }

--- a/templates/activity/parts/activity-tooltip.hbs
+++ b/templates/activity/parts/activity-tooltip.hbs
@@ -1,0 +1,39 @@
+<section class="content">
+    <section class="header">
+        <div class="top">
+            <div class="images">
+                <img src="{{ item.img }}" alt="{{ item.name }}">
+                {{ dnd5e-icon img alt=name }}
+            </div>
+            <div class="name name-stacked">
+                <span class="title">{{ name }}</span>
+                <span class="subtitle">{{{ subtitle }}}</span>
+            </div>
+        </div>
+        <div class="bottom">
+            <div class="charges">
+                {{#if uses.max}}
+                <span class="value">{{ uses.value }}</span>
+                <span class="separator">&sol;</span>
+                <span class="max">{{ uses.max }}</span>
+                <span>{{ localize "DND5E.Charges" }}</span>
+                {{/if}}
+            </div>
+        </div>
+    </section>
+    {{#if extras}}<p class="extras">{{{ extras }}}</p>{{/if}}
+    <section class="description">{{{ description }}}</section>
+    <ul class="pills">
+        {{#each properties}}
+        <li class="pill transparent">
+            <span class="label">{{ this }}</span>
+        </li>
+        {{/each}}
+    </ul>
+    {{#if controlHints}}
+    <div class="control-hint lock-hint">
+        <img src="systems/dnd5e/icons/svg/mouse-middle.svg" alt="{{ localize "DND5E.Controls.MiddleClick" }}">
+        <span>{{ localize "DND5E.Controls.LockHint" }}</span>
+    </div>
+    {{/if}}
+</section>

--- a/templates/inventory/activity.hbs
+++ b/templates/inventory/activity.hbs
@@ -1,8 +1,8 @@
-<li class="activity-row draggable item-row" data-activity-id="{{ _id }}">
+<li class="activity-row draggable item-row" data-activity-id="{{ _id }}" data-uuid="{{ uuid }}">
 
     {{!-- Name --}}
-    <div class="activity-name item-name item-action {{ @root.rollableClass }}" role="button" aria-label="{{ name }}"
-         data-action="activity-use">
+    <div class="activity-name item-name item-action item-tooltip {{ @root.rollableClass }}" role="button"
+         aria-label="{{ name }}" data-action="activity-use">
 
         {{ dnd5e-icon img alt=name classes="activity-image item-image gold-icon" }}
 

--- a/templates/shared/activities.hbs
+++ b/templates/shared/activities.hbs
@@ -57,7 +57,7 @@
 {{#*inline ".activity"}}
 
 {{!-- Name & Icon --}}
-<div class="item-name activity-name">
+<div class="item-name item-tooltip activity-name">
 
     {{ dnd5e-icon img alt=name classes="item-image gold-icon" }}
 


### PR DESCRIPTION
Adds tooltips to activities similar to items and effects. These will display the item icon alongside the activity icon, uses, description, and usage properties.

For cast activites, if no activity description is provided then it will display the spell's description. This also fixes some bugs where cast activites weren't properly getting the activation, duration, range, and target from the spell.