### PR TITLE
Fix tag-showing css to work with `document-tags`

### DIFF
--- a/less/v2/forms.less
+++ b/less/v2/forms.less
@@ -559,12 +559,14 @@
       &:hover a { text-shadow: 0 0 6px var(--color-shadow-primary); }
     }
 
-    &:has(select:disabled) .tags.input-element-tags .tag {
-      cursor: var(--cursor-default);
-      a { cursor: var(--cursor-default); }
-      &:hover a { text-shadow: none; }
-      .remove { display: unset; }
-      .fa-xmark { display: none; }
+    &:has(select:disabled), &:is(:disabled, [readonly]) {
+      .tags.input-element-tags .tag {
+        cursor: var(--cursor-default);
+        a { cursor: var(--cursor-default); }
+        &:hover a { text-shadow: none; }
+        .remove { display: unset; }
+        .fa-xmark { display: none; }
+      }
     }
 
     &.hidden-tags .tags.input-element-tags { display: none; }


### PR DESCRIPTION
Closes #7331 
I'm not sure whether we need the existing` :has` tbh. Kept it just in case, but the core css which hides it (which we undo) comes out to:
```css
:is(autocomplete-tags, document-tags, string-tags, multi-select):is(:disabled, [readonly]) .tags.input-element-tags .tag .remove {
  display: none;
}
```