### PR TITLE
[#7367] Allow customizable death save thresholds

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2534,7 +2534,7 @@
 "DND5E.DeathSaveFailures": "Failures",
 "DND5E.DeathSaveRoll": "Roll a Death Saving Throw",
 "DND5E.DeathSavingThrow": "Death Saving Throw",
-"DND5E.DeathSaveUnnecessary": "You do not need to roll death saves because you have a positive number of hit points or have already reached 3 successes or failures.",
+"DND5E.DeathSaveUnnecessary": "You do not need to roll death saves because you have a positive number of hit points or have already reached the required successes or failures.",
 
 "DND5E.DEATH": {
   "FIELDS": {
@@ -2550,9 +2550,9 @@
     }
   },
   "Outcome": {
-    "death": "{name} has died with 3 death save failures!",
+    "death": "{name} has died after reaching the required number of death save failures!",
     "revive": "{name} critically succeeded on a death saving throw and has regained 1 Hit Point!",
-    "stable": "{name} has survived with 3 death save successes and is now stable!"
+    "stable": "{name} has survived after reaching the required number of death save successes and is now stable!"
   }
 },
 
@@ -6983,7 +6983,7 @@
     },
     "AutoApplyDowned": {
       "Name": "Auto-Apply Downed",
-      "Hint": "Automatically mark a creature as Dead or Unconscious when it is reduced to 0 HP in combat. Unimportant NPCs are marked Dead. Important NPCs and PCs are marked Unconscious first, and Dead if they fail three death saving throws.",
+      "Hint": "Automatically mark a creature as Dead or Unconscious when it is reduced to 0 HP in combat. Unimportant NPCs are marked Dead. Important NPCs and PCs are marked Unconscious first, and Dead when they reach their failed death save threshold.",
       "None": "Never",
       "DeadOnly": "For NPCs (dead only)",
       "NPCs": "For NPCs (dead and unconscious)",

--- a/module/data/actor/_types.mjs
+++ b/module/data/actor/_types.mjs
@@ -20,6 +20,9 @@
  * @property {Omit<RollConfigData, "ability">} attributes.death
  * @property {number} attributes.death.success            Number of successful death saves.
  * @property {number} attributes.death.failure            Number of failed death saves.
+ * @property {object} attributes.death.threshold           Death save thresholds.
+ * @property {number} attributes.death.threshold.success   Successes required to stabilize.
+ * @property {number} attributes.death.threshold.failure   Failures required to die.
  * @property {number} attributes.inspiration              Does this character have inspiration?
  * @property {object} attributes.piety
  * @property {number} attributes.piety.value              The creature's piety score.
@@ -138,6 +141,9 @@
  * @property {Omit<RollConfigData, "ability">} attributes.death
  * @property {number} attributes.death.success        Number of successful death saves.
  * @property {number} attributes.death.failure        Number of failed death saves.
+ * @property {object} attributes.death.threshold      Death save thresholds.
+ * @property {number} attributes.death.threshold.success  Successes required to stabilize.
+ * @property {number} attributes.death.threshold.failure  Failures required to die.
  * @property {object} attributes.price
  * @property {number|null} attributes.price.value     The creature's value in the specified denomination.
  * @property {string} attributes.price.denomination   The currency denomination.

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -79,8 +79,8 @@ export default class CharacterData extends CreatureTemplate {
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveFailures"
           }),
           threshold: new SchemaField({
-            success: new NumberField({ integer: true, min: 1, initial: 3 }),
-            failure: new NumberField({ integer: true, min: 1, initial: 3 })
+            success: new NumberField({ integer: true, min: 1, initial: 3, nullable: false }),
+            failure: new NumberField({ integer: true, min: 1, initial: 3, nullable: false })
           }, { persisted: false }),
           bonuses: new SchemaField({}, { persisted: false })
         }, { label: "DND5E.DeathSave", labelPrefix: "DND5E.DEATH.FIELDS.attributes.death.roll." }),

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -78,6 +78,10 @@ export default class CharacterData extends CreatureTemplate {
           failure: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveFailures"
           }),
+          threshold: new SchemaField({
+            success: new NumberField({ integer: true, min: 1, initial: 3 }),
+            failure: new NumberField({ integer: true, min: 1, initial: 3 })
+          }, { persisted: false }),
           bonuses: new SchemaField({}, { persisted: false })
         }, { label: "DND5E.DeathSave", labelPrefix: "DND5E.DEATH.FIELDS.attributes.death.roll." }),
         inspiration: new BooleanField({ required: true, label: "DND5E.Inspiration" }),

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -75,6 +75,10 @@ export default class NPCData extends CreatureTemplate {
           failure: new NumberField({
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveFailures"
           }),
+          threshold: new SchemaField({
+            success: new NumberField({ integer: true, min: 1, initial: 3 }),
+            failure: new NumberField({ integer: true, min: 1, initial: 3 })
+          }, { persisted: false }),
           bonuses: new SchemaField({}, { persisted: false })
         }, { label: "DND5E.DeathSave", labelPrefix: "DND5E.DEATH.FIELDS.attributes.death.roll." }),
         price: new SchemaField({
@@ -577,13 +581,13 @@ export default class NPCData extends CreatureTemplate {
     const messageUpdate = { _id: message.id, "system.resisted": true };
 
     // Legendary resistance turns the failed save into a success: revert this save's failure and credit a success
-    // (which may stabilize the creature at three).
+    // (which may stabilize the creature at its success threshold).
     if ( message.system.type === "death" ) {
       const priorFailure = message.system.deltas?.actor
         ?.find(d => d.keyPath === "system.attributes.death.failure")?.delta ?? 0;
       const failure = this.attributes.death.failure - priorFailure;
       const { outcome, updates } = AttributesFields.applyDeathSaveResult({
-        failure, success: this.attributes.death.success
+        failure, success: this.attributes.death.success, threshold: this.attributes.death.threshold
       }, { isSuccess: true });
       updates["system.attributes.death.failure"] ??= failure;
       Object.assign(actorUpdate, updates);

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -76,8 +76,8 @@ export default class NPCData extends CreatureTemplate {
             required: true, nullable: false, integer: true, min: 0, initial: 0, label: "DND5E.DeathSaveFailures"
           }),
           threshold: new SchemaField({
-            success: new NumberField({ integer: true, min: 1, initial: 3 }),
-            failure: new NumberField({ integer: true, min: 1, initial: 3 })
+            success: new NumberField({ integer: true, min: 1, initial: 3, nullable: false }),
+            failure: new NumberField({ integer: true, min: 1, initial: 3, nullable: false })
           }, { persisted: false }),
           bonuses: new SchemaField({}, { persisted: false })
         }, { label: "DND5E.DeathSave", labelPrefix: "DND5E.DEATH.FIELDS.attributes.death.roll." }),

--- a/module/data/actor/templates/attributes.mjs
+++ b/module/data/actor/templates/attributes.mjs
@@ -718,14 +718,15 @@ export default class AttributesFields {
   /* -------------------------------------------- */
 
   /**
-   * Trigger auto-downed logic if failed three death saves.
+   * Trigger auto-downed logic if the failed death save threshold is reached.
    * @this {CharacterData|NPCData}
    * @param {object} changed  The differential data that was changed relative to the document's prior values.
    * @param {object} options  Additional options which modify the update request.
    * @param {string} userId   The id of the User requesting the document update.
    */
   static async onUpdateDeathSaves(changed, options, userId) {
-    if ( changed.system?.attributes?.death?.failure !== 3 ) return;
+    const failure = changed.system?.attributes?.death?.failure;
+    if ( (failure === undefined) || (failure < this.attributes.death.threshold.failure) ) return;
 
     // If hp update is included, updateDowned will be called in onUpdateHP, so exit early
     if ( changed.system.attributes.hp ) return;
@@ -738,7 +739,10 @@ export default class AttributesFields {
 
   /**
    * Determine the actor updates and terminal outcome resulting from a death saving throw.
-   * @param {{ success: number, failure: number }} death  Current death save success/failure counts.
+   * @param {object} death                            Current death save data.
+   * @param {number} death.success                    Number of successful death saves.
+   * @param {number} death.failure                    Number of failed death saves.
+   * @param {{ success: number, failure: number }} death.threshold  Success and failure thresholds.
    * @param {object} result
    * @param {boolean} result.isSuccess                    Whether the save succeeded.
    * @param {boolean} [result.isCritical]                 Whether the save was a natural 20.
@@ -761,8 +765,8 @@ export default class AttributesFields {
         outcome = "revive";
       }
 
-      // Normal success - stabilize on the third.
-      else if ( successes >= 3 ) {
+      // Normal success - stabilize when the success threshold is reached.
+      else if ( successes >= death.threshold.success ) {
         Object.assign(updates, {
           "system.attributes.death.success": 0,
           "system.attributes.death.failure": 0
@@ -770,13 +774,13 @@ export default class AttributesFields {
         outcome = "stable";
       }
 
-      else updates["system.attributes.death.success"] = Math.clamp(successes, 0, 3);
+      else updates["system.attributes.death.success"] = Math.clamp(successes, 0, death.threshold.success);
     }
 
     else {
-      const failures = Math.clamp((death.failure || 0) + (isFumble ? 2 : 1), 0, 3);
+      const failures = Math.clamp((death.failure || 0) + (isFumble ? 2 : 1), 0, death.threshold.failure);
       updates["system.attributes.death.failure"] = failures;
-      if ( failures >= 3 ) outcome = "death";
+      if ( failures >= death.threshold.failure ) outcome = "death";
     }
 
     return { outcome, updates };

--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1672,8 +1672,9 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
     const death = this.system.attributes?.death;
     if ( !death ) throw new Error(`Actors of the type '${this.type}' don't support death saves.`);
 
-    // Display a warning if we are not at zero HP or if we already have reached 3
-    if ( (this.system.attributes.hp.value > 0) || (death.failure >= 3) || (death.success >= 3) ) {
+    // Display a warning if we are not at zero HP or if we already reached a death save threshold.
+    if ( (this.system.attributes.hp.value > 0) || (death.failure >= death.threshold.failure)
+      || (death.success >= death.threshold.success) ) {
       ui.notifications.warn("DND5E.DeathSaveUnnecessary", { localize: true });
       return null;
     }
@@ -3665,7 +3666,8 @@ export default class Actor5e extends SystemDocumentMixin(Actor) {
 
     // Do not auto-apply statuses outside of combat or if already dead
     if ( !this.inCombat || isDead ) return;
-    const failedDeathSaves = this.system.attributes.death.failure >= 3;
+    const death = this.system.attributes.death;
+    const failedDeathSaves = death.failure >= death.threshold.failure;
     let toApply = null;
     if ( this.type === "npc" ) {
       if ( !this.system.traits.important ) toApply = "dead";


### PR DESCRIPTION
Add non-persisted success and failure thresholds that Active Effects can modify, and use them throughout death save and auto-death handling.

```
Key: system.attributes.death.threshold.failure
Mode: Override
Value: 5
```

```
Key: system.attributes.death.threshold.failure
Mode: Add
Value: 2
```