### PR TITLE
Add "postAbilities" phase, prepare item `UsesField` data in that phase, prepare `@item.uses.value`-using changes' `phase` to "postAbilities"

### DIFF
--- a/dnd5e.mjs
+++ b/dnd5e.mjs
@@ -155,6 +155,7 @@ Hooks.once("init", function() {
   // Hook up system data types
   Object.assign(CONFIG.ActiveEffect.changeTypes, DND5E.activeEffectChangeTypes);
   Object.assign(CONFIG.ActiveEffect.dataModels, dataModels.activeEffect.config);
+  Object.assign(CONFIG.ActiveEffect.phases, dataModels.activeEffect.phases);
   CONFIG.Actor.dataModels = dataModels.actor.config;
   CONFIG.ChatMessage.dataModels = dataModels.chatMessage.config;
   CONFIG.Item.dataModels = dataModels.item.config;

--- a/lang/en.json
+++ b/lang/en.json
@@ -2764,6 +2764,12 @@
   },
   "Label": "Available Effects",
   "New": "New Effect",
+  "PHASES": {
+    "postAbilities": {
+      "label": "Post Abilities",
+      "hint": "Immediately after ability data has been prepared"
+    }
+  },
   "Replacement": {
     "NoChange": "No Change",
     "Origin": "Origin",

--- a/module/data/active-effect/_module.mjs
+++ b/module/data/active-effect/_module.mjs
@@ -13,3 +13,10 @@ export const config = {
   condition: ConditionData,
   enchantment: EnchantmentData
 };
+
+export const phases = {
+  postAbilities: {
+    label: "DND5E.EFFECT.PHASES.postAbilities.label",
+    hint: "DND5E.EFFECT.PHASES.postAbilities.hint"
+  }
+};

--- a/module/data/active-effect/base.mjs
+++ b/module/data/active-effect/base.mjs
@@ -35,6 +35,18 @@ export default class BaseEffectData extends ActiveEffectDataModel {
   }
 
   /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  prepareBaseData() {
+    super.prepareBaseData();
+    for ( const change of this.changes ) {
+      if ( change.value.includes?.("@item.uses.value") ) change.phase = "postAbilities";
+    }
+  }
+
+  /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
 

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -384,6 +384,8 @@ export default class CommonTemplate extends ActorDataModel.mixin(CurrencyTemplat
 
       CommonTemplate.shimAbilityData(abl, id);
     }
+
+    this.parent.applyActiveEffects("postAbilities");
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -244,7 +244,7 @@ export default class ConsumableData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareFinalData() {
-    this.prepareFinalActivityData(this.parent.getRollData({ deterministic: true }));
+    this.prepareFinalActivityData();
     this.prepareFinalEquippableData();
   }
 

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -300,7 +300,7 @@ export default class EquipmentData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareFinalData() {
-    this.prepareFinalActivityData(this.parent.getRollData({ deterministic: true }));
+    this.prepareFinalActivityData();
     this.prepareFinalEquippableData();
   }
 

--- a/module/data/item/facility.mjs
+++ b/module/data/item/facility.mjs
@@ -208,7 +208,7 @@ export default class FacilityData extends ItemDataModel.mixin(ActivitiesTemplate
 
   /** @inheritDoc */
   prepareFinalData() {
-    this.prepareFinalActivityData(this.parent.getRollData({ deterministic: true }));
+    this.prepareFinalActivityData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/feat.mjs
+++ b/module/data/item/feat.mjs
@@ -283,7 +283,7 @@ export default class FeatData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareFinalData() {
-    this.prepareFinalActivityData(this.parent.getRollData({ deterministic: true }));
+    this.prepareFinalActivityData();
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -504,7 +504,7 @@ export default class SpellData extends ItemDataModel.mixin(ActivitiesTemplate, I
   prepareFinalData() {
     const rollData = this.parent.getRollData({ deterministic: true });
     const labels = this.parent.labels ??= {};
-    this.prepareFinalActivityData(rollData);
+    this.prepareFinalActivityData();
     ActivationField.prepareData.call(this, rollData, labels);
     DurationField.prepareData.call(this, rollData, labels);
     RangeField.prepareData.call(this, rollData, labels);

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -313,12 +313,20 @@ export default class ActivitiesTemplate extends SystemDataModel {
   /* -------------------------------------------- */
 
   /**
-   * Prepare final data for the activities & uses.
+   * Prepare final uses data.
    * @param {ItemRollData} rollData
    */
-  prepareFinalActivityData(rollData) {
+  prepareUsesData(rollData=this.parent.getRollData({ deterministic: true })) {
     const labels = this.parent.labels;
     UsesField.prepareData.call(this, rollData, labels);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Prepare final data for the activities.
+   */
+  prepareFinalActivityData() {
     for ( const activity of this.activities ) activity.prepareFinalData();
   }
 

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -206,7 +206,7 @@ export default class ToolData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareFinalData() {
-    this.prepareFinalActivityData(this.parent.getRollData({ deterministic: true }));
+    this.prepareFinalActivityData();
     this.prepareFinalEquippableData();
   }
 

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -494,7 +494,7 @@ export default class WeaponData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   prepareFinalData() {
-    this.prepareFinalActivityData(this.parent.getRollData({ deterministic: true }));
+    this.prepareFinalActivityData();
     this.prepareFinalEquippableData();
 
     const labels = this.parent.labels ??= {};

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -402,6 +402,11 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
       }
     }
 
+    // Prepare item uses, if present
+    if ( phase === "postAbilities" ) {
+      this.items.forEach(item => item.system?.prepareUsesData?.())
+    }
+
     // Prepare final attributes & spellcasting so that they can be used/modified in "final" phase
     if ( phase === "final" ) {
       this.items.forEach(item => item.prepareFinalAttributes());


### PR DESCRIPTION
Further enables #3011 by allowing use of `@item.uses.value` specifically, which currently wouldn't be prepared in time for use in a change value. Builds on #7366.
Changes:
- Moved preparation of Item Uses in `ActivitiesTemplate` to its own method, `ActivitiesTemplate#prepareUsesData`. `ActivitiesTemplate#prepareFinalActivityData` now no longer requires roll data passed to it (as such, removed various `getRollData` calls in all mixing item subtypes' calls to that method)
- Added a new AE change phase, `postAbilities`, which is fired at the end of `CommonTemplate#prepareAbilities`
- Prior to application of any changes with this phase, all item uses data is prepared
- During base data prep for base AE subtype, if any change's value includes `@item.uses.value` in it, set its `phase` to the new phase

Effectively, the only not-present-at-"initial"-phase item data that might reasonably be used in an AE is `uses.value`, because previously it was prepared after (or immediately before, after #7366) the `final` stage. Ideally, it would be accessible as early as possible. There are certainly first party items which have limited uses depending on ability modifier, and so it must _at earliest_ be after those are calculated.

Questions/potential issues:
- Gating `@item.uses.value`-valued changes to be only after ability prep means you cannot, for instance, modify your strength value based on remaining uses of a given item. Since these items presumably would not be referencing ability mod in their max uses field, this could be worked around by prepping Uses data during "initial" for non-ability-mod-referencing items, and in "postAbilities" for ability-mod-referencing items. This then would also need to be considered when setting change phase during prep.
- Moving Uses data prep to be pre-final for items means there may be some cases where we aren't able to evaluate max uses properly. Max uses equal to max HP, for instance. We may need to consider preparation across multiple phases based on the contents of `uses.max`.
- There is absolutely room to further modify `phase` during data prep. It would now, for instance, be possible to increase `system.spell.spell1.max` during "final" phase, and so we should consider how to coerce `phase` to the "appropriate" value for such changes.