### PR TITLE
Add compact styling for saving throw cards. Allow save cards to be rendered as a summary of the usage card that spawned them.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1752,6 +1752,11 @@
 "DND5E.ChatFlavor": "Chat Message Flavor",
 
 "DND5E.CHATMESSAGE": {
+  "Action": {
+    "SelectAll": "Select All Outcomes",
+    "SelectFailure": "Select Failures",
+    "SelectSuccess": "Select Successes"
+  },
   "Activities": "Activities",
   "Button": {
     "rollAttack": "Attack",

--- a/lang/en.json
+++ b/lang/en.json
@@ -6829,7 +6829,7 @@
   },
   "CHATLOG": {
     "Hint": "Specify a theme for the chat log. By default this will inherit from the Application theme.",
-    "Name": "Chat Log",
+    "Name": "Chat Log Theme",
     "Options": {
       "blank": "Default",
       "dark": "Dark",
@@ -6967,6 +6967,10 @@
     "Hint": "Change handling of various rules between the 2024 and 2014 rule sets.",
     "Legacy": "Legacy Rules (2014)",
     "Modern": "Modern Rules (2024)"
+  },
+  "SUMMARIZECHAT": {
+    "Hint": "Append certain results as summaries rather than full chat cards.",
+    "Name": "Summary Chat Cards"
   },
   "VARIANT": {
     "Hint": "Enable and configure rules variations offered by the system.",

--- a/less/v2/chat.less
+++ b/less/v2/chat.less
@@ -92,7 +92,7 @@
 
 /* Modifier Keys */
 :is(.chat-popout, #chat-log, .chat-log)[data-modifier-shift] {
-  .message .message-header .message-delete { display: unset; }
+  .message :is(.message-header, .card-summary) .message-delete { display: unset; }
   .message .message-header:has(.message-delete) .chat-control { display: none; }
 }
 

--- a/less/v3/chat.less
+++ b/less/v3/chat.less
@@ -31,7 +31,8 @@
     .message-header {
       align-items: center;
       color: var(--color-text-primary);
-      margin-block-end: 4px;
+
+      &:has(+ .message-content .card-header) { margin-block-end: 4px; }
 
       .whisper-to {
         color: var(--color-text-secondary);
@@ -332,6 +333,52 @@
       }
 
       &:disabled:hover { text-shadow: none; }
+    }
+
+    /* Deltas */
+    .deltas {
+      border-block-start: 1px dashed var(--dnd5e-color-blue-gray-3);
+      margin: 4px -8px 0;
+      padding: 4px 8px 0;
+
+      > strong { font-size: var(--font-size-12); }
+
+      .delta {
+        display: flex;
+        font-size: var(--font-size-11);
+
+        .label { flex: 1; }
+      }
+    }
+
+    /* Summaries */
+    .card-summary {
+      border-block-start: 1px dashed var(--dnd5e-color-blue-gray-3);
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      margin: 4px -8px 0;
+      padding: 6px 8px 0;
+
+      button.dice-roll {
+        --button-background-color: transparent;
+        --button-border-color: transparent;
+        --button-hover-border-color: transparent;
+        justify-content: end;
+        padding: 0;
+
+        .d20die { display: none; }
+        .result { flex: unset; }
+        .icons { position: unset; }
+
+        .total {
+          border: none;
+          &::before, &::after { content: none; }
+        }
+      }
+
+      .icon-row.with-buttons { gap: 0; }
+      .supplement { text-align: center; }
     }
   }
 }

--- a/less/v3/chat.less
+++ b/less/v3/chat.less
@@ -58,6 +58,13 @@
       &:hover { text-shadow: 0 0 8px var(--color-shadow-primary); }
     }
 
+    button.message-delete {
+      --button-size: unset;
+      block-size: unset;
+      color: var(--color-text-secondary);
+      font-size: var(--font-size-10);
+    }
+
     .chat-card {
       display: flex;
       flex-direction: column;

--- a/module/applications/components/chat-tray-element.mjs
+++ b/module/applications/components/chat-tray-element.mjs
@@ -52,7 +52,7 @@ export default class ChatTrayElement extends foundry.applications.elements.Adopt
    * @param {PointerEvent} event  Triggering click event.
    */
   _handleClickHeader(event) {
-    if ( event.target.closest(".collapsible-content") ) return;
+    if ( !event.target.isConnected || event.target.closest(".collapsible-content") ) return;
     event.preventDefault();
     event.stopImmediatePropagation();
     this.toggleAttribute("open");

--- a/module/applications/components/damage-application.mjs
+++ b/module/applications/components/damage-application.mjs
@@ -162,7 +162,7 @@ export default class DamageApplicationElement extends ChatTrayElement {
    */
   getMergedOptions(uuid) {
     const options = this.getTargetOptions(uuid);
-    return { ...options, multiplier: options.multiplier ?? this.multiplier };
+    return { ...options, multiplier: options.multiplier ?? this.#saveMultiplier(uuid) ?? this.multiplier };
   }
 
   /* -------------------------------------------- */
@@ -231,6 +231,24 @@ export default class DamageApplicationElement extends ChatTrayElement {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Determine a multiplier based on the save outcome.
+   * @param {string} uuid  The target's UUID.
+   * @returns {number|null}
+   */
+  #saveMultiplier(uuid) {
+    const { onSave, origin } = this.chatMessage.system;
+    if ( !onSave || (origin?.system?.outcomes?.get(uuid) !== "success") ) return null;
+    switch ( onSave ) {
+      case "full": return 1;
+      case "half": return .5;
+      case "none": return 0;
+    }
+    return null;
+  }
+
+  /* -------------------------------------------- */
   /*  Life-Cycle                                  */
   /* -------------------------------------------- */
 
@@ -280,6 +298,7 @@ export default class DamageApplicationElement extends ChatTrayElement {
       multipliers.addEventListener("click", this._onChangeMultiplier.bind(this));
       div.querySelector("template").replaceWith(this.buildTargetContainer());
       div.addEventListener("click", this._handleClickHeader.bind(this));
+      this.targetList.addEventListener("recorded-targets:build", this.refreshMultiplier.bind(this));
     }
   }
 
@@ -421,6 +440,19 @@ export default class DamageApplicationElement extends ChatTrayElement {
     m.textContent = formatNumber(-tempMax, { signDisplay: "always" });
     m.parentElement.classList.toggle("healing", tempMax < 0);
     m.parentElement.hidden = !tempMax;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Refresh the global multiplier display.
+   */
+  refreshMultiplier() {
+    const multipliers = new Set(Array.from(this.targetList.querySelectorAll("option"), o => {
+      return this.getMergedOptions(o.value).multiplier;
+    }));
+    this.querySelector(".multiplier-row .damage-multipliers")
+      .replaceChildren(...this.buildMultiplierButtons(multipliers));
   }
 
   /* -------------------------------------------- */
@@ -577,9 +609,6 @@ export default class DamageApplicationElement extends ChatTrayElement {
     const button = event.target.closest(".multiplier-button");
     if ( !button ) return;
     this.multiplier = Number(button.value);
-    for ( const other of this.querySelectorAll(".multiplier-row .multiplier-button") ) {
-      other.ariaPressed = `${Number(other.value) === this.multiplier}`;
-    }
     this.targetList.buildTargetsList();
   }
 

--- a/module/applications/components/damage-application.mjs
+++ b/module/applications/components/damage-application.mjs
@@ -73,6 +73,14 @@ export default class DamageApplicationElement extends ChatTrayElement {
   /* -------------------------------------------- */
 
   /**
+   * Whether the tray has received user modifications.
+   * @type {boolean}
+   */
+  #dirty = false;
+
+  /* -------------------------------------------- */
+
+  /**
    * Stacked target menu states.
    * @type {TargetPillMenuState[]}
    */
@@ -161,8 +169,9 @@ export default class DamageApplicationElement extends ChatTrayElement {
    * @returns {DamageApplicationOptions}
    */
   getMergedOptions(uuid) {
+    const fallback = this.#dirty ? this.multiplier : (this.#saveMultiplier(uuid) ?? this.multiplier);
     const options = this.getTargetOptions(uuid);
-    return { ...options, multiplier: options.multiplier ?? this.#saveMultiplier(uuid) ?? this.multiplier };
+    return { ...options, multiplier: options.multiplier ?? fallback };
   }
 
   /* -------------------------------------------- */
@@ -299,6 +308,7 @@ export default class DamageApplicationElement extends ChatTrayElement {
       div.querySelector("template").replaceWith(this.buildTargetContainer());
       div.addEventListener("click", this._handleClickHeader.bind(this));
       this.targetList.addEventListener("recorded-targets:build", this.refreshMultiplier.bind(this));
+      this.targetList.addEventListener("recorded-targets:change", () => this.#dirty = false);
     }
   }
 
@@ -451,8 +461,9 @@ export default class DamageApplicationElement extends ChatTrayElement {
     const multipliers = new Set(Array.from(this.targetList.querySelectorAll("option"), o => {
       return this.getMergedOptions(o.value).multiplier;
     }));
-    this.querySelector(".multiplier-row .damage-multipliers")
-      .replaceChildren(...this.buildMultiplierButtons(multipliers));
+    for ( const button of this.querySelectorAll(".multiplier-row .multiplier-button") ) {
+      button.ariaPressed = `${multipliers.has(Number(button.value))}`;
+    }
   }
 
   /* -------------------------------------------- */
@@ -609,6 +620,7 @@ export default class DamageApplicationElement extends ChatTrayElement {
     const button = event.target.closest(".multiplier-button");
     if ( !button ) return;
     this.multiplier = Number(button.value);
+    this.#dirty = true;
     this.targetList.buildTargetsList();
   }
 

--- a/module/applications/components/recorded-targets.mjs
+++ b/module/applications/components/recorded-targets.mjs
@@ -164,6 +164,14 @@ export default class RecordedTargetsElement extends foundry.applications.element
   /* -------------------------------------------- */
 
   /**
+   * The set of targets last recorded.
+   * @type {Set<string>}
+   */
+  #lastTargets = new Set();
+
+  /* -------------------------------------------- */
+
+  /**
    * Checked status for application targets.
    * @type {Map<string, boolean>}
    */
@@ -248,6 +256,11 @@ export default class RecordedTargetsElement extends foundry.applications.element
           if ( t.actor ) targetedTokens.set(t.document.uuid, t.name);
         });
         break;
+    }
+    const uuids = new Set(targetedTokens.keys());
+    if ( uuids.symmetricDifference(this.#lastTargets).size ) {
+      this.#lastTargets = uuids;
+      this.dispatchEvent(new Event("recorded-targets:change"));
     }
     const targets = Array.from(targetedTokens.entries())
       .map(([uuid, name]) => {

--- a/module/applications/components/recorded-targets.mjs
+++ b/module/applications/components/recorded-targets.mjs
@@ -101,6 +101,7 @@ export default class RecordedTargetsElement extends foundry.applications.element
   set targetingMode(mode) {
     if ( !this.hasRecordedTargets ) mode = "selected";
     this.#targetingMode = mode;
+    if ( this.chatMessage ) this.chatMessage._targetState.mode = mode;
     this._refreshTargetMode();
     this.buildTargetsList();
     if ( (mode === "targeted") && (this.selectedTokensHook !== null) ) {
@@ -164,7 +165,7 @@ export default class RecordedTargetsElement extends foundry.applications.element
 
   /**
    * Checked status for application targets.
-   * @type {Map<any, any>}
+   * @type {Map<string, boolean>}
    */
   #targetOptions = new Map();
 
@@ -179,7 +180,8 @@ export default class RecordedTargetsElement extends foundry.applications.element
     this.chatMessage = game.messages.get(this.closest("[data-message-id]")?.dataset.messageId);
     if ( !this.targetList ) this.replaceChildren(this.buildTargetContainer());
     this.addEventListener("change", this._onCheckTarget.bind(this), { signal: this.#abortController.signal });
-    this.targetingMode = "targeted";
+    this.#targetOptions = this.chatMessage?._targetState.checked ?? new Map();
+    this.targetingMode = this.chatMessage?._targetState.mode || "targeted";
   }
 
   /* -------------------------------------------- */
@@ -261,6 +263,7 @@ export default class RecordedTargetsElement extends foundry.applications.element
       li.textContent = _loc("DND5E.Tokens.NoTargets");
       this.targetList.replaceChildren(li);
     }
+    this.dispatchEvent(new Event("recorded-targets:build"));
   }
 
   /* -------------------------------------------- */
@@ -378,6 +381,7 @@ export default class RecordedTargetsElement extends foundry.applications.element
   _onCheckTarget(event) {
     this.#targetOptions = new Map(Iterator.from(event.currentTarget.querySelectorAll(".target option"))
       .map(el => [el.value, "checked" in el.dataset]));
+    if ( this.chatMessage ) this.chatMessage._targetState.checked = this.#targetOptions;
   }
 
   /* -------------------------------------------- */

--- a/module/data/abstract/_types.mjs
+++ b/module/data/abstract/_types.mjs
@@ -10,6 +10,8 @@
 /**
  * @typedef ChatMessageDataModelMetadata
  * @property {Record<string, ApplicationClickAction>} actions  Default click actions for buttons on the message.
+ * @property {string} summaryTemplate                          Template to use when rendering the message as a summary
+ *                                                             in a different message.
  * @property {string} template                                 Template to use when rendering this message.
  */
 

--- a/module/data/abstract/chat-message-data-model.mjs
+++ b/module/data/abstract/chat-message-data-model.mjs
@@ -20,6 +20,7 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
       toggleDescription: ChatMessageDataModel.#toggleDescription,
       use: ChatMessageDataModel.#useActivity
     },
+    summaryTemplate: "",
     template: ""
   });
 
@@ -35,6 +36,16 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
    */
   get canApplyDamage() {
     return false;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Template to use when rendering this message as a summary item.
+   * @type {string}
+   */
+  get summaryTemplate() {
+    return this.metadata.summaryTemplate;
   }
 
   /* -------------------------------------------- */
@@ -65,7 +76,7 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
     const click = this.#onClick.bind(this);
     element.addEventListener("click", click);
     element.addEventListener("contextmenu", click);
-    this._onRender(element);
+    this._onRender(element, options);
   }
 
   /* -------------------------------------------- */
@@ -76,8 +87,9 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
    * @returns {Promise<string>}
    */
   async render(options) {
-    if ( !this.template ) return "";
-    return foundry.applications.handlebars.renderTemplate(this.template, await this._prepareContext(options));
+    const template = options.summary ? this.summaryTemplate : this.template;
+    if ( !template ) return "";
+    return foundry.applications.handlebars.renderTemplate(template, await this._prepareContext(options));
   }
 
   /* -------------------------------------------- */
@@ -107,10 +119,11 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
 
   /**
    * Actions taken after the message has been rendered.
-   * @param {HTMLElement} element
+   * @param {HTMLElement} element  The message element.
+   * @param {object} [options]     Render options.
    * @protected
    */
-  _onRender(element) {
+  _onRender(element, options={}) {
     for ( const e of element.querySelectorAll(".item-tooltip") ) {
       const uuid = e.closest("[data-item-uuid]")?.dataset.itemUuid;
       if ( !uuid ) continue;
@@ -122,6 +135,9 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
     }
     for ( const popover of element.querySelectorAll(".roll-breakdown[popover]") ) {
       popover.previousElementSibling.popoverTargetElement = popover;
+    }
+    for ( const summary of element.querySelectorAll(".card-summary[data-message-id]") ) {
+      game.messages.get(summary.dataset.messageId)?.system?._onRender(summary, { summary: true });
     }
   }
 
@@ -135,18 +151,19 @@ export default class ChatMessageDataModel extends foundry.abstract.TypeDataModel
    */
   #onClick(event) {
     const target = event.target.closest("[data-action]");
+    const message = game.messages.get(event.target.closest("[data-message-id]")?.dataset.messageId) ?? this;
     if ( target ) {
       const action = target.dataset.action;
-      let handler = this.metadata.actions[action];
+      let handler = message.system.metadata.actions[action];
       if ( handler ) {
         let buttons = [0];
         if ( typeof handler === "object" ) {
           buttons = handler.buttons;
           handler = handler.handler;
         }
-        if ( buttons.includes(event.button) ) handler?.call(this, event, target);
+        if ( buttons.includes(event.button) ) handler?.call(message.system, event, target);
       } else {
-        this._onClickAction(event, target);
+        message.system._onClickAction(event, target);
       }
     }
   }

--- a/module/data/chat-message/attack-message-data.mjs
+++ b/module/data/chat-message/attack-message-data.mjs
@@ -39,10 +39,6 @@ export default class AttackMessageData extends RollMessageData {
   }, { inplace: false }));
 
   /* -------------------------------------------- */
-
-  static ROLL_TEMPLATE = "systems/dnd5e/templates/chat/parts/roll-compact.hbs";
-
-  /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */
 
@@ -104,19 +100,12 @@ export default class AttackMessageData extends RollMessageData {
   /*  Rendering                                   */
   /* -------------------------------------------- */
 
-  /** @override */
-  _getEnrichmentOptions() {
-    return { avatar: false };
-  }
-
-  /* -------------------------------------------- */
-
   /** @inheritDoc */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     const isPrivate = !this.parent.isContentVisible;
     const item = this.parent.getAssociatedItem();
-    if ( !isPrivate && item ) context.header = { item, activity: this.activity };
+    if ( !isPrivate && item ) context.header = { item, activity: this.activity, subtitle: this.activity.name };
     const mastery = CONFIG.DND5E.weaponMasteries[this.mastery];
     if ( mastery ) context.mastery = { label: mastery.label, reference: mastery.reference };
     context.rows = {
@@ -150,9 +139,8 @@ export default class AttackMessageData extends RollMessageData {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _onRender(element) {
-    super._onRender(element);
-    element.classList.add("compact");
+  _onRender(element, options={}) {
+    super._onRender(element, options);
     if ( element.querySelector(".chat-card .card-header") ) {
       element.querySelector(".message-header .flavor-text")?.remove();
     }

--- a/module/data/chat-message/bastion-turn-message-data.mjs
+++ b/module/data/chat-message/bastion-turn-message-data.mjs
@@ -109,8 +109,8 @@ export default class BastionTurnMessageData extends ChatMessageDataModel {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _onRender(element) {
-    super._onRender(element);
+  _onRender(element, options={}) {
+    super._onRender(element, options);
     if ( !this.actor?.isOwner ) return;
 
     element.querySelectorAll(".item-summary > li").forEach(async el => {

--- a/module/data/chat-message/check-message-data.mjs
+++ b/module/data/chat-message/check-message-data.mjs
@@ -39,6 +39,7 @@ export default class CheckMessageData extends RollMessageData {
   /*  Rendering                                   */
   /* -------------------------------------------- */
 
+  /** @inheritDoc */
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     const actor = this.parent.getAssociatedActor();

--- a/module/data/chat-message/check-message-data.mjs
+++ b/module/data/chat-message/check-message-data.mjs
@@ -31,6 +31,26 @@ export default class CheckMessageData extends RollMessageData {
 
   /** @inheritDoc */
   static metadata = Object.freeze(foundry.utils.mergeObject(super.metadata, {
+    summaryTemplate: "systems/dnd5e/templates/chat/check-summary.hbs",
     template: "systems/dnd5e/templates/chat/check-card.hbs"
   }, { inplace: false }));
+
+  /* -------------------------------------------- */
+  /*  Rendering                                   */
+  /* -------------------------------------------- */
+
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    const actor = this.parent.getAssociatedActor();
+    const token = this.parent.getAssociatedToken();
+    const item = this.parent.getAssociatedItem();
+    const isPrivate = !this.parent.isContentVisible;
+    context.token = token ?? actor;
+    if ( !isPrivate && item ) context.header = {
+      item,
+      activity: this.activity,
+      subtitle: [this.activity.name, this.parent.flavor].filterJoin(" • ")
+    };
+    return context;
+  }
 }

--- a/module/data/chat-message/damage-message-data.mjs
+++ b/module/data/chat-message/damage-message-data.mjs
@@ -66,7 +66,7 @@ export default class DamageMessageData extends RollMessageData {
     activity ??= this.parent.getAssociatedActivity();
     const { isSpell=false } = activity ?? {};
     const isCritical = this.parent.rolls[0]?.isCritical === true;
-    const isWeapon = this.item.type === "weapon";
+    const isWeapon = this.item?.type === "weapon";
     const props = new Set(this.parent.rolls.flatMap(r => r.options.properties ?? []));
     const tags = [];
     if ( isCritical ) tags.push({ css: "critical", label: _loc("DND5E.Critical") });

--- a/module/data/chat-message/damage-message-data.mjs
+++ b/module/data/chat-message/damage-message-data.mjs
@@ -79,13 +79,6 @@ export default class DamageMessageData extends RollMessageData {
   /* -------------------------------------------- */
 
   /** @override */
-  _getEnrichmentOptions() {
-    return { avatar: false };
-  }
-
-  /* -------------------------------------------- */
-
-  /** @override */
   async _prepareContext(options) {
     const aggregate = CONFIG.DND5E.aggregateDamageDisplay;
     const rolls = aggregate ? aggregateDamageRolls(this.parent.rolls) : this.parent.rolls;
@@ -127,9 +120,8 @@ export default class DamageMessageData extends RollMessageData {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _onRender(element) {
-    super._onRender(element);
-    element.classList.add("compact");
+  _onRender(element, options={}) {
+    super._onRender(element, options);
     if ( element.querySelector(".chat-card .card-header") ) {
       element.querySelector(".message-header .flavor-text")?.remove();
     }

--- a/module/data/chat-message/item-message-data.mjs
+++ b/module/data/chat-message/item-message-data.mjs
@@ -88,8 +88,8 @@ export default class ItemMessageData extends ChatMessageDataModel {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _onRender(element) {
-    super._onRender(element);
+  _onRender(element, options={}) {
+    super._onRender(element, options);
     element.classList.add("compact");
     if ( game.settings.get("dnd5e", "autoCollapseItemCards") ) {
       element.querySelectorAll(".card-header, .card-description").forEach(el => el.classList.add("collapsed"));

--- a/module/data/chat-message/prompt-message-data.mjs
+++ b/module/data/chat-message/prompt-message-data.mjs
@@ -102,8 +102,8 @@ export default class PromptMessageData extends ChatMessageDataModel {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _onRender(element) {
-    super._onRender(element);
+  _onRender(element, options={}) {
+    super._onRender(element, options);
     if ( this.parent.shouldDisplayChallenge ) element.dataset.displayChallenge = "";
   }
 

--- a/module/data/chat-message/request-message-data.mjs
+++ b/module/data/chat-message/request-message-data.mjs
@@ -71,8 +71,8 @@ export default class RequestMessageData extends ChatMessageDataModel {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _onRender(element) {
-    super._onRender(element);
+  _onRender(element, options={}) {
+    super._onRender(element, options);
     this._highlightSuccessFailure(element);
   }
 

--- a/module/data/chat-message/roll-message-data.mjs
+++ b/module/data/chat-message/roll-message-data.mjs
@@ -20,7 +20,7 @@ export default class RollMessageData extends ChatMessageDataModel {
    * Template used to render each individual roll within the message.
    * @type {string}
    */
-  static ROLL_TEMPLATE = "systems/dnd5e/templates/chat/parts/roll.hbs";
+  static ROLL_TEMPLATE = "systems/dnd5e/templates/chat/parts/roll-compact.hbs";
 
   /* -------------------------------------------- */
   /*  Model Configuration                         */
@@ -77,6 +77,13 @@ export default class RollMessageData extends ChatMessageDataModel {
   /* -------------------------------------------- */
 
   /** @override */
+  _getEnrichmentOptions() {
+    return { avatar: false };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
   async _prepareContext(options) {
     const { canCrit, displayResult, forceSuccess } = this;
     const isPrivate = !this.parent.isContentVisible;
@@ -87,5 +94,13 @@ export default class RollMessageData extends ChatMessageDataModel {
         template: this.constructor.ROLL_TEMPLATE
       })))
     };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onRender(element, options={}) {
+    super._onRender(element, options);
+    if ( !options.summary ) element.classList.add("compact");
   }
 }

--- a/module/data/chat-message/save-message-data.mjs
+++ b/module/data/chat-message/save-message-data.mjs
@@ -40,6 +40,7 @@ export default class SaveMessageData extends RollMessageData {
       breakConcentration: SaveMessageData.#breakConcentration,
       resistSave: SaveMessageData.#resistSave
     },
+    summaryTemplate: "systems/dnd5e/templates/chat/save-summary.hbs",
     template: "systems/dnd5e/templates/chat/save-card.hbs"
   }, { inplace: false }));
 
@@ -112,8 +113,10 @@ export default class SaveMessageData extends RollMessageData {
     const context = await super._prepareContext(options);
     const { canBreakConcentration, canResist, concentrationBroken, resisted } = this;
     const actor = this.parent.getAssociatedActor();
+    const token = this.parent.getAssociatedToken();
     Object.assign(context, { canBreakConcentration, canResist, concentrationBroken, resisted });
     context.death = this.type === "death";
+    context.token = token ?? actor;
     if ( actor ) {
       // Filter out success & failure tallies since their real data changes might read as confusing.
       const deltas = {
@@ -124,7 +127,36 @@ export default class SaveMessageData extends RollMessageData {
     if ( context.death && this.outcome ) context.outcome = _loc(`DND5E.DEATH.Outcome.${this.outcome}`, {
       name: actor?.name ?? ""
     });
+    const item = this.parent.getAssociatedItem();
+    const isPrivate = !this.parent.isContentVisible;
+    if ( !isPrivate && item ) context.header = {
+      item,
+      activity: this.activity,
+      subtitle: [this.activity.name, this.parent.flavor].filterJoin(" • ")
+    };
+    const buttons = {};
+    if ( !resisted && canResist ) buttons.resist = { entries: [{
+      action: "resistSave",
+      icon: "fa-solid fa-dragon",
+      label: "DND5E.LegendaryResistance.Action.Resist"
+    }] };
+    if ( !concentrationBroken && canBreakConcentration ) buttons.concentration = { entries: [{
+      action: "breakConcentration",
+      icon: "fa-solid fa-ban",
+      label: "DND5E.CONCENTRATION.Action.Break"
+    }] };
+    if ( !foundry.utils.isEmpty(buttons) ) context.buttonGroups = buttons;
     return context;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onRender(element, options={}) {
+    super._onRender(element, options);
+    if ( element.querySelector(".chat-card .card-header") ) {
+      element.querySelector(".message-header .flavor-text")?.remove();
+    }
   }
 
   /* -------------------------------------------- */

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -196,13 +196,15 @@ export default class UsageMessageData extends ItemMessageData {
       context.showTargets = true;
       this._prepareButtonGroups(context);
       if ( this.activity.name ) context.subtitle = this.activity.name;
-      context.summaries = (await Promise.all(this.parent.getAssociatedRolls()
-        .filter(m => m.visible)
-        .map(async m => {
-          const token = m.getAssociatedToken();
-          return { html: await m.system.render({ summary: true }), id: m.id, token: token };
-        })))
-        .filter(s => s.html);
+      if ( game.settings.get("dnd5e", "chatCardSummary") ) {
+        context.summaries = (await Promise.all(this.parent.getAssociatedRolls()
+          .filter(m => m.visible)
+          .map(async m => {
+            const token = m.getAssociatedToken();
+            return { html: await m.system.render({ summary: true }), id: m.id, token: token };
+          })))
+          .filter(s => s.html);
+      }
     }
 
     const item = this.parent.getAssociatedItem();

--- a/module/data/chat-message/usage-message-data.mjs
+++ b/module/data/chat-message/usage-message-data.mjs
@@ -71,9 +71,92 @@ export default class UsageMessageData extends ItemMessageData {
 
   /* -------------------------------------------- */
 
+  /**
+   * The message's currently configured targets.
+   * @type {(TokenDocument5e|Actor5e)[]|void}
+   */
+  get evaluatedTargets() {
+    const { checked, mode } = this.parent._targetState;
+    if ( !mode ) return;
+    if ( mode === "selected" ) return canvas.tokens?.controlled;
+    return this.targets.map(descriptor => {
+      if ( checked.get(descriptor.token) === false ) return null;
+      const { actor, token } = TargetsField.resolve(descriptor);
+      return token?.document ?? actor;
+    }).filter(_ => _);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Marshal all the rolled outcomes of this usage.
+   * @type {Map<string, "failure"|"success">}
+   */
+  get outcomes() {
+    if ( this.#outcomes ) return this.#outcomes;
+    const outcomes = new Map();
+    for ( const message of this.parent.getAssociatedRolls(this.activity.type) ) {
+      const [roll] = message.rolls;
+      if ( !(roll instanceof CONFIG.Dice.D20Roll) ) continue;
+      const uuid = message.getAssociatedToken()?.uuid;
+      if ( !uuid ) continue;
+      if ( roll.isSuccess || message.system.forceSuccess ) outcomes.set(uuid, "success");
+      else if ( roll.isFailure ) outcomes.set(uuid, "failure");
+    }
+    return this.#outcomes = outcomes;
+  }
+
+  #outcomes;
+
+  /* -------------------------------------------- */
+
   /** @inheritDoc */
   get showIdentity() {
     return !!this.activity.name;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * The currently highlighted token.
+   * @type {Token5e|null}
+   */
+  #highlighted = null;
+
+  /* -------------------------------------------- */
+  /*  Methods                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Perform operations when one of the descendent cards is created, updated, or deleted.
+   * @param {ChatMessage5e} message  The descendent.
+   * @returns {Promise}
+   */
+  async onDescendentRefresh(message) {
+    if ( message.type !== this.activity.type ) return; // The descendent wasn't an outcome, it was some other action.
+    this.#outcomes = undefined;
+    return Promise.all(this.parent.getAssociatedRolls("damage").map(m => ui.chat?.updateMessage(m)));
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Update targets based on roll outcomes.
+   * @param {"all"|"failure"|"success"} outcome  The outcomes to gather.
+   * @param {HTMLLIElement} element              The chat message element.
+   */
+  selectOutcomes(outcome, element) {
+    if ( !canvas?.ready ) return;
+    canvas.tokens.releaseAll();
+    const outcomes = this.outcomes.entries().filter(([, o]) => outcome === "all" ? true : o === outcome);
+    for ( const [uuid] of outcomes ) {
+      const token = fromUuidSync(uuid)?.object;
+      if ( token?.isVisible && token?.actor?.testUserPermission(game.user, "OWNER") ) {
+        token.control({ releaseOthers: false });
+      }
+    }
+    const targets = element.querySelector("recorded-targets");
+    if ( targets ) targets.targetingMode = "selected";
   }
 
   /* -------------------------------------------- */
@@ -113,11 +196,18 @@ export default class UsageMessageData extends ItemMessageData {
       context.showTargets = true;
       this._prepareButtonGroups(context);
       if ( this.activity.name ) context.subtitle = this.activity.name;
+      context.summaries = (await Promise.all(this.parent.getAssociatedRolls()
+        .filter(m => m.visible)
+        .map(async m => {
+          const token = m.getAssociatedToken();
+          return { html: await m.system.render({ summary: true }), id: m.id, token: token };
+        })))
+        .filter(s => s.html);
     }
 
     const item = this.parent.getAssociatedItem();
     const activity = this.parent.getAssociatedActivity();
-    context.showTargets = this.effects.length || (activity.type === "check") || (activity.type === "save");
+    context.showTargets = this.effects.length || (activity.metadata.targetPhase === "pre");
     const allowPlayerApplication = this.targets?.some(t => TargetsField.resolve(t).token?.isOwner)
       || ((this.parent.author?.id === game.user.id) && (activity?.target.affects.type === "self"));
     context.effects = (await Promise.all(this.effects.map(uuid => fromUuid(uuid, { relative: item }))))
@@ -180,12 +270,14 @@ export default class UsageMessageData extends ItemMessageData {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _onRender(element) {
-    super._onRender(element);
+  _onRender(element, options={}) {
+    super._onRender(element, options);
     if ( this.parent.shouldDisplayChallenge ) element.dataset.displayChallenge = "";
     const activity = this.parent.getAssociatedActivity();
     activity?.onRenderChatCard(this.parent, element);
     activity?._activateLegacyChatListeners(this.parent, element);
+    element.addEventListener("pointerover", this.#onHoverInSummary.bind(this));
+    element.addEventListener("pointerout", this.#onHoverOutSummary.bind(this));
   }
 
   /* -------------------------------------------- */
@@ -196,6 +288,32 @@ export default class UsageMessageData extends ItemMessageData {
   _onClickAction(event, target) {
     if ( event.button !== 0 ) return;
     this.parent.getAssociatedActivity()?.onChatAction(event, target, this.parent);
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle hovering over a summary element.
+   * @param {PointerEvent} event  The triggering event.
+   */
+  #onHoverInSummary(event) {
+    const { targetUuid } = event.target.closest(".card-summary[data-target-uuid]")?.dataset ?? {};
+    if ( !canvas.ready || !targetUuid ) return;
+    const token = fromUuidSync(targetUuid)?.object;
+    if ( token && token._canHover(game.user, event) && token.visible ) {
+      token._onHoverIn(event, { hoverOutOthers: true });
+      this.#highlighted = token;
+    }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Handle hovering out a summary element.
+   */
+  #onHoverOutSummary() {
+    this.#highlighted?._onHoverOut();
+    this.#highlighted = null;
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/_types.mjs
+++ b/module/documents/activity/_types.mjs
@@ -14,6 +14,8 @@
  * @property {string} title                             Default title.
  * @property {string} [hint]                            Hint about how this activity type functions.
  * @property {typeof ActivitySheet} sheetClass          Sheet class used to configure this activity.
+ * @property {""|"pre"|"post"} targetPhase              Whether this activity selects targets before its initial use or
+ *                                                      afterward.
  * @property {object} usage
  * @property {Record<string, Function>} usage.actions   Actions that can be triggered from the chat card.
  * @property {typeof ActivityUsageDialog} usage.dialog  Default usage prompt.

--- a/module/documents/activity/check.mjs
+++ b/module/documents/activity/check.mjs
@@ -25,6 +25,7 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
       title: "DND5E.CHECK.Title",
       hint: "DND5E.CHECK.Hint",
       sheetClass: CheckSheet,
+      targetPhase: "pre",
       usage: {
         actions: {
           rollCheck: CheckActivity.#rollCheck
@@ -32,6 +33,15 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
       }
     }, { inplace: false })
   );
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get hasOutcomes() {
+    return Number.isFinite(this.check.dc.value);
+  }
 
   /* -------------------------------------------- */
   /*  Activation                                  */
@@ -91,9 +101,9 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
    * @param {ChatMessage5e} message  Message associated with the activation.
    */
   static async #rollCheck(event, target, message) {
-    const targets = getSceneTargets();
+    const targets = message.system?.evaluatedTargets ?? getSceneTargets();
     if ( !targets.length && game.user.character ) targets.push(game.user.character);
-    if ( !targets.length ) ui.notifications.warn("DND5E.ActionWarningNoToken");
+    if ( !targets.length ) ui.notifications.warn("DND5E.ActionWarningNoToken", { localize: true });
     const { ability, dc, skill, tool } = message.system.getButton(target)?.dataset ?? {};
     const rollData = { event, target: Number.isFinite(dc) ? dc : this.check.dc.value };
     const bonusData = CONFIG.Dice.BasicRoll.constructParts({ activityBonus: this.check.bonus }, this.getRollData());
@@ -102,7 +112,7 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
     for ( const token of targets ) {
       const actor = token instanceof Actor ? token : token.actor;
       const speaker = ChatMessage.getSpeaker({ actor, scene: canvas.scene, token: token.document });
-      const messageData = { data: { speaker } };
+      const messageData = { data: { speaker, system: this.messageSources } };
       if ( bonusData.parts.length ) rollData.rolls = [bonusData];
       if ( skill ) await actor.rollSkill({ ...rollData, skill }, {}, messageData);
       else if ( tool ) {

--- a/module/documents/activity/check.mjs
+++ b/module/documents/activity/check.mjs
@@ -112,7 +112,7 @@ export default class CheckActivity extends ActivityMixin(BaseCheckActivityData) 
     for ( const token of targets ) {
       const actor = token instanceof Actor ? token : token.actor;
       const speaker = ChatMessage.getSpeaker({ actor, scene: canvas.scene, token: token.document });
-      const messageData = { data: { speaker, system: this.messageSources } };
+      const messageData = { data: { speaker, system: { ...this.messageSources, origin: message.id } } };
       if ( bonusData.parts.length ) rollData.rolls = [bonusData];
       if ( skill ) await actor.rollSkill({ ...rollData, skill }, {}, messageData);
       else if ( tool ) {

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -41,6 +41,7 @@ export default function ActivityMixin(Base) {
       label: "DOCUMENT.DND5E.Activity",
       name: "Activity",
       sheetClass: ActivitySheet,
+      targetPhase: "",
       usage: {
         actions: {},
         applyEffectsInChat: true,
@@ -122,6 +123,16 @@ export default function ActivityMixin(Base) {
      */
     get dependentOrigin() {
       return this.item.effects.get(this.flags?.dnd5e?.dependentOn) ?? null;
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Whether this activity supports pass/fail outcomes.
+     * @type {boolean}
+     */
+    get hasOutcomes() {
+      return false;
     }
 
     /* -------------------------------------------- */

--- a/module/documents/activity/save.mjs
+++ b/module/documents/activity/save.mjs
@@ -129,7 +129,9 @@ export default class SaveActivity extends ActivityMixin(BaseSaveActivityData) {
         target: Number.isFinite(dc) ? dc : this.save.dc.value
       };
       if ( bonusData.parts.length ) rollData.rolls = [bonusData];
-      await actor.rollSavingThrow(rollData, {}, { data: { speaker, system: this.messageSources } });
+      await actor.rollSavingThrow(rollData, {}, {
+        data: { speaker, system: { ...this.messageSources, origin: message.id } }
+      });
     }
   }
 

--- a/module/documents/activity/save.mjs
+++ b/module/documents/activity/save.mjs
@@ -24,6 +24,7 @@ export default class SaveActivity extends ActivityMixin(BaseSaveActivityData) {
       title: "DND5E.SAVE.Title.one",
       hint: "DND5E.SAVE.Hint",
       sheetClass: SaveSheet,
+      targetPhase: "pre",
       usage: {
         actions: {
           rollDamage: SaveActivity.#rollDamage,
@@ -32,6 +33,15 @@ export default class SaveActivity extends ActivityMixin(BaseSaveActivityData) {
       }
     }, { inplace: false })
   );
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /** @override */
+  get hasOutcomes() {
+    return Number.isFinite(this.save.dc.value);
+  }
 
   /* -------------------------------------------- */
   /*  Activation                                  */
@@ -105,9 +115,9 @@ export default class SaveActivity extends ActivityMixin(BaseSaveActivityData) {
    * @param {ChatMessage5e} message  Message associated with the activation.
    */
   static async #rollSave(event, target, message) {
-    const targets = getSceneTargets();
+    const targets = message.system?.evaluatedTargets ?? getSceneTargets();
     if ( !targets.length && game.user.character ) targets.push(game.user.character);
-    if ( !targets.length ) ui.notifications.warn("DND5E.ActionWarningNoToken");
+    if ( !targets.length ) ui.notifications.warn("DND5E.ActionWarningNoToken", { localize: true });
     const { ability, dc } = message.system.getButton(target)?.dataset ?? {};
     const bonusData = CONFIG.Dice.BasicRoll.constructParts({ activityBonus: this.save.bonus }, this.getRollData());
     for ( const token of targets ) {
@@ -119,7 +129,7 @@ export default class SaveActivity extends ActivityMixin(BaseSaveActivityData) {
         target: Number.isFinite(dc) ? dc : this.save.dc.value
       };
       if ( bonusData.parts.length ) rollData.rolls = [bonusData];
-      await actor.rollSavingThrow(rollData, {}, { data: { speaker } });
+      await actor.rollSavingThrow(rollData, {}, { data: { speaker, system: this.messageSources } });
     }
   }
 

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -356,70 +356,70 @@ export default class ChatMessage5e extends ChatMessage {
     const canSelectOutcomes = li => game.messages.get(li.dataset.messageId)?.canSelectOutcomes;
     options.push(
       {
-        label: _loc("DND5E.ChatContextDamage"),
+        label: "DND5E.ChatContextDamage",
         icon: "fa-solid fa-user-minus",
         group: "damage",
         visible: canApply,
         onClick: (_, target) => game.messages.get(target.dataset.messageId)?.applyChatCardDamage(target, 1)
       },
       {
-        label: _loc("DND5E.ChatContextHealing"),
+        label: "DND5E.ChatContextHealing",
         icon: "fa-solid fa-user-plus",
         group: "damage",
         visible: canApply,
         onClick: (_, target) => game.messages.get(target.dataset.messageId)?.applyChatCardDamage(target, -1)
       },
       {
-        label: _loc("DND5E.ChatContextTempHP"),
+        label: "DND5E.ChatContextTempHP",
         icon: "fa-solid fa-user-clock",
         group: "damage",
         visible: canApply,
         onClick: (_, target) => game.messages.get(target.dataset.messageId)?.applyChatCardTemp(target)
       },
       {
-        label: _loc("DND5E.ChatContextDoubleDamage"),
+        label: "DND5E.ChatContextDoubleDamage",
         icon: "fa-solid fa-user-injured",
         group: "damage",
         visible: canApply,
         onClick: (_, target) => game.messages.get(target.dataset.messageId)?.applyChatCardDamage(target, 2)
       },
       {
-        label: _loc("DND5E.ChatContextHalfDamage"),
+        label: "DND5E.ChatContextHalfDamage",
         icon: "fa-solid fa-user-shield",
         group: "damage",
         visible: canApply,
         onClick: (_, target) => game.messages.get(target.dataset.messageId)?.applyChatCardDamage(target, 0.5)
       },
       {
-        label: _loc("DND5E.ChatContextSelectHit"),
+        label: "DND5E.ChatContextSelectHit",
         icon: "fa-solid fa-bullseye",
         group: "attack",
         visible: canTarget,
         onClick: (_, target) => game.messages.get(target.dataset.messageId)?.selectTargets("hit")
       },
       {
-        label: _loc("DND5E.ChatContextSelectMiss"),
+        label: "DND5E.ChatContextSelectMiss",
         icon: "fa-solid fa-bullseye",
         group: "attack",
         visible: canTarget,
         onClick: (_, target) => game.messages.get(target.dataset.messageId)?.selectTargets("miss")
       },
       {
-        label: _loc("DND5E.CHATMESSAGE.Action.SelectAll"),
+        label: "DND5E.CHATMESSAGE.Action.SelectAll",
         icon: "fa-solid fa-bullseye",
         group: "outcomes",
         visible: canSelectOutcomes,
         onClick: (_, target) => game.messages.get(target.dataset.messageId)?.system?.selectOutcomes("all", target)
       },
       {
-        label: _loc("DND5E.CHATMESSAGE.Action.SelectSuccess"),
+        label: "DND5E.CHATMESSAGE.Action.SelectSuccess",
         icon: "fa-solid fa-bullseye",
         group: "outcomes",
         visible: canSelectOutcomes,
         onClick: (_, target) => game.messages.get(target.dataset.messageId)?.system?.selectOutcomes("success", target)
       },
       {
-        label: _loc("DND5E.CHATMESSAGE.Action.SelectFailure"),
+        label: "DND5E.CHATMESSAGE.Action.SelectFailure",
         icon: "fa-solid fa-bullseye",
         group: "outcomes",
         visible: canSelectOutcomes,

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -151,7 +151,12 @@ export default class ChatMessage5e extends ChatMessage {
       this._collapseTrays(html);
     }
 
-    if ( this.system?.summaryTemplate && this.system.origin && !options.canClose ) html.hidden = true;
+    if ( game.settings.get("dnd5e", "chatCardSummary")
+      && this.system?.summaryTemplate
+      && this.system.origin
+      && !options.canClose ) {
+      html.hidden = true;
+    }
 
     /**
      * A hook event that fires after dnd5e-specific chat message modifications have completed.
@@ -221,6 +226,16 @@ export default class ChatMessage5e extends ChatMessage {
         onOpen: () => ui.context.menuItems = this.system._getButtonGroupContextOptions()
       });
     }
+
+    // Summary controls
+    html.querySelectorAll(".card-summary[data-message-id] > :first-child").forEach(el => {
+      el.insertAdjacentHTML("beforeend", `
+        <button type="button" class="unbutton control-button message-delete" data-action="deleteMessage"
+                aria-label="${_loc("COMMON.Delete")}">
+          <i class="fa-solid fa-trash" inert></i>
+        </button>
+      `);
+    });
 
     // SVG icons
     html.querySelectorAll("i.dnd5e-icon").forEach(el => {

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -39,6 +39,19 @@ export default class ChatMessage5e extends ChatMessage {
   /* -------------------------------------------- */
 
   /**
+   * Whether the given message offers the option to select targets based on outcome of subsequent rolls.
+   * @type {boolean}
+   */
+  get canSelectOutcomes() {
+    if ( (this.type !== "usage") || !this.isContentVisible ) return false;
+    const activity = this.getAssociatedActivity();
+    if ( !activity ) return false;
+    return activity.hasOutcomes;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Should the select targets options appear?
    * @type {boolean}
    */
@@ -61,6 +74,15 @@ export default class ChatMessage5e extends ChatMessage {
       default: return false;
     }
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Store the targeting state of the message, if applicable.
+   * @type {{ checked: Map<string, boolean>, mode: ""|"selected"|"targeted" }}
+   * @internal
+   */
+  _targetState = { checked: new Map(), mode: "" };
 
   /* -------------------------------------------- */
 
@@ -128,6 +150,8 @@ export default class ChatMessage5e extends ChatMessage {
       await this._enrichChatCard(html);
       this._collapseTrays(html);
     }
+
+    if ( this.system?.summaryTemplate && this.system.origin && !options.canClose ) html.hidden = true;
 
     /**
      * A hook event that fires after dnd5e-specific chat message modifications have completed.
@@ -287,6 +311,18 @@ export default class ChatMessage5e extends ChatMessage {
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Re-render the chat message that spawned this one so this one can be rendered as a summary.
+   */
+  async #refreshOrigin() {
+    const origin = this.system?.origin;
+    if ( !origin ) return;
+    await origin.system?.onDescendentRefresh?.(this);
+    ui.chat?.updateMessage(origin);
+  }
+
+  /* -------------------------------------------- */
   /*  Event Handlers                              */
   /* -------------------------------------------- */
 
@@ -302,6 +338,7 @@ export default class ChatMessage5e extends ChatMessage {
   static addChatMessageContextOptions(html, options) {
     const canApply = li => game.messages.get(li.dataset.messageId)?.canApplyDamage;
     const canTarget = li => game.messages.get(li.dataset.messageId)?.canSelectTargets;
+    const canSelectOutcomes = li => game.messages.get(li.dataset.messageId)?.canSelectOutcomes;
     options.push(
       {
         label: _loc("DND5E.ChatContextDamage"),
@@ -351,6 +388,27 @@ export default class ChatMessage5e extends ChatMessage {
         group: "attack",
         visible: canTarget,
         onClick: (_, target) => game.messages.get(target.dataset.messageId)?.selectTargets("miss")
+      },
+      {
+        label: _loc("DND5E.CHATMESSAGE.Action.SelectAll"),
+        icon: "fa-solid fa-bullseye",
+        group: "outcomes",
+        visible: canSelectOutcomes,
+        onClick: (_, target) => game.messages.get(target.dataset.messageId)?.system?.selectOutcomes("all", target)
+      },
+      {
+        label: _loc("DND5E.CHATMESSAGE.Action.SelectSuccess"),
+        icon: "fa-solid fa-bullseye",
+        group: "outcomes",
+        visible: canSelectOutcomes,
+        onClick: (_, target) => game.messages.get(target.dataset.messageId)?.system?.selectOutcomes("success", target)
+      },
+      {
+        label: _loc("DND5E.CHATMESSAGE.Action.SelectFailure"),
+        icon: "fa-solid fa-bullseye",
+        group: "outcomes",
+        visible: canSelectOutcomes,
+        onClick: (_, target) => game.messages.get(target.dataset.messageId)?.system?.selectOutcomes("failure", target)
       }
     );
     return options;
@@ -546,6 +604,20 @@ export default class ChatMessage5e extends ChatMessage {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  static async _preDeleteOperation(documents, operation, user) {
+    const ids = new Set(operation.ids);
+    for ( const message of documents ) {
+      for ( const result of dnd5e.registry.messages.get(message.id) ) {
+        if ( result.system.summaryTemplate ) ids.add(result.id);
+      }
+    }
+    operation.ids = Array.from(ids);
+    return super._preDeleteOperation(documents, operation, user);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   async _preCreate(data, options, user) {
     if ( (await super._preCreate(data, options, user)) === false ) return false;
     if ( !foundry.utils.hasProperty(data, "flags.core.canPopout") ) {
@@ -556,9 +628,26 @@ export default class ChatMessage5e extends ChatMessage {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  _onCreate(data, options, userId) {
+    super._onCreate(data, options, userId);
+    this.#refreshOrigin();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   _onDelete(options, userId) {
     super._onDelete(options, userId);
     dnd5e.registry.messages.untrack(this);
+    this.#refreshOrigin();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onUpdate(changed, options, userId) {
+    super._onUpdate(changed, options, userId);
+    if ( "system" in changed ) this.#refreshOrigin();
   }
 
   /* -------------------------------------------- */

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -205,6 +205,7 @@ export function registerSystemSettings() {
 
   // Chat card summaries
   game.settings.register("dnd5e", "chatCardSummary", {
+    config: true,
     default: true,
     hint: "SETTINGS.DND5E.SUMMARIZECHAT.Hint",
     name: "SETTINGS.DND5E.SUMMARIZECHAT.Name",

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -203,6 +203,15 @@ export function registerSystemSettings() {
     requiresReload: true
   });
 
+  // Chat card summaries
+  game.settings.register("dnd5e", "chatCardSummary", {
+    default: true,
+    hint: "SETTINGS.DND5E.SUMMARIZECHAT.Hint",
+    name: "SETTINGS.DND5E.SUMMARIZECHAT.Name",
+    scope: "client",
+    type: Boolean
+  });
+
   // Collapse Item Cards (by default)
   game.settings.register("dnd5e", "autoCollapseItemCards", {
     name: "SETTINGS.5eAutoCollapseCardN",

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -996,8 +996,12 @@ export async function preloadHandlebarsTemplates() {
 
     // Chat Message Partials
     "systems/dnd5e/templates/chat/parts/card-activities.hbs",
+    "systems/dnd5e/templates/chat/parts/card-buttons.hbs",
     "systems/dnd5e/templates/chat/parts/card-deltas.hbs",
     "systems/dnd5e/templates/chat/parts/card-face.hbs",
+    "systems/dnd5e/templates/chat/parts/card-header.hbs",
+    "systems/dnd5e/templates/chat/parts/card-rolls.hbs",
+    "systems/dnd5e/templates/chat/parts/card-rows.hbs",
     "systems/dnd5e/templates/chat/parts/damage-breakdown.hbs",
     "systems/dnd5e/templates/chat/parts/roll.hbs",
 

--- a/templates/chat/attack-card.hbs
+++ b/templates/chat/attack-card.hbs
@@ -2,22 +2,7 @@
 <div class="chat-card">
 
     {{!-- Header --}}
-    {{#with header}}
-    <section class="card-header no-description">
-        <div class="item-icon" data-action="showDocument" data-uuid="{{ item.uuid }}">
-            <img class="gold-icon" src="{{ item.img }}" alt="{{ item.name }}">
-        </div>
-        {{#if activity.uuid}}
-        <div class="activity-icon">{{ dnd5e-icon activity.img alt=activity.name classes="gold-icon" }}</div>
-        {{/if}}
-        <div class="name-stacked">
-            <span class="title">{{ item.name }}</span>
-            {{#if activity.name}}
-            <span class="subtitle">{{ activity.name }}</span>
-            {{/if}}
-        </div>
-    </section>
-    {{/with}}
+    {{> "dnd5e.card-header" }}
 
     {{!-- Supplements --}}
     {{#if mastery}}
@@ -33,20 +18,7 @@
     {{/if}}
 
     {{!-- Rows --}}
-    {{#each rows}}
-    {{#if entries.length}}
-    <section class="icon-row">
-        <i class="fa-fw {{ icon }}" aria-label="{{ localize label }}"></i>
-        <ul class="pills unlist">
-            {{#each entries}}
-            <li class="pill transparent">
-                <span class="label">{{ this }}</span>
-            </li>
-            {{/each}}
-        </ul>
-    </section>
-    {{/if}}
-    {{/each}}
+    {{> "dnd5e.card-rows" }}
 </div>
 {{/if}}
 
@@ -73,9 +45,4 @@
 {{/if}}
 
 {{!-- Rolls --}}
-{{#each rolls}}
-<section class="icon-row">
-    <i class="fa-fw fa-solid fa-dice" aria-label="{{ localize "DND5E.CHATMESSAGE.Row.Roll" }}"></i>
-    {{{ this }}}
-</section>
-{{/each}}
+{{> "dnd5e.card-rolls" }}

--- a/templates/chat/check-card.hbs
+++ b/templates/chat/check-card.hbs
@@ -1,3 +1,9 @@
-{{#each rolls}}
-{{{ this }}}
-{{/each}}
+<div class="chat-card">
+
+    {{!-- Header --}}
+    {{> "dnd5e.card-header" }}
+
+</div>
+
+{{!-- Rolls --}}
+{{> "dnd5e.card-rolls" }}

--- a/templates/chat/check-summary.hbs
+++ b/templates/chat/check-summary.hbs
@@ -1,0 +1,9 @@
+<section class="icon-row">
+    <i class="fa-solid fa-bullseye" aria-label="{{ localize "DND5E.CHATMESSAGE.Row.Targets" }}"></i>
+    <ul class="pills unlist">
+        <li class="pill target transparent">{{ token.name }}</li>
+    </ul>
+</section>
+
+{{!-- Rolls --}}
+{{> "dnd5e.card-rolls" }}

--- a/templates/chat/damage-card.hbs
+++ b/templates/chat/damage-card.hbs
@@ -1,22 +1,7 @@
 <div class="chat-card">
 
     {{!-- Header --}}
-    {{#with header}}
-    <section class="card-header no-description">
-        <div class="item-icon" data-action="showDocument" data-uuid="{{ item.uuid }}">
-            <img class="gold-icon" src="{{ item.img }}" alt="{{ item.name }}">
-        </div>
-        {{#if activity.uuid}}
-        <div class="activity-icon">{{ dnd5e-icon activity.img alt=activity.name classes="gold-icon" }}</div>
-        {{/if}}
-        <div class="name-stacked">
-            <span class="title">{{ item.name }}</span>
-            {{#if activity.name}}
-            <span class="subtitle">{{ subtitle }}</span>
-            {{/if}}
-        </div>
-    </section>
-    {{/with}}
+    {{> "dnd5e.card-header" }}
 
     {{!-- Supplements --}}
     {{#if onSave}}
@@ -24,20 +9,7 @@
     {{/if}}
 
     {{!-- Rows --}}
-    {{#each rows}}
-    {{#if entries.length}}
-    <section class="icon-row">
-        <i class="fa-fw {{ icon }}" aria-label="{{ localize label }}"></i>
-        <ul class="pills unlist">
-            {{#each entries}}
-            <li class="pill transparent {{ css }}">
-                <span class="label">{{ label }}</span>
-            </li>
-            {{/each}}
-        </ul>
-    </section>
-    {{/if}}
-    {{/each}}
+    {{> "dnd5e.card-rows" }}
 </div>
 
 {{!-- Rolls --}}

--- a/templates/chat/parts/card-buttons.hbs
+++ b/templates/chat/parts/card-buttons.hbs
@@ -1,0 +1,18 @@
+{{#if buttonGroups}}
+<section class="icon-row">
+    <i class="fa-solid fa-fw fa-circle-play" aria-label="{{ localize "DND5E.CHATMESSAGE.Row.Actions" }}"></i>
+    <ul class="unlist">
+    {{#each buttonGroups}}
+    {{#each entries}}
+    <li>
+        <button type="button" class="icon" data-tooltip aria-label="{{ localize label }}"
+            {{#if (and canGroup (not singleton))}}data-group data-forward-action="{{ action}}"
+            {{else}}data-action="{{ action }}" data-index="{{ index }}"{{/if}}>
+            {{ dnd5e-icon icon }}
+        </button>
+    </li>
+    {{/each}}
+    {{/each}}
+    </ul>
+</section>
+{{/if}}

--- a/templates/chat/parts/card-face.hbs
+++ b/templates/chat/parts/card-face.hbs
@@ -73,7 +73,7 @@
             <li>
                 <button type="button" class="icon" data-tooltip aria-label="{{ localize label }}"
                         {{#if (and canGroup (not singleton))}}data-group data-forward-action="{{ action }}"
-                        {{else}}data-action="{{ action }}" data-index="{{ index}}"{{/if}}>
+                        {{else}}data-action="{{ action }}" data-index="{{ index }}"{{/if}}>
                     {{ dnd5e-icon icon }}
                 </button>
             </li>

--- a/templates/chat/parts/card-header.hbs
+++ b/templates/chat/parts/card-header.hbs
@@ -1,0 +1,16 @@
+{{#with header}}
+<section class="card-header no-description">
+    <div class="item-icon" data-action="showDocument" data-uuid="{{ item.uuid }}">
+        <img class="gold-icon" src="{{ item.img }}" alt="{{ item.name }}">
+    </div>
+    {{#if activity.uuid}}
+    <div class="activity-icon">{{ dnd5e-icon activity.img alt=activity.name classes="gold-icon" }}</div>
+    {{/if}}
+    <div class="name-stacked">
+        <span class="title">{{ item.name }}</span>
+        {{#if activity.name}}
+        <span class="subtitle">{{ subtitle }}</span>
+        {{/if}}
+    </div>
+</section>
+{{/with}}

--- a/templates/chat/parts/card-rolls.hbs
+++ b/templates/chat/parts/card-rolls.hbs
@@ -1,0 +1,6 @@
+{{#each rolls}}
+<section class="icon-row">
+    <i class="fa-fw fa-solid fa-dice" aria-label="{{ localize "DND5E.CHATMESSAGE.Row.Roll" }}"></i>
+    {{{ this }}}
+</section>
+{{/each}}

--- a/templates/chat/parts/card-rows.hbs
+++ b/templates/chat/parts/card-rows.hbs
@@ -1,0 +1,14 @@
+{{#each rows}}
+{{#if entries.length}}
+<section class="icon-row">
+    <i class="fa-fw {{ icon }}" aria-label="{{ localize label }}"></i>
+    <ul class="pills unlist">
+        {{#each entries}}
+        <li class="pill transparent {{ css }}">
+            <span class="label">{{ label }}</span>
+        </li>
+        {{/each}}
+    </ul>
+</section>
+{{/if}}
+{{/each}}

--- a/templates/chat/save-card.hbs
+++ b/templates/chat/save-card.hbs
@@ -1,9 +1,9 @@
-{{#each rolls}}
-{{{ this }}}
-{{/each}}
-
-{{#if (or outcome resisted canResist concentrationBroken canBreakConcentration deltas.length)}}
 <div class="chat-card{{#if death}} death-save{{/if}}">
+
+    {{!-- Header --}}
+    {{> "dnd5e.card-header" }}
+
+    {{!-- Supplements --}}
     {{#if outcome}}
     <p class="supplement">{{ outcome }}</p>
     {{/if}}
@@ -13,13 +13,6 @@
         <strong>{{ localize "DND5E.ROLL.Status" }}</strong>
         {{ localize "DND5E.LegendaryResistance.Resisted" }}
     </p>
-    {{else if canResist}}
-    <div class="card-buttons">
-        <button type="button" data-action="resistSave">
-            <i class="fa-solid fa-dragon" inert></i>
-            {{ localize "DND5E.LegendaryResistance.Action.Resist" }}
-        </button>
-    </div>
     {{/if}}
 
     {{#if concentrationBroken}}
@@ -27,17 +20,20 @@
         <strong>{{ localize "DND5E.ROLL.Status" }}</strong>
         {{ localize "DND5E.CONCENTRATION.Lost" }}
     </p>
-    {{else if canBreakConcentration}}
-    <div class="card-buttons">
-        <button type="button" data-action="breakConcentration">
-            <i class="fa-solid fa-ban" inert></i>
-            {{ localize "DND5E.CONCENTRATION.Action.Break" }}
-        </button>
-    </div>
     {{/if}}
 
-    {{#if deltas.length}}
-    {{> "dnd5e.card-deltas" }}
-    {{/if}}
+    {{!-- Rows --}}
+    {{> "dnd5e.card-rows" }}
+
+    {{!-- Buttons --}}
+    {{> "dnd5e.card-buttons" }}
+
 </div>
+
+{{!-- Rolls --}}
+{{> "dnd5e.card-rolls" }}
+
+{{!-- Deltas --}}
+{{#if deltas.length}}
+{{> "dnd5e.card-deltas" }}
 {{/if}}

--- a/templates/chat/save-summary.hbs
+++ b/templates/chat/save-summary.hbs
@@ -1,0 +1,30 @@
+<section class="icon-row">
+    <i class="fa-solid fa-bullseye" aria-label="{{ localize "DND5E.CHATMESSAGE.Row.Targets" }}"></i>
+    <ul class="pills unlist">
+        <li class="pill target transparent">{{ token.name }}</li>
+    </ul>
+</section>
+
+{{!-- Rolls --}}
+{{#each rolls}}
+<section class="icon-row with-buttons">
+    <i class="fa-fw fa-solid fa-dice" aria-label="{{ localize "DND5E.CHATMESSAGE.Row.Roll" }}"></i>
+    {{{ this }}}
+    {{#with @root.buttonGroups.resist}}
+    {{#each entries}}
+    <button type="button" class="icon" data-tooltip aria-label="{{ localize label }}"
+        {{#if (and canGroup (not singleton))}}data-group data-forward-action="{{ action}}"
+        {{else}}data-action="{{ action }}" data-index="{{ index }}"{{/if}}>
+        {{ dnd5e-icon icon }}
+    </button>
+    {{/each}}
+    {{/with}}
+</section>
+{{/each}}
+
+{{#if resisted}}
+<p class="supplement">
+    <strong>{{ localize "DND5E.ROLL.Status" }}</strong>
+    {{ localize "DND5E.LegendaryResistance.Resisted" }}
+</p>
+{{/if}}

--- a/templates/chat/usage-card.hbs
+++ b/templates/chat/usage-card.hbs
@@ -4,6 +4,10 @@
 {{> "dnd5e.card-face" }}
 {{/if}}
 
+{{#each summaries}}
+<div class="card-summary" data-message-id="{{ id }}" data-target-uuid="{{ token.uuid }}">{{{ html }}}</div>
+{{/each}}
+
 {{#if (and effects.length showTargets)}}
 <effect-application class="dnd5e2">
     {{#each effects}}


### PR DESCRIPTION
Adds compact styling for standalone saving throw cards, like death saves or concentration saves.

<img width="394" height="226" alt="image" src="https://github.com/user-attachments/assets/26ec4c43-d2ba-43b6-ad91-a7642aadf651" />

If a save card is spawned from a usage card, it will show the standalone card in the notification tray, but will be appended as a summary to the usage card that spawned it.

<img width="398" height="1026" alt="Screenshot From 2026-08-21 20-43-11" src="https://github.com/user-attachments/assets/5a06fb0d-6971-4be0-a26c-e64f7b4f9130" />

A damage card spawned by the same usage card is also now aware of any outcomes and will update its multipliers accordingly, including if an outcome comes in after the damage has already been rolled.

Some other changes:
- Deleting a usage card deletes all attached summary cards.
- Hovering a summary card will hover the token that rolled it.
- Added context menu options to select all summary outcomes, or just the successes or failures.

Most of these have also been applied to the check card.