### PR TITLE
V6 Concentration Effect Fixes

### DIFF
--- a/module/applications/components/effects.mjs
+++ b/module/applications/components/effects.mjs
@@ -177,7 +177,7 @@ export default class EffectsElement extends (foundry.applications.elements.Adopt
     // Iterate over active effects, classifying them into categories
     for ( const e of effects ) {
       if ( e.isConcealed ) continue;
-      if ( e.type === "condition" ) continue;
+      if ( ( e.type === "condition" ) && !e.statuses.has(CONFIG.specialStatusEffects.CONCENTRATING) ) continue;
       if ( e.isAppliedEnchantment ) {
         if ( e.disabled || e.duration.expired ) categories.enchantmentInactive.effects.push(e);
         else categories.enchantmentActive.effects.push(e);

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -889,10 +889,8 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     const newEncumbrance = data.statuses?.[0];
     const name = this.name;
 
-    // Delete expired concentration effects immediately, and other expired effects outside of combat
+    // If out of combat & effect expires, delete it
     if ( game.user.isActiveGM && data.duration?.expired ) {
-      const isConcentration = this.statuses.has(CONFIG.specialStatusEffects.CONCENTRATING);
-      if ( isConcentration ) return this.delete();
       const actor = this.isAppliedEnchantment ? this.parent.parent : this.parent;
       const combat = this.start?.combat ?? game.combat;
       if ( !combat?.getCombatantsByActor(actor).length ) return this.delete();

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -889,8 +889,10 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     const newEncumbrance = data.statuses?.[0];
     const name = this.name;
 
-    // If out of combat & effect expires, delete it
+    // Delete expired concentration effects immediately, and other expired effects outside of combat
     if ( game.user.isActiveGM && data.duration?.expired ) {
+      const isConcentration = this.statuses.has(CONFIG.specialStatusEffects.CONCENTRATING);
+      if ( isConcentration ) return this.delete();
       const actor = this.isAppliedEnchantment ? this.parent.parent : this.parent;
       const combat = this.start?.combat ?? game.combat;
       if ( !combat?.getCombatantsByActor(actor).length ) return this.delete();

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -244,7 +244,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( !limit ) return concentration;
 
     for ( const effect of this.effects ) {
-      if ( !effect.statuses.has(CONFIG.specialStatusEffects.CONCENTRATING) ) continue;
+      if ( !effect.active || !effect.statuses.has(CONFIG.specialStatusEffects.CONCENTRATING) ) continue;
       const data = effect.getFlag("dnd5e", "item");
       concentration.effects.add(effect);
       if ( data ) {


### PR DESCRIPTION
Fixes the following:

- Concentration effects no longer show up in effects panel
- When concentration expires the effect remains (not visible), but the spell still picked up it was concetrating (swirly spell icon) in the spell list ui.

This PR:
- Removes the concentration effect when it expires.
- Restores visibility in the UI
- Adds a guard aginst showing in active put still present concentration effects on an actor.