### PR TITLE
Enable recursive roll formula replacement

### DIFF
--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -52,10 +52,7 @@ export default class BasicRoll extends Roll {
     for ( const [key, value] of Object.entries(parts) ) {
       if ( !value && (value !== 0) ) continue;
       finalParts.push(`@${key}`);
-      foundry.utils.setProperty(
-        data, key, foundry.utils.getType(value) === "string"
-          ? BasicRoll.replaceFormulaData(value, data, { missing: 0 }) : value
-      );
+      foundry.utils.setProperty(data, key, value);
     }
     return { parts: finalParts, data };
   }
@@ -331,10 +328,7 @@ export default class BasicRoll extends Roll {
   /** @inheritDoc */
   static replaceFormulaData(formula, data, options={}, _r=0) {
     options.recursive ??= true;
-    // This looks for the pattern `$!!$` and replaces it with just the value between the marks (the bang has
-    // been added to ensure this is a deliberate shim from the system, not a unintentional usage that should
-    // show an error).
-    return super.replaceFormulaData(formula, data, options, _r).replaceAll(/\$"?!(.+?)!"?\$/g, "$1");
+    return super.replaceFormulaData(formula, data, options, _r);
   }
 
   /* -------------------------------------------- */

--- a/module/dice/basic-roll.mjs
+++ b/module/dice/basic-roll.mjs
@@ -329,11 +329,12 @@ export default class BasicRoll extends Roll {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  static replaceFormulaData(formula, data, options) {
+  static replaceFormulaData(formula, data, options={}, _r=0) {
+    options.recursive ??= true;
     // This looks for the pattern `$!!$` and replaces it with just the value between the marks (the bang has
     // been added to ensure this is a deliberate shim from the system, not a unintentional usage that should
     // show an error).
-    return super.replaceFormulaData(formula, data, options).replaceAll(/\$"?!(.+?)!"?\$/g, "$1");
+    return super.replaceFormulaData(formula, data, options, _r).replaceAll(/\$"?!(.+?)!"?\$/g, "$1");
   }
 
   /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -533,7 +533,6 @@ export function replaceFormulaData(formula, data, options={}) {
         return value;
       }
       case "boolean": return String(Number(value));
-      case "number": return String(value);
       default: return String(value).trim();
     }
   });

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -497,6 +497,9 @@ export function prepareFormulaValue(model, keyPath, label, rollData) {
 
 /* -------------------------------------------- */
 
+const DEPTH = Symbol("depth");
+const MISSING = Symbol("missingReferences");
+
 /**
  * Replace referenced data attributes in the roll formula with values from the provided data.
  * If the attribute is not found in the provided data, display a warning on the actor.
@@ -507,21 +510,35 @@ export function prepareFormulaValue(model, keyPath, label, rollData) {
  * @param {Item5e} [options.item]              Item for which the value is being prepared.
  * @param {string|null} [options.missing="0"]  Value to use when replacing missing references, or `null` to not replace.
  * @param {string} [options.property]          Name of the property to which this formula belongs.
+ * @param {boolean} [options.recursive=true]   Recursively replace data references.
  * @returns {string}                 Formula with replaced data.
  */
-export function replaceFormulaData(formula, data, { actor, item, missing="0", property }={}) {
+export function replaceFormulaData(formula, data, options={}) {
+  let {
+    actor, item, missing="0", property, recursive=true, [DEPTH]: depth=0, [MISSING]: missingReferences=new Set()
+  } = options;
   const dataRgx = new RegExp(/@([a-z.0-9_-]+)/gi);
-  const missingReferences = new Set();
   formula = String(formula).replace(dataRgx, (match, term) => {
     let value = foundry.utils.getProperty(data, term);
     if ( value == null ) {
       missingReferences.add(match);
       return missing ?? match[0];
     }
-    return String(value).trim();
+    switch ( foundry.utils.getType(value) ) {
+      case "string": {
+        value = value.trim();
+        if ( recursive && (depth < 3) && value.includes("@") ) {
+          return replaceFormulaData(value, data, { ...options, [DEPTH]: depth + 1, [MISSING]: missingReferences });
+        }
+        return value;
+      }
+      case "boolean": return String(Number(value));
+      case "number": return String(value);
+      default: return String(value).trim();
+    }
   });
   actor ??= item?.parent;
-  if ( (missingReferences.size > 0) && actor && property ) {
+  if ( (depth < 1) && (missingReferences.size > 0) && actor && property ) {
     const listFormatter = new Intl.ListFormat(game.i18n.lang, { style: "long", type: "conjunction" });
     const message = _loc("DND5E.FormulaMissingReferenceWarn", {
       property, name: item?.name ?? actor.name, references: listFormatter.format(missingReferences)
@@ -538,7 +555,7 @@ export function replaceFormulaData(formula, data, { actor, item, missing="0", pr
  * @param {number|string|null} bonus  Bonus formula.
  * @param {object} [data={}]          Data to use for replacing @ strings.
  * @param {object} [options={}]
- * @param {boolean} [option.strict]   Throw error if evaluation fails.
+ * @param {boolean} [options.strict]  Throw error if evaluation fails.
  * @returns {number}                  Simplified bonus as an integer.
  * @protected
  */


### PR DESCRIPTION
Sets `options.recursive` to `true` by default when replacing formula data on `BasicRoll`.

Also rewrites `dnd5e.utils.replaceFormulaData` to also accept the recursive option which defaults to `true`.