### PR TITLE
[#6626, #6660] Fix Select Form transform mode, add profile origin

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -5919,7 +5919,6 @@
   "TemporaryClass": "Temporary Class",
   "Title": "Transform",
   "Warning": {
-    "FormActive": "{form} already active on {actor}.",
     "NoOwnership": "You do not have permission to transform this actor.",
     "NoPermission": "Transformation permission haven't been granted to players.",
     "OriginalActor": "No original actor was found with ID '{reference}'.",

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -331,8 +331,9 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
       system: {
         origin: {
           [activity ? "activity" : "item"]: activity ? activity.uuid : item?.uuid,
-          effect: concentration?.uuid
-          // TODO: Should set the profile here, but currently that data isn't fully available in the message data
+          effect: concentration?.uuid,
+          profile: activity
+            ? activity.effects?.find(e => (e.uuid === effect.uuid) || (e._id === effect.id))?._id : undefined
         }
       }
     };

--- a/module/applications/components/effect-application.mjs
+++ b/module/applications/components/effect-application.mjs
@@ -332,6 +332,7 @@ export default class EffectApplicationElement extends TargetedApplicationMixin(C
         origin: {
           [activity ? "activity" : "item"]: activity ? activity.uuid : item?.uuid,
           effect: concentration?.uuid
+          // TODO: Should set the profile here, but currently that data isn't fully available in the message data
         }
       }
     };

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -21,7 +21,8 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
         actor: new DocumentUUIDField({ relative: true, required: false, type: "Actor" }),
         behavior: new DocumentUUIDField({ required: false, type: "RegionBehavior" }),
         effect: new DocumentUUIDField({ relative: true, required: false, type: "ActiveEffect" }),
-        item: new DocumentUUIDField({ relative: true, required: false, type: "Item" })
+        item: new DocumentUUIDField({ relative: true, required: false, type: "Item" }),
+        profile: new DocumentIdField({ required: false })
       })
     };
     schema.changes.element.extendFields({

--- a/module/data/activity/transform-data.mjs
+++ b/module/data/activity/transform-data.mjs
@@ -66,10 +66,8 @@ export default class BaseTransformActivityData extends BaseActivityData {
    */
   get currentProfile() {
     if ( this.transform.mode !== "form" ) return null;
-    const active = this.effects.find(e => {
-      const effect = e.getEffect();
-      return !effect?.disabled && effect?.transfer;
-    })?._id;
+    const relativeUuid = foundry.utils.buildRelativeUuid(this.uuid, this.actor.uuid);
+    const active = this.actor.effects.find(e => e.system.origin?.activity === relativeUuid)?.system.origin.profile;
     return active ?? (this.transform.formless ? "" : null);
   }
 

--- a/module/documents/activity/enchant.mjs
+++ b/module/documents/activity/enchant.mjs
@@ -170,7 +170,8 @@ export default class EnchantActivity extends ActivityMixin(BaseEnchantActivityDa
       system: {
         origin: {
           activity: this.uuid,
-          effect: concentration?.uuid
+          effect: concentration?.uuid,
+          profile: profileId
         }
       }
     }).toObject();

--- a/module/documents/activity/transform.mjs
+++ b/module/documents/activity/transform.mjs
@@ -157,7 +157,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
         (e.system.type === "concentrating") && (e.flags.dnd5e?.activity?.id === this.id)
       )?.uuid,
       scaling: config.scaling ? config.scaling : undefined,
-      spellLevel: this.item.level
+      spellLevel: this.item.system.level
     });
   }
 
@@ -217,15 +217,18 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
     const profile = this.applicableEffects.find(e => e._id === profileId);
     if ( !profile && !this.transform.formless ) return;
 
-    let targets = getSceneTargets(this.actor, { checkBaseActor: true }).map(t => t.actor);
-    if ( !targets.length ) targets.push(this.actor);
+    const targets = new Set(getSceneTargets(this.actor, { checkBaseActor: true }).map(t => t.actor));
+    if ( !targets.size ) targets.add(this.actor);
     const operations = [];
     for ( const target of targets ) {
       const item = target.items.get(this.item.id);
       if ( !item ) continue;
       const ids = [];
+      const activityUuid = foundry.utils.buildRelativeUuid(this.uuid, target.uuid);
       for ( const profile of this.effects ) {
-        const appliedEffect = target.effects.find(e => e.system.origin?.profile === profile._id);
+        const appliedEffect = target.effects.find(e =>
+          (e.system.origin?.profile === profile._id) && (e.system.origin?.activity === activityUuid)
+        );
         const sourceEffect = item.effects.get(profile._id);
         if ( (profile._id === profileId) && sourceEffect ) {
           const effectFlags = {
@@ -234,7 +237,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
             },
             system: {
               origin: {
-                activity: foundry.utils.buildRelativeUuid(this.uuid, target.uuid),
+                activity: activityUuid,
                 profile: profileId
               }
             }
@@ -243,7 +246,7 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
           // Effect already exists, reset its duration
           if ( appliedEffect ) operations.push({
             action: "update", documentName: "ActiveEffect", updates: [foundry.utils.mergeObject({
-              _id: appliedEffect._id, start: ActiveEffect5e.getEffectStart()
+              _id: appliedEffect._id, start: ActiveEffect5e.getEffectStart(), disabled: false
             }, effectFlags)], parent: target
           });
 

--- a/module/documents/activity/transform.mjs
+++ b/module/documents/activity/transform.mjs
@@ -3,6 +3,7 @@ import TransformUsageDialog from "../../applications/activity/transform-usage-di
 import CompendiumBrowser from "../../applications/compendium-browser.mjs";
 import BaseTransformActivityData from "../../data/activity/transform-data.mjs";
 import { getSceneTargets, simplifyBonus } from "../../utils.mjs";
+import ActiveEffect5e from "../active-effect.mjs";
 import ActivityMixin from "./mixin.mjs";
 
 /**
@@ -151,7 +152,13 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
     if ( this.transform.mode !== "form" ) return;
     const profile = results.message?.flags?.dnd5e?.transform?.profile
       ?? results.message?.data?.flags?.dnd5e?.transform?.profile;
-    this.#transformToForm(profile);
+    this.#transformToForm(profile, {
+      dependentOn: results.effects?.find(e =>
+        (e.system.type === "concentrating") && (e.flags.dnd5e?.activity?.id === this.id)
+      )?.uuid,
+      scaling: config.scaling ? config.scaling : undefined,
+      spellLevel: this.item.level
+    });
   }
 
   /* -------------------------------------------- */
@@ -167,7 +174,11 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
    */
   static async #transformActor(event, target, message) {
     if ( this.transform.mode === "form" ) {
-      await this.#transformToForm(message.getFlag("dnd5e", "transform.profile"));
+      await this.#transformToForm(message.getFlag("dnd5e", "transform.profile"), {
+        dependentOn: message.getAssociatedActor()?.effects.get(message.system.concentration)?.uuid,
+        scaling: message.system.scaling,
+        spellLevel: message.system.level
+      });
       return;
     }
 
@@ -199,31 +210,58 @@ export default class TransformActivity extends ActivityMixin(BaseTransformActivi
   /**
    * Handle transforming the actor to a specific form.
    * @param {string} [profileId]  ID of the profile into which to transform.
+   * @param {object} [flags={}]   Flags to apply to the created effect.
    */
-  async #transformToForm(profileId) {
+  async #transformToForm(profileId, flags={}) {
     if ( this.transform.mode !== "form" ) return;
     const profile = this.applicableEffects.find(e => e._id === profileId);
     if ( !profile && !this.transform.formless ) return;
 
     let targets = getSceneTargets(this.actor, { checkBaseActor: true }).map(t => t.actor);
     if ( !targets.length ) targets.push(this.actor);
+    const operations = [];
     for ( const target of targets ) {
       const item = target.items.get(this.item.id);
       if ( !item ) continue;
-      const updates = [];
+      const ids = [];
       for ( const profile of this.effects ) {
-        const effect = item.effects.get(profile._id);
-        if ( !effect ) continue;
-        const enabledEffect = effect.id === profileId;
-        if ( enabledEffect && effect.transfer && !effect.disabled ) {
-          ui.notifications.info("DND5E.TRANSFORM.Warning.FormActive", {
-            format: { form: effect.name, actor: target.token?.name ?? target.name }
+        const appliedEffect = target.effects.find(e => e.system.origin?.profile === profile._id);
+        const sourceEffect = item.effects.get(profile._id);
+        if ( (profile._id === profileId) && sourceEffect ) {
+          const effectFlags = {
+            flags: {
+              dnd5e: flags
+            },
+            system: {
+              origin: {
+                activity: foundry.utils.buildRelativeUuid(this.uuid, target.uuid),
+                profile: profileId
+              }
+            }
+          };
+
+          // Effect already exists, reset its duration
+          if ( appliedEffect ) operations.push({
+            action: "update", documentName: "ActiveEffect", updates: [foundry.utils.mergeObject({
+              _id: appliedEffect._id, start: ActiveEffect5e.getEffectStart()
+            }, effectFlags)], parent: target
           });
-        } else {
-          updates.push({ _id: effect.id, disabled: !enabledEffect, transfer: enabledEffect });
+
+          // Create new effect
+          else {
+            const effectData = sourceEffect.clone(foundry.utils.mergeObject({
+              disabled: false, _stats: { compendiumSource: null, duplicateSource: sourceEffect.uuid }
+            }, effectFlags)).toObject();
+            effectData.system.changes = await ActiveEffect5e.forApplication(effectData.system.changes, this, target);
+            operations.push({ action: "create", documentName: "ActiveEffect", data: [effectData], parent: target });
+          }
         }
+
+        // Remove the existing effect
+        else if ( appliedEffect ) ids.push(appliedEffect.id);
       }
-      if ( updates.length ) await item.updateEmbeddedDocuments("ActiveEffect", updates);
+      if ( ids.length ) operations.push({ action: "delete", documentName: "ActiveEffect", ids, parent: target });
     }
+    await foundry.documents.modifyBatch(operations);
   }
 }


### PR DESCRIPTION
Changes how the "Select Form" transformation mode works to create the effect directly on the actor rather than transfering the effect to work with recent changes to how transfer works with applied effects. This also ensures that duration is set properly when using this transformation mode and it is linked to concentration.

Adds a `system.origin.profile` so each effect can know which profile on the activity was used to apply it. This is populated for transformation and enchantment activities, but not yet for base actvities because the profile data isn't fully communicated to the chat cards.