### PR TITLE
[#3011] Allow `@item` use in effect values, move custom `_checkCondition` into core `shouldApplyChange`

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -596,10 +596,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
       if ( this.system.conditions?.check(conditionData) === false ) return false;
       if ( change.conditions?.check(conditionData) === false ) return false;
     }
-
-    const originalChange = this.system.changes.find(c => c._id === change._id);
-    if ( originalChange ) originalChange.applied = true;
-
+    change.applied = true;
     return true;
   }
 
@@ -607,15 +604,14 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /** @inheritDoc */
   getReplacementData(baseData) {
+    if ( !this.item ) return super.getReplacementData(baseData);
     baseData = { ...super.getReplacementData(baseData) };
-    if ( this.item ) {
-      baseData.item = {
-        ...this.item.system,
-        flags: this.item.flags,
-        name: this.item.name
-      };
-      baseData.scaling = new Scaling(this.item.scalingIncrease);
-    }
+    baseData.item = {
+      ...this.item.system,
+      flags: this.item.flags,
+      name: this.item.name
+    };
+    baseData.scaling = new Scaling(this.item.scalingIncrease);
     return baseData;
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -323,9 +323,6 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     // Apply shims to moved fields
     change = change.effect._applyChangeShim(change);
 
-    if ( (model instanceof foundry.abstract.Document)
-      && !change.effect._checkCondition(change, options.replacementData) ) return {};
-
     // Handle special actor flags
     if ( change.key.startsWith("flags.dnd5e.") ) change = change.effect._prepareFlagChange(model, change);
 
@@ -590,14 +587,10 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /* -------------------------------------------- */
 
-  /**
-   * Determine whether a specific change should be applied during this phase, setting `applied` if approved.
-   * @param {object} change           Change that might be applied.
-   * @param {object} [conditionData]  Data used to evaluate conditions.
-   * @returns {boolean}
-   * @internal
-   */
-  _checkCondition(change, conditionData) {
+  /** @inheritDoc */
+  shouldApplyChange(change, options) {
+    if ( !super.shouldApplyChange(change, options) ) return false;
+    const conditionData = options?.replacementData;
     if ( conditionData && !CONFIG.ActiveEffect.changeTypes[change.type]?.skipConditions ) {
       if ( this.system.conditions?.check(conditionData) === false ) return false;
       if ( change.conditions?.check(conditionData) === false ) return false;
@@ -607,6 +600,19 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     if ( originalChange ) originalChange.applied = true;
 
     return true;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  getReplacementData(baseData) {
+    baseData = { ...super.getReplacementData(baseData) };
+    if ( this.item ) baseData.item = {
+      ...this.item.system,
+      flags: this.item.flags,
+      name: this.item.name
+    };
+    return baseData;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -5,6 +5,7 @@ import MappingField from "../data/fields/mapping-field.mjs";
 import { parseOrString, simplifyBonus, staticID } from "../utils.mjs";
 import Item5e from "./item.mjs";
 import DependentDocumentMixin from "./mixins/dependent.mjs";
+import Scaling from "./scaling.mjs";
 
 const TextEditor = foundry.applications.ux.TextEditor.implementation;
 const { NumberField, ObjectField, SchemaField, SetField, StringField } = foundry.data.fields;
@@ -607,11 +608,14 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /** @inheritDoc */
   getReplacementData(baseData) {
     baseData = { ...super.getReplacementData(baseData) };
-    if ( this.item ) baseData.item = {
-      ...this.item.system,
-      flags: this.item.flags,
-      name: this.item.name
-    };
+    if ( this.item ) {
+      baseData.item = {
+        ...this.item.system,
+        flags: this.item.flags,
+        name: this.item.name
+      };
+      baseData.scaling = new Scaling(this.item.scalingIncrease);
+    }
     return baseData;
   }
 

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -389,7 +389,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     // Prepare final attributes & spellcasting so that they can be used/modified in "final" phase
-    if ( phase === "final" && (this.system?.modelProvider === dnd5e) ) {
+    if ( phase === "final" ) {
       this.items.forEach(item => item.prepareFinalAttributes());
       this._prepareSpellcasting();
     }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -337,17 +337,6 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     return type;
   }
 
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
-  prepareData() {
-    super.prepareData();
-    if ( this.system.modelProvider === dnd5e ) {
-      this.items.forEach(item => item.prepareFinalAttributes());
-      this._prepareSpellcasting();
-    }
-  }
-
   /* --------------------------------------------- */
 
   /** @inheritDoc */
@@ -397,6 +386,12 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       for ( const effect of this.allApplicableEffects() ) {
         if ( effect.active ) for ( const statusId of effect.statuses ) this.statuses.add(statusId);
       }
+    }
+
+    // Prepare final attributes & spellcasting so that they can be used/modified in "final" phase
+    if ( phase === "final" && (this.system?.modelProvider === dnd5e) ) {
+      this.items.forEach(item => item.prepareFinalAttributes());
+      this._prepareSpellcasting();
     }
 
     return super.applyActiveEffects(phase);

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -472,10 +472,13 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   applyActiveEffects() {
     // Organize non-disabled effects by their application priority
     const changes = [];
+    const replacementData = this.getRollData();
     for ( const effect of this.allApplicableEffects() ) {
       if ( !effect.active ) continue;
       for ( const change of effect.system.changes ) {
-        if ( change.key === "" ) continue;
+        if ( (change.key === "") || !effect.shouldApplyChange(change, { replacementData, phase: change.phase }) ) {
+          continue;
+        }
         const copy = foundry.utils.deepClone(change);
         copy.effect = effect;
         changes.push(copy);
@@ -486,7 +489,6 @@ export default class Item5e extends SystemDocumentMixin(Item) {
 
     // Apply all changes
     const overrides = {};
-    const replacementData = this.getRollData();
     for ( const change of changes ) {
       const result = change.effect.constructor.applyChange(this, change, { replacementData });
       if ( foundry.utils.isPlainObject(result) ) Object.assign(overrides, result);


### PR DESCRIPTION
Closes #3011 
The changes to `ActiveEffect5e` are self-explanatory. Other piece is that I moved the call of `prepareFinalAttributes` on embedded items & `_prepareSpellcasting` from `Actor5e#prepareData` into the "final" phase in `Actor5e#applyActiveEffects`, so that resulting values can actually be modified by `final`-phase AE changes.

Follow-up improvement of this (specifically, being able to use `@item.uses.value`) in #7368.