### PR TITLE
[#7439] Be permissive of a delta's effects lacking `statuses` altogether

### DIFF
--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -45,7 +45,7 @@ export default class TokenDocument5e extends SystemFlagsMixin(TokenDocument) {
     const statuses = new Set(foundry.utils.iterateValues(CONFIG.statusEffects).map(s => s._id));
     for ( const effect of data.delta?.effects ?? [] ) {
       if ( (effect.type === "condition") || !statuses.has(effect._id) ) continue;
-      foundry.utils.mergeObject(effect, { type: "condition", "system.type": effect.statuses[0] });
+      foundry.utils.mergeObject(effect, { type: "condition", "system.type": effect.statuses?.[0] });
     }
 
     // Migrate backpack -> container.


### PR DESCRIPTION
Closes #7439 
`{_id: "something", _tombstone: true}` won't error at all with this, and if some other effect _somehow_ was missing `statuses` in its source entirely, this would result in that effect having validation errors, rather than initialization entirely failing.