### PR TITLE
[#7429] Refactor summoned token creation for non gm owner issue

### DIFF
--- a/module/canvas/token-placement.mjs
+++ b/module/canvas/token-placement.mjs
@@ -20,7 +20,7 @@ export default class TokenPlacement extends BasePlacement {
     const uniqueTokens = new Map();
     const base = this.config.origin?.elevation ?? canvas.level.elevation.base; // Use the summoner's elevation.
     await canvas.tokens.placeTokens(this.config.tokens.map(t => ({
-      ...t.toObject(), elevation: base, level: canvas.level.id
+      ...t.toObject(), actorId: t.parent.id, elevation: base, level: canvas.level.id
     })), {
       create: false,
       onChange: ({ document, preview }) => {

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -154,14 +154,7 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
     const tokensData = [];
     try {
       // Figure out where to place the summons
-      const tokenUpdates = {};
-      if ( actor.prototypeToken.randomImg && !game.user.can("FILES_BROWSE") ) {
-        tokenUpdates.texture ??= {};
-        tokenUpdates.texture.src ??= actor.img;
-        ui.notifications.warn("DND5E.SUMMON.Warning.Wildcard", { localize: true });
-      }
-      const prototypeToken = await actor.getTokenDocument(tokenUpdates, { parent: canvas.scene });
-      const placements = await this.getPlacement(prototypeToken, profile, options);
+      const placements = await this.getPlacement(actor.prototypeToken, profile, options);
 
       for ( const placement of placements ) {
         // Prepare changes to actor data, re-calculating per-token for potentially random values
@@ -519,11 +512,14 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
    * @returns {object}
    */
   async getTokenData({ actor, placement, tokenUpdates, actorUpdates }) {
-    const prototypeToken = placement.prototypeToken;
+    if ( actor.prototypeToken.randomImg && !game.user.can("FILES_BROWSE") ) {
+      tokenUpdates.texture ??= {};
+      tokenUpdates.texture.src ??= actor.img;
+      ui.notifications.warn("DND5E.SUMMON.Warning.Wildcard", { localize: true });
+    }
+
     delete placement.prototypeToken;
-    const tokenDocument = prototypeToken.clone(
-      foundry.utils.mergeObject(placement, tokenUpdates), { parent: canvas.scene }
-    );
+    const tokenDocument = await actor.getTokenDocument(foundry.utils.mergeObject(placement, tokenUpdates));
 
     // Linked summons require more explicit updates before token creation
     if ( tokenDocument.actorLink ) {

--- a/module/documents/activity/summon.mjs
+++ b/module/documents/activity/summon.mjs
@@ -154,7 +154,14 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
     const tokensData = [];
     try {
       // Figure out where to place the summons
-      const placements = await this.getPlacement(actor.prototypeToken, profile, options);
+      const tokenUpdates = {};
+      if ( actor.prototypeToken.randomImg && !game.user.can("FILES_BROWSE") ) {
+        tokenUpdates.texture ??= {};
+        tokenUpdates.texture.src ??= actor.img;
+        ui.notifications.warn("DND5E.SUMMON.Warning.Wildcard", { localize: true });
+      }
+      const prototypeToken = await actor.getTokenDocument(tokenUpdates, { parent: canvas.scene });
+      const placements = await this.getPlacement(prototypeToken, profile, options);
 
       for ( const placement of placements ) {
         // Prepare changes to actor data, re-calculating per-token for potentially random values
@@ -512,14 +519,11 @@ export default class SummonActivity extends ActivityMixin(BaseSummonActivityData
    * @returns {object}
    */
   async getTokenData({ actor, placement, tokenUpdates, actorUpdates }) {
-    if ( actor.prototypeToken.randomImg && !game.user.can("FILES_BROWSE") ) {
-      tokenUpdates.texture ??= {};
-      tokenUpdates.texture.src ??= actor.img;
-      ui.notifications.warn("DND5E.SUMMON.Warning.Wildcard", { localize: true });
-    }
-
+    const prototypeToken = placement.prototypeToken;
     delete placement.prototypeToken;
-    const tokenDocument = await actor.getTokenDocument(foundry.utils.mergeObject(placement, tokenUpdates));
+    const tokenDocument = prototypeToken.clone(
+      foundry.utils.mergeObject(placement, tokenUpdates), { parent: canvas.scene }
+    );
 
     // Linked summons require more explicit updates before token creation
     if ( tokenDocument.actorLink ) {


### PR DESCRIPTION
Closes #7429

- Should be fixing non-GM summon placement failing. `actor.getTokenDocument()` previously ran only after placement and the preview was built from `actor.prototypeToken` without an `actorId`.
- Moves creation of a "proper" Scene `TokenDocument` before placement.
- Uses that preview document for final creation, which should be keeping any wildcard selections consistent.