### PR TITLE
[#6357] Add riders directly to enchantment active effects

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2909,6 +2909,21 @@
     "magical": {
       "hint": "This enchantment is magical and should be disabled when magic isn't available.",
       "label": "Magical"
+    },
+    "rider": {
+      "activities": {
+        "hint": "These additional activities will be added to the enchanted item when this enchantment is applied, and removed when the enchantment is removed.",
+        "label": "Additional Activities"
+      },
+      "effects": {
+        "hint": "These additional effects will be added to the enchanted item when this enchantment is applied, and removed when the enchantment is removed.",
+        "label": "Additional Effects"
+      },
+      "items": {
+        "hint": "These additional items will be added to the creature when one of its items is enchanted, and will be removed if the enchantment is ever removed.",
+        "label": "Additional Items"
+      },
+      "label": "Attached"
     }
   },
   "Items": {

--- a/less/v2/inventory.less
+++ b/less/v2/inventory.less
@@ -456,6 +456,20 @@
       &:last-child { border: none; }
     }
 
+    .activity.rider {
+      padding-left: 20px;
+      position: relative;
+
+      &::before {
+        color: var(--activity-row-indent-color);
+        content: "━";
+        font-size: var(--font-size-12);
+        font-weight: bold;
+        inset: 14px auto auto 5px;
+        position: absolute;
+      }
+    }
+
     .activities .activity-row {
       position: relative;
       border-top: var(--activity-row-border);

--- a/less/v2/items.less
+++ b/less/v2/items.less
@@ -512,7 +512,7 @@
 
   /* Activities */
   .activities { gap: 0; }
-  .activities-list .activity:first-child { border-left: 4px solid var(--dnd5e-color-gold); }
+  .activities-list .activity:first-child:not(.rider) { border-left: 4px solid var(--dnd5e-color-gold); }
 
   /* Facilities */
   fieldset.harvesting {

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -293,11 +293,17 @@ export default class ItemSheet5e extends PrimarySheetMixin(DocumentSheet5e) {
       else arr.push(descriptor);
       return arr;
     }, []);
-    riders.forEach(r => {
+    context.activities.push(...riders.filter(r => {
+      let unmatched = true;
       for ( const origin of origins[r.id] ?? [] ) {
-        if ( origin in activityMap ) activityMap[origin].riders.add(r);
+        if ( origin in activityMap ) {
+          activityMap[origin].riders.add(r);
+          unmatched = false;
+        }
       }
-    });
+      r.isRider = true;
+      return unmatched;
+    }));
     return context;
   }
 

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -126,6 +126,16 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
   }
 
   /* -------------------------------------------- */
+
+  /**
+   * Does this active effect have rider activities or effects that should be tracked on the item.
+   * @type {boolean}
+   */
+  get trackRiders() {
+    return false;
+  }
+
+  /* -------------------------------------------- */
   /*  Event Listeners and Handlers                */
   /* -------------------------------------------- */
 

--- a/module/data/active-effect/_types.mjs
+++ b/module/data/active-effect/_types.mjs
@@ -8,6 +8,10 @@
 
 /**
  * @typedef EnchantmentActiveEffectSystemData
- * @property {EffectChangeData[]} changes  Changes to apply to the item.
- * @property {boolean} magical             Does this effect originate from a magical source?
+ * @property {EffectChangeData[]} changes    Changes to apply to the item.
+ * @property {boolean} magical               Does this effect originate from a magical source?
+ * @property {object} rider
+ * @property {Set<string>} rider.activities  Additional activities to add when enchantment is applied.
+ * @property {Set<string>} rider.effects     Additional effects to add when enchantment is applied.
+ * @property {Set<string>} rider.items       Additional items to add when enchantment is applied to item on actor.
  */

--- a/module/data/active-effect/enchantment.mjs
+++ b/module/data/active-effect/enchantment.mjs
@@ -3,7 +3,7 @@ import { bulkFromUuid, getHumanReadableAttributeLabel } from "../../utils.mjs";
 import ActiveEffectDataModel from "../abstract/active-effect-data-model.mjs";
 import { DamageData } from "../shared/damage-field.mjs";
 
-const { BooleanField } = foundry.data.fields;
+const { BooleanField, DocumentIdField, DocumentUUIDField, SchemaField, SetField } = foundry.data.fields;
 
 /**
  * @import { EnchantmentActiveEffectSystemData } from "./_types.mjs";
@@ -28,7 +28,12 @@ export default class EnchantmentData extends ActiveEffectDataModel {
   static defineSchema() {
     return {
       ...super.defineSchema(),
-      magical: new BooleanField({ initial: true })
+      magical: new BooleanField({ initial: true }),
+      rider: new SchemaField({
+        activities: new SetField(new DocumentIdField()),
+        effects: new SetField(new DocumentUUIDField({ type: "ActiveEffect" })),
+        items: new SetField(new DocumentUUIDField({ type: "Item" }))
+      })
     };
   }
 
@@ -59,6 +64,13 @@ export default class EnchantmentData extends ActiveEffectDataModel {
    */
   get item() {
     return this.parent.item;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  get trackRiders() {
+    return !this.isApplied && (!!this.rider?.activities?.size || !!this.rider?.effects?.size);
   }
 
   /* -------------------------------------------- */
@@ -274,14 +286,16 @@ export default class EnchantmentData extends ActiveEffectDataModel {
         activity = item.system.activities?.get(activityId);
       }
       profile = activity?.effects.find(e => e._id === enchantmentProfile);
+    } else {
+      item = (await fromUuid(this.parent._stats.compendiumSource))?.item;
     }
 
-    if ( !profile || !item ) return [];
+    const documents = await bulkFromUuid([...this.rider.effects, ...this.rider.items, ...(profile?.riders.item ?? [])]);
 
     // Create Activities
     const riderActivities = {};
     let riderEffects = [];
-    for ( const id of profile.riders.activity ) {
+    for ( const id of [...this.rider.activities, ...(profile?.riders.activity ?? [])] ) {
       const activity = item?.system.activities.get(id);
       if ( !activity ) continue;
       const activityData = activity.toObject();
@@ -298,8 +312,9 @@ export default class EnchantmentData extends ActiveEffectDataModel {
     });
 
     // Create Effects
-    riderEffects.push(...profile.riders.effect.map(id => {
-      const effectData = item.effects.get(id)?.toObject();
+    const effectIds = [...this.rider.effects, ...(profile?.riders.effect ?? [])];
+    riderEffects.push(...effectIds.map(id => {
+      const effectData = (documents.get(id) ?? item?.effects.get(id))?.toObject();
       if ( effectData ) {
         delete effectData._id;
         delete effectData.flags?.dnd5e?.rider;
@@ -315,9 +330,8 @@ export default class EnchantmentData extends ActiveEffectDataModel {
 
     // Create Items
     if ( this.item.isEmbedded ) {
-      const items = await bulkFromUuid(profile.riders.item);
       const riderItems = await Item5e.createWithContents(
-        items.values(), {
+        itemUuids.map(uuid => documents.get(uuid)).filter(_ => _), {
           transformAll: item => {
             const itemData = item.clone({}, { keepId: true }).toObject();
             foundry.utils.setProperty(itemData, "flags.dnd5e.dependentOn", this.parent.uuid);
@@ -343,5 +357,26 @@ export default class EnchantmentData extends ActiveEffectDataModel {
         item: this.isApplied ? this.item : true, prefixItemName: false
       })
     };
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async getSheetData(context) {
+    if ( this.isApplied ) return;
+
+    context.additionalChangesFields.unshift({
+      field: context.systemFields.rider.fields.effects,
+      value: context.source.system.rider.effects
+    }, {
+      field: context.systemFields.rider.fields.items,
+      value: context.source.system.rider.items
+    });
+
+    if ( this.item?.system.activities ) context.additionalChangesFields.unshift({
+      field: context.systemFields.rider.fields.activities,
+      options: this.item.system.activities.map(a => ({ value: a.id, label: a.name })),
+      value: context.source.system.rider.activities
+    });
   }
 }

--- a/module/data/item/templates/activities.mjs
+++ b/module/data/item/templates/activities.mjs
@@ -433,17 +433,7 @@ export default class ActivitiesTemplate extends SystemDataModel {
       });
       return riders;
     }, { activity: new Set(), effect: new Set() });
-    if ( !riders.activity.size && !riders.effect.size ) {
-      foundry.utils.setProperty(changed, "flags.dnd5e.riders", _del);
-    } else {
-      foundry.utils.setProperty(changed, "flags.dnd5e.riders", Object.entries(riders)
-        .reduce((updates, [key, value]) => {
-          if ( value.size ) updates[key] = Array.from(value);
-          else updates[key] = _del;
-          return updates;
-        }, {})
-      );
-    }
+    this.parent.updateRiderFlags(riders, changed);
 
     if ( !this.parent.isEmbedded ) return;
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1156,6 +1156,14 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  _onCreateDescendantDocuments(parent, collection, documents, data, options, userId) {
+    super._onCreateDescendantDocuments(parent, collection, documents, data, options, userId);
+    if ( (userId === game.user.id) && (collection === "effects") ) this.updateRiderFlags();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   async _preUpdate(changed, options, user) {
     if ( (await super._preUpdate(changed, options, user)) === false ) return false;
     await this.system.preUpdateActivities?.(changed, options, user);
@@ -1173,12 +1181,71 @@ export default class Item5e extends SystemDocumentMixin(Item) {
   /* -------------------------------------------- */
 
   /** @inheritDoc */
+  _onUpdateDescendantDocuments(parent, collection, documents, changes, options, userId) {
+    super._onUpdateDescendantDocuments(parent, collection, documents, changes, options, userId);
+    if ( (userId === game.user.id) && (collection === "effects") ) this.updateRiderFlags();
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
   async _onDelete(options, userId) {
     super._onDelete(options, userId);
     await this.system.onDeleteActivities?.(options, userId);
     if ( game.user.isActiveGM ) this.effects.forEach(e => e.getDependents().forEach(e => e.delete()));
     if ( userId !== game.user.id ) return;
     this.parent?.endConcentration?.(this);
+  }
+
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  _onDeleteDescendantDocuments(parent, collection, documents, ids, options, userId) {
+    super._onDeleteDescendantDocuments(parent, collection, documents, ids, options, userId);
+    if ( (userId === game.user.id) && (collection === "effects") ) this.updateRiderFlags();
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Track changes to rider activities & effects and store values in flag.
+   * @param {{ activity: Set<string>, effect: Set<string> }} [activityRiders]  Prepared riders from activities.
+   * @param {object} [changes]                                                 Ongoing change from a pre-update.
+   */
+  updateRiderFlags(activityRiders, changes) {
+    const riders = activityRiders ?? { activity: new Set(), effect: new Set() };
+
+    // Consolidate riders from included enchantments
+    for ( const effect of this.effects ) {
+      if ( !effect.system.trackRiders ) continue;
+      effect.system.rider.activities?.forEach(a => riders.activity.add(a));
+    }
+
+    // Consolidate riders from activities if not already provided
+    if ( !activityRiders && this.system.activities ) {
+      for ( const activity of this.system.activities.getByType("enchant") ) {
+        activity.effects.forEach(profile => {
+          profile.riders.activity.forEach(a => riders.activity.add(a));
+          profile.riders.effect.forEach(e => riders.effect.add(e));
+        });
+      }
+    }
+
+    // Completely remove flag if no riders set
+    if ( !riders.activity.size && !riders.effect.size ) {
+      if ( changes ) foundry.utils.setProperty(changes, "flags.dnd5e.riders", _del);
+      else this.unsetFlag("dnd5e", "riders");
+    }
+
+    // Selectively add/remove categories and set flag
+    else {
+      const update = Object.entries(riders).reduce((update, [key, value]) => {
+        update[key] = value.size ? Array.from(value) : _del;
+        return update;
+      }, {});
+      if ( changes ) foundry.utils.setProperty(changes, "flags.dnd5e.riders", update);
+      else this.update({ flags: { dnd5e: { riders: { ...update } } } });
+    }
   }
 
   /* -------------------------------------------- */

--- a/templates/shared/activities.hbs
+++ b/templates/shared/activities.hbs
@@ -19,7 +19,8 @@
                 {{#each activities}}
 
                 {{!-- Activities --}}
-                <li class="item activity" data-activity-id="{{ id }}" data-uuid="{{ uuid }}">
+                <li class="item activity {{~#if isRider}} rider{{/if}}" data-activity-id="{{ id }}"
+                    data-uuid="{{ uuid }}">
 
                     {{!-- Primary Activity --}}
                     <div class="item-row draggable">


### PR DESCRIPTION
Adds the ability to specify rider effects and items on enchantments (both using UUIDs) and rider activities (using IDs, but only if the enchantment is embedded in an item).

Adjusts the API for how rider statuses as well as enchantment riders are added using a new `system.collectRiders` method to give AE types full control over riders.

Closes #6357