### PR TITLE
Allow 'turns'-duration effects to have `null` expiry

### DIFF
--- a/module/data/shared/duration-field.mjs
+++ b/module/data/shared/duration-field.mjs
@@ -16,7 +16,7 @@ export default class DurationField extends SchemaField {
     fields = {
       value: new FormulaField({ deterministic: true }),
       units: new StringField({ required: true, blank: false, initial: "inst" }),
-      expiry: new StringField(),
+      expiry: new StringField({ nullable: true, blank: false, initial: null }),
       special: new StringField(),
       ...fields
     };
@@ -98,6 +98,7 @@ export default class DurationField extends SchemaField {
       case "year": units = "years"; break;
       default: return expiry ? { expiry, value: null } : {};
     }
-    return { value, units, expiry: expiry ?? "turnStart" };
+    if ( units !== "turns" ) expiry ??= "turnStart";
+    return { value, units, expiry };
   }
 }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -842,10 +842,10 @@ export default class ActiveEffect5e extends DependentDocumentMixin(ActiveEffect)
     const { units, expiry } = this.duration;
     if ( expiry && !this.expirySupportsDuration(expiry) ) this.updateSource({ "duration.value": null });
 
-    // Default combat-duration expiry to turnStart to avoid effect expiry at round turnover
+    // Default non-turns expiry to turnStart to avoid effect expiry at round turnover
     const actor = this.isAppliedEnchantment ? this.parent.parent : this.parent;
     if ( !(actor instanceof Actor) || !this.start?.combat?.started ) return;
-    if ( !expiry && (units === "rounds") ) this.updateSource({ "duration.expiry": "turnStart" });
+    if ( !expiry && (units !== "turns") ) this.updateSource({ "duration.expiry": "turnStart" });
   }
 
   /* -------------------------------------------- */

--- a/module/documents/activity/mixin.mjs
+++ b/module/documents/activity/mixin.mjs
@@ -1205,7 +1205,7 @@ export default function ActivityMixin(Base) {
         if ( !Number.isFinite(effect.duration.value) ) {
           const duration = this.duration?.getEffectData();
           if ( !foundry.utils.isEmpty(duration) ) changes.duration = duration;
-        } else {
+        } else if ( effect.duration.units !== "turns" ) {
           changes.duration = { expiry: "turnStart" };
         }
       }


### PR DESCRIPTION
Pending a core release with https://github.com/foundryvtt/foundryvtt/issues/14725 resolved, this'll allow someone to mark "1 turn" rather than "0 turns, turnEnd expiry" to have an effect expire after 1 turn. 

Minor change to `DurationField`'s `expiry` field so that null expiry is represented by `null`, rather than `""`. The latter is coerced to `turnStart` during document creation, since core disallows blank expiry and its `initial` function results in "turnStart" for a finite duration value.