### PR TITLE
[#7436] Validate condition filters and keep their editor accessible for invalid saved filters.

### DIFF
--- a/module/applications/components/filters-input.mjs
+++ b/module/applications/components/filters-input.mjs
@@ -1,4 +1,4 @@
-import { COMPARISON_FUNCTIONS, OPERATOR_FUNCTIONS } from "../../filter.mjs";
+import { COMPARISON_FUNCTIONS, isValidFilter, OPERATOR_FUNCTIONS } from "../../filter.mjs";
 import { getHumanReadableAttributeLabel } from "../../utils.mjs";
 import FiltersEditor from "../filters-editor.mjs";
 
@@ -90,6 +90,11 @@ export default class FiltersInputElement extends foundry.applications.elements.A
     this.#breakdown.classList.toggle("empty", isEmpty);
     if ( isEmpty ) {
       this.#breakdown.innerText = _loc("DND5E.FILTER.Empty");
+      return;
+    }
+
+    if ( !isValidFilter(filters) ) {
+      this.#breakdown.innerText = _loc("DND5E.FILTER.Invalid");
       return;
     }
 

--- a/module/applications/filters-editor.mjs
+++ b/module/applications/filters-editor.mjs
@@ -1,4 +1,5 @@
 import Application5e from "./api/application.mjs";
+import { isValidFilter } from "../filter.mjs";
 
 /**
  * Application for creating and modifying filters.
@@ -49,6 +50,23 @@ export default class FiltersEditor extends Application5e {
    */
   get value() {
     return this.#editor.value;
+  }
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async close(options={}) {
+    const value = this.value.trim() || "{}";
+    let isValid = false;
+    try {
+      isValid = isValidFilter(JSON.parse(value));
+    } catch {}
+    if ( !isValid ) {
+      ui.notifications.warn("DND5E.FILTER.Invalid", { localize: true });
+      return;
+    }
+    this.#editor.value = value;
+    return super.close(options);
   }
 
   /* -------------------------------------------- */

--- a/module/filter.mjs
+++ b/module/filter.mjs
@@ -70,6 +70,32 @@ export function performCheck(data, filter=[]) {
 /* -------------------------------------------- */
 
 /**
+ * Test whether a filter definition is valid.
+ * @param {*} filter  Filter definition to test.
+ * @returns {boolean}
+ */
+export function isValidFilter(filter) {
+  if ( Array.isArray(filter) ) return filter.every(isValidFilter);
+  if ( !foundry.utils.isPlainObject(filter) ) return false;
+  
+  // Blank input is normalized to "{}" before validation in FiltersEditor.
+  if ( foundry.utils.isEmpty(filter) ) return true;
+  
+  const { k: key, o: operator="exact", v: value } = filter;
+  if ( Object.hasOwn(OPERATOR_FUNCTIONS, operator) ) {
+    if ( operator === "NOT" ) {
+      return foundry.utils.isPlainObject(value) && !foundry.utils.isEmpty(value) && isValidFilter(value);
+    }
+    return Array.isArray(value) && value.every(isValidFilter);
+  }
+  if ( !Object.hasOwn(COMPARISON_FUNCTIONS, operator) || (typeof key !== "string") || !key.trim() ) return false;
+  if ( operator === "empty" ) return !Object.hasOwn(filter, "v") || (typeof value === "boolean");
+  return Object.hasOwn(filter, "v");
+}
+
+/* -------------------------------------------- */
+
+/**
  * Determine the unique keys referenced by a set of filters.
  * @param {FilterDescription[]} filter  Filter to examine.
  * @returns {Set<string>}


### PR DESCRIPTION
- Closes #7436 by keeping the editor accessible when invalid filters have been saved, allowing them to be corrected.
- Adds condition filters validation before closing the editor, preventing malformed filters from being saved.
- Blank input is normalized to `{}` to avoid requiring users to enter an empty JSON object manually.
- Closes #7430 