### PR TITLE
Evaluate conditions as late as possible, add condition warnings

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2787,7 +2787,11 @@
   "Suppressed": {
     "Hint": "Source item must be equipped or attuned to activate these"
   },
-  "Tab": "Effects"
+  "Tab": "Effects",
+  "Warning": {
+    "RollCondition": "Effect conditions cannot reference 'roll.' properties. Move this condition into the individual changes for the effect to be applied.",
+    "StatusCondition": "Effect that grant statuses cannot also be conditional on statuses. Move this condition into the individual changes for the effect to be applied."
+  }
 },
 
 "DND5E.ENCHANT": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -2790,7 +2790,7 @@
   "Tab": "Effects",
   "Warning": {
     "RollCondition": "Effect conditions cannot reference 'roll.' properties. Move this condition into the individual changes for the effect to be applied.",
-    "StatusCondition": "Effect that grant statuses cannot also be conditional on statuses. Move this condition into the individual changes for the effect to be applied."
+    "StatusCondition": "Effects that grant statuses cannot also be conditional on statuses. Move this condition into the individual changes for the effect to be applied."
   }
 },
 

--- a/less/v2/apps.less
+++ b/less/v2/apps.less
@@ -2005,12 +2005,6 @@ dialog.dnd5e2.application {
   }
 }
 
-
-.active-effect-config section.changes header div.key i {
-  margin-left: 0.25rem;
-  cursor: help;
-}
-
 /* ---------------------------------- */
 /*  Collapsible Content               */
 /* ---------------------------------- */

--- a/less/v2/sheets.less
+++ b/less/v2/sheets.less
@@ -284,6 +284,7 @@ body.detached .dnd5e2.sheet .tab { max-height: unset; }
     font-weight: bold;
     text-align: center;
   }
+  .scrollable > .note { margin-inline: 8px; }
   .tab.changes {
     overflow-y: auto;
     padding-block-end: 45px;

--- a/module/applications/active-effect/active-effect-sheet.mjs
+++ b/module/applications/active-effect/active-effect-sheet.mjs
@@ -100,6 +100,14 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
    * @protected
    */
   async _prepareDetailsContext(context, options) {
+    const { statuses, system } = context.document;
+    if ( system.conditions ) {
+      if ( statuses.size && system.conditions.some(f => f.k?.startsWith?.("statuses")) ) {
+        context.conditionsWarning = "DND5E.EFFECT.Warning.StatusCondition";
+      } else if ( system.conditions.some(f => f.k?.startsWith?.("roll.")) ) {
+        context.conditionsWarning = "DND5E.EFFECT.Warning.RollCondition";
+      }
+    }
     return context;
   }
 

--- a/module/applications/active-effect/active-effect-sheet.mjs
+++ b/module/applications/active-effect/active-effect-sheet.mjs
@@ -102,7 +102,7 @@ export default class ActiveEffectSheet5e extends ApplicationV2Mixin(ActiveEffect
   async _prepareDetailsContext(context, options) {
     const { statuses, system } = context.document;
     if ( system.conditions ) {
-      if ( statuses.size && system.conditions.some(f => f.k?.startsWith?.("statuses")) ) {
+      if ( statuses.size && system.conditions.some(f => f.k?.startsWith?.("statuses.")) ) {
         context.conditionsWarning = "DND5E.EFFECT.Warning.StatusCondition";
       } else if ( system.conditions.some(f => f.k?.startsWith?.("roll.")) ) {
         context.conditionsWarning = "DND5E.EFFECT.Warning.RollCondition";

--- a/module/data/abstract/active-effect-data-model.mjs
+++ b/module/data/abstract/active-effect-data-model.mjs
@@ -143,9 +143,11 @@ export default class ActiveEffectDataModel extends foundry.data.ActiveEffectType
 
   /**
    * Evaluate the effect's conditions and store the result.
-   * @param {RollData} baseData
+   * @param {RollData} [baseData]
    */
   evaluateCondition(baseData) {
+    if ( this.#conditionSuppressed !== null ) return;
+    baseData ??= this.parent.target?.getRollData() ?? {};
     this.#conditionSuppressed = this.conditions?.check(this.parent.getReplacementData(baseData)) === false;
   }
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -173,6 +173,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
 
   /** @inheritDoc */
   get isSuppressed() {
+    if ( super.isSuppressed ) return true;
     if ( this.system.magical && this.actor?.statuses.has("antimagic") ) return true;
     if ( this.type === "enchantment" ) return false;
     if ( this.type === "condition" ) return false;
@@ -602,13 +603,15 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  shouldApplyChange(change, options) {
+  shouldApplyChange(change, options={}) {
     if ( !super.shouldApplyChange(change, options) ) return false;
-    const conditionData = options?.replacementData;
-    if ( conditionData && !CONFIG.ActiveEffect.changeTypes[change.type]?.skipConditions ) {
-      if ( this.system.conditions?.check(conditionData) === false ) return false;
-      if ( change.conditions?.check(conditionData) === false ) return false;
+    const conditionData = options.replacementData;
+    if ( this.system.evaluateCondition && this.system.changes.some(c => c.phase === options.phase) ) {
+      this.system.evaluateCondition(conditionData);
+      if ( this.isSuppressed ) return false;
     }
+    if ( conditionData && !CONFIG.ActiveEffect.changeTypes[change.type]?.skipConditions
+      && (change.conditions?.check(conditionData) === false) ) return false;
     change.applied = true;
     return true;
   }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -606,7 +606,7 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
   shouldApplyChange(change, options={}) {
     if ( !super.shouldApplyChange(change, options) ) return false;
     const conditionData = options.replacementData;
-    if ( this.system.evaluateCondition && this.system.changes.some(c => c.phase === options.phase) ) {
+    if ( this.system.evaluateCondition ) {
       this.system.evaluateCondition(conditionData);
       if ( this.isSuppressed ) return false;
     }

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -387,7 +387,7 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     if ( phase === "initial" ) {
       const replacementData = this.getRollData();
       for ( const effect of this.allApplicableEffects() ) {
-        effect.system.evaluateCondition?.(replacementData);
+        if ( effect.statuses.size ) effect.system.evaluateCondition?.(replacementData);
         if ( effect.active ) for ( const statusId of effect.statuses ) this.statuses.add(statusId);
       }
     }
@@ -399,6 +399,15 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     }
 
     super.applyActiveEffects(phase);
+
+    // Ensure conditions are evaluated for all effects even if they don't have changes
+    if ( phase === "final" ) {
+      const replacementData = this.getRollData();
+      for ( const effect of this.allApplicableEffects() ) {
+        effect.system.evaluateCondition?.(replacementData);
+      }
+    }
+
     if ( (phase !== "initial") || !this.system.isCreature || !dnd5e.settings.tokenSizeSync ) return;
 
     // Translate this Actor's size category into Token changes

--- a/module/filter.mjs
+++ b/module/filter.mjs
@@ -33,10 +33,21 @@ export class Filter {
     try {
       if ( foundry.utils.isEmpty(this.#definition) ) return true;
       else return performCheck(data, this.#definition);
-    } catch(err) {
+    } catch (err) {
       console.error(err);
       return false;
     }
+  }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Evaluate the callback for each individual filter, returning early if the callback returns `true` for any filter.
+   * @param {Function} cb
+   * @returns {boolean}
+   */
+  some(cb) {
+    return _some(cb, this.#definition);
   }
 }
 
@@ -96,6 +107,23 @@ function _check(data, keyPath, value, operation="exact") {
   const comparison = COMPARISON_FUNCTIONS[operation];
   if ( !comparison ) throw new Error(`Comparison function "${operation}" could not be found.`);
   return comparison(foundry.utils.getProperty(data, keyPath), value);
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Evaluate the callback for each individual filter, returning early if the callback returns `true` for any filter.
+ * @param {Function} cb
+ * @param {FilterDescription|FilterDescription[]} filter
+ * @returns {boolean}
+ * @internal
+ */
+function _some(cb, filter=[]) {
+  if ( Array.isArray(filter) && filter.some(f => _some(cb, f)) ) return true;
+  if ( !foundry.utils.isPlainObject(filter) ) return false;
+  if ( cb(filter) === true ) return true;
+  if ( filter.o in OPERATOR_FUNCTIONS ) return _some(cb, filter.v);
+  return false;
 }
 
 /* -------------------------------------------- */

--- a/templates/effects/effect-details.hbs
+++ b/templates/effects/effect-details.hbs
@@ -5,6 +5,9 @@
 
     {{#if systemFields.conditions}}
     {{ formGroup systemFields.conditions value=source.system.conditions rootId=partId }}
+    {{#if conditionsWarning}}
+    <div class="note warn">{{ localize conditionsWarning }}</div>
+    {{/if}}
     {{/if}}
 
     {{#if isActorEffect}}


### PR DESCRIPTION
Rather than evaluating all effect conditions before statuses are applied, instead only evaluate conditions for effects that apply their own statuses at that point. Other conditions are evaluated during the earliest phase of any of their changes. Any effect that doesn't have changes is checked during the final phase.

Also introduces warnings to the active effect config sheet when a condition key is used that won't work in an effect condition. This includes using a `statuses.` key while also applying a status effect or using any `roll.` property.