### PR TITLE
Evaluate effect conditions during initial phase, set suppressed

### DIFF
--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -144,7 +144,7 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
    * @param {RollData} baseData
    */
   evaluateCondition(baseData) {
-    this.#conditionSuppressed = !this.conditions?.check(this.parent.getReplacementData(baseData));
+    this.#conditionSuppressed = this.conditions?.check(this.parent.getReplacementData(baseData)) === false;
   }
 
   /* -------------------------------------------- */

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -46,6 +46,7 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
 
   /** @inheritDoc */
   prepareBaseData() {
+    this.#conditionSuppressed = null;
     super.prepareBaseData();
     if ( this.isOnActivity ) this.parent.transfer = this.parent.disabled = false;
   }
@@ -71,6 +72,14 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
   get applicableType() {
     return "Actor";
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Cached evaluation of effect's condition during the initial application phase.
+   * @type {boolean|null}
+   */
+  #conditionSuppressed = null;
 
   /* -------------------------------------------- */
 
@@ -101,7 +110,7 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
    * @type {boolean}
    */
   get isSuppressed() {
-    return false;
+    return this.#conditionSuppressed ?? false;
   }
 
   /* -------------------------------------------- */
@@ -128,6 +137,16 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
 
   /* -------------------------------------------- */
   /*  Helpers                                     */
+  /* -------------------------------------------- */
+
+  /**
+   * Evaluate the effect's conditions and store the result.
+   * @param {RollData} baseData
+   */
+  evaluateCondition(baseData) {
+    this.#conditionSuppressed = !this.conditions?.check(this.parent.getReplacementData(baseData));
+  }
+
   /* -------------------------------------------- */
 
   /**

--- a/module/data/active-effect/condition.mjs
+++ b/module/data/active-effect/condition.mjs
@@ -50,7 +50,7 @@ export default class ConditionData extends foundry.data.ActiveEffectTypeDataMode
 
   /** @inheritDoc */
   get isSuppressed() {
-    return this.parent.actor?.system.traits?.ci?.value.has(this.type);
+    return super.isSuppressed || this.parent.actor?.system.traits?.ci?.value.has(this.type);
   }
 
   /* -------------------------------------------------- */

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -382,8 +382,10 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     // Pre-collect statuses so they can be reliably used for conditions
+    const replacementData = this.getRollData();
     if ( phase === "initial" ) {
       for ( const effect of this.allApplicableEffects() ) {
+        effect.system.evaluateCondition?.(replacementData);
         if ( effect.active ) for ( const statusId of effect.statuses ) this.statuses.add(statusId);
       }
     }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -382,8 +382,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     // Pre-collect statuses so they can be reliably used for conditions
-    const replacementData = this.getRollData();
     if ( phase === "initial" ) {
+      const replacementData = this.getRollData();
       for ( const effect of this.allApplicableEffects() ) {
         effect.system.evaluateCondition?.(replacementData);
         if ( effect.active ) for ( const statusId of effect.statuses ) this.statuses.add(statusId);

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -474,6 +474,7 @@ export default class Item5e extends SystemDocumentMixin(Item) {
     const changes = [];
     const replacementData = this.getRollData();
     for ( const effect of this.allApplicableEffects() ) {
+      effect.system.evaluateCondition?.(replacementData);
       if ( !effect.active ) continue;
       for ( const change of effect.system.changes ) {
         if ( (change.key === "") || !effect.shouldApplyChange(change, { replacementData, phase: change.phase }) ) {


### PR DESCRIPTION
Evaluates effect-wide conditions during the initial phase of application and use the result in `isSuppressed`. This allows conditions to prevent status effects from being applied but limits the data that can be evaluated using effect conditions.

Still evaluate the effect conditions for each phase, allowing individual changes to be disabled if another effect makes that condition invalid even if the whole effect is still enabled.