### PR TITLE
BUG: Guard against effects not existing on cast activities

### DIFF
--- a/module/data/active-effect/base.mjs
+++ b/module/data/active-effect/base.mjs
@@ -61,7 +61,7 @@ export default class BaseEffectData extends ActiveEffectDataModel {
    */
   get isOnActivity() {
     return this.item
-      && (this.item.system.activities?.contents ?? []).some(a => a.effects.some(e => e._id === this.parent._id));
+      && (this.item.system.activities?.contents ?? []).some(a => a.effects?.some(e => e._id === this.parent._id));
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
In the v6 codebase moving into regions with effects breaks if the actor has an item with a cast activity. I think this is because the cast activity deletes effects from the schema data. https://github.com/foundryvtt/dnd5e/blob/6db48c81992abed2ebd84833d2ff741807d467fa/module/data/activity/cast-data.mjs#L19

This fix guards against effects not existing. Not sure if you want to do this another way.